### PR TITLE
refactor: remove spurious scripts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3240,11 +3240,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@stackoverflow/stacks-icons": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-2.20.0.tgz",
-      "integrity": "sha512-IxRt8SCSXmOAnvLNd4vIb2xkflNwuksfBBinLUSO0xv8mhGq5IKjiCnnSd4Iu59dnrOxUQVjzGeJcMwDNbctZg=="
-    },
     "@styled-icons/boxicons-logos": {
       "version": "10.34.0",
       "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.34.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,6 @@
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@fullstory/browser": "^1.4.9",
-    "@stackoverflow/stacks-icons": "2.20.0",
     "@styled-icons/boxicons-logos": "^10.23.0",
     "@styled-icons/boxicons-regular": "^10.34.0",
     "@testing-library/jest-dom": "^4.2.4",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -17,24 +17,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="theme-dark">
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+  <body>
     <div id="root"></div>
-    <script src="https://unpkg.com/@stackoverflow/stacks-icons"></script>
-    <script
-      src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-      integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
-      integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
-      integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/server/src/bootstrap/helmet-options.ts
+++ b/server/src/bootstrap/helmet-options.ts
@@ -23,12 +23,6 @@ export const helmetOptions = {
         'https://*.google.com',
         'https://www.gstatic.com',
         'https://edge.fullstory.com',
-        // TODO: Remove this by removing script entries in index.html
-        'https://code.jquery.com',
-        'https://cdnjs.cloudflare.com',
-        'https://maxcdn.bootstrapcdn.com',
-        // TODO: Remove this by removing stack-icons and boxicons
-        'https://unpkg.com',
       ],
       connectSrc: [
         "'self'",
@@ -36,8 +30,6 @@ export const helmetOptions = {
         'https://ssl.google-analytics.com/',
         'https://www.googletagmanager.com/',
         'https://rs.fullstory.com',
-        // TODO: Remove this by removing stack-icons and boxicons
-        'https://unpkg.com',
       ],
       frameAncestors: ["'self'"],
       upgradeInsecureRequests: [],


### PR DESCRIPTION
## Problem

There are four scripts called in `index.html` for CDN. External <script> entries in index.html should be examined and removed or replaced with equivalent npm entries

Closes #4 

## Solution

The four packages `stacks-icons`, `jquery`, `popper`, `bootstrap` are not used in our codebase. They were put there by the initial author of `stackoverflow-clone`. Since we are using react, and box-icons for our icons, we do not use the scripts at all. The relevant permissions in Content Security Policy are also removed.