### PR TITLE
feat: create new email modal component

### DIFF
--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -10,7 +10,7 @@ export interface Enquiry {
 }
 
 const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
-  const cc = agency.email === 'feedback@ask.gov.sg' ? '' : 'feedback@ask.gov.sg'
+  const cc = agency.email === 'enquires@ask.gov.sg' ? '' : 'enquires@ask.gov.sg'
   const {
     onOpen: onDeleteModalOpen,
     onClose: onDeleteModalClose,

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -2,10 +2,6 @@ import { Text, Button, Flex, useDisclosure } from '@chakra-ui/react'
 import { EnquiryModal } from '../EnquiryModal/EnquiryModal.component'
 import { Agency } from '../../services/AgencyService'
 
-interface CitizenRequestProps {
-  agency?: Agency
-}
-
 // TODO: combine interface Enquiry from both client and server
 export interface Enquiry {
   questionTitle: string
@@ -13,22 +9,13 @@ export interface Enquiry {
   senderEmail: string
 }
 
-const CitizenRequest = ({
-  agency = {
-    id: '',
-    email: 'askgov@open.gov.sg',
-    shortname: 'AskGov',
-    longname: 'AskGov',
-    logo: '',
-  },
-}: CitizenRequestProps): JSX.Element => {
+const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
   const cc = agency.email === 'askgov@open.gov.sg' ? '' : 'askgov@open.gov.sg'
   const {
     onOpen: onDeleteModalOpen,
     onClose: onDeleteModalClose,
     isOpen: isDeleteModalOpen,
   } = useDisclosure()
-
   const onPostConfirm = async (enquiry: Enquiry): Promise<void> => {
     window.location.href =
       'mailto:' +
@@ -60,7 +47,6 @@ const CitizenRequest = ({
           background: 'primary.600',
         }}
         borderRadius="4px"
-        // colorScheme="blue"
         color="white"
         onClick={onDeleteModalOpen}
       >

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -1,16 +1,46 @@
-import React from 'react'
-import { Text, Button, Flex } from '@chakra-ui/react'
+import { Text, Button, Flex, useDisclosure } from '@chakra-ui/react'
+import { EnquiryModal } from '../EnquiryModal/EnquiryModal.component'
+import { Agency } from '../../services/AgencyService'
 
 interface CitizenRequestProps {
-  email?: string
-  longName?: string
+  agency?: Agency
+}
+
+// TODO: combine interface Enquiry from both client and server
+export interface Enquiry {
+  questionTitle: string
+  description: string
+  senderEmail: string
 }
 
 const CitizenRequest = ({
-  email = 'askgov@open.gov.sg',
-  longName = '',
+  agency = {
+    id: '',
+    email: 'askgov@open.gov.sg',
+    shortname: 'AskGov',
+    longname: 'AskGov',
+    logo: '',
+  },
 }: CitizenRequestProps): JSX.Element => {
-  const cc = email === 'askgov@open.gov.sg' ? '' : 'askgov@open.gov.sg'
+  const cc = agency.email === 'askgov@open.gov.sg' ? '' : 'askgov@open.gov.sg'
+  const {
+    onOpen: onDeleteModalOpen,
+    onClose: onDeleteModalClose,
+    isOpen: isDeleteModalOpen,
+  } = useDisclosure()
+
+  const onPostConfirm = async (enquiry: Enquiry): Promise<void> => {
+    window.location.href =
+      'mailto:' +
+      agency.email +
+      '?cc=' +
+      cc +
+      '&subject=AskGov enquiry:%20' +
+      enquiry.questionTitle +
+      ' AskGov&body=' +
+      enquiry.description
+  }
+
   return (
     <Flex
       direction="column"
@@ -32,20 +62,16 @@ const CitizenRequest = ({
         borderRadius="4px"
         // colorScheme="blue"
         color="white"
-        onClick={(e) => {
-          e.preventDefault()
-          window.location.href =
-            'mailto:' +
-            email +
-            '?cc=' +
-            cc +
-            '&subject=' +
-            longName +
-            ' AskGov&body=Let%20us%20know%20how%20we%20can%20help%20below!'
-        }}
+        onClick={onDeleteModalOpen}
       >
         Submit an enquiry
       </Button>
+      <EnquiryModal
+        isOpen={isDeleteModalOpen}
+        onClose={onDeleteModalClose}
+        onConfirm={onPostConfirm}
+        agency={agency}
+      />
     </Flex>
   )
 }

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -10,7 +10,7 @@ export interface Enquiry {
 }
 
 const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
-  const cc = agency.email === 'askgov@open.gov.sg' ? '' : 'askgov@open.gov.sg'
+  const cc = agency.email === 'feedback@ask.gov.sg' ? '' : 'feedback@ask.gov.sg'
   const {
     onOpen: onDeleteModalOpen,
     onClose: onDeleteModalClose,

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -103,7 +103,7 @@ export const EnquiryModal = ({
                 focusBorderColor="primary.500"
                 errorBorderColor="error.500"
                 isInvalid={formErrors.senderEmail}
-                placeholder="jony_tan@gmail.com"
+                placeholder="example@email.com"
                 {...register('senderEmail', {
                   required: true,
                   pattern: /^\S+@\S+$/i,

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -1,0 +1,146 @@
+import {
+  Box,
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  ModalProps,
+  HStack,
+  Input,
+  Text,
+  VStack,
+  Textarea,
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { Agency } from '../../services/AgencyService'
+import { BiErrorCircle } from 'react-icons/bi'
+import { Enquiry } from '../CitizenRequest/CitizenRequest.component'
+
+interface EnquiryModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
+  onConfirm: (enquiry: Enquiry) => Promise<void>
+  agency: Agency
+}
+
+export const EnquiryModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  agency,
+}: EnquiryModalProps): JSX.Element => {
+  const { register, handleSubmit, reset, formState } = useForm()
+  const { errors: formErrors } = formState
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+
+  const onSubmit: SubmitHandler<Enquiry> = async (enquiry) => {
+    setIsLoading(true)
+    await onConfirm(enquiry)
+    setIsLoading(false)
+    reset()
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <ModalOverlay />
+        <ModalContent w="660px">
+          <ModalHeader>
+            <Text textStyle="h2" color="secondary.700">
+              {`${agency.shortname.toUpperCase()} Enquiry Form`}
+            </Text>
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <VStack align="left" spacing={0}>
+              <Text>
+                {`This enquiry form will be sent to ${agency.longname}. Please do
+                note that we would take at least 3 working days to process your
+                enquiry. Thank you.`}
+              </Text>
+              <Box h={4} />
+              <Text textStyle="subhead-1" color="secondary.700">
+                Question Title
+              </Text>
+              <Box h={3} />
+              <Input
+                focusBorderColor="primary.500"
+                errorBorderColor="error.500"
+                isInvalid={formErrors.questionTitle}
+                {...register('questionTitle', {
+                  required: true,
+                })}
+              />
+              {formErrors.questionTitle && errorLabel('This field is required')}
+              <Box h={4} />
+              <Text textStyle="subhead-1" color="secondary.700">
+                Description
+              </Text>
+              <Box h={3} />
+              <Textarea
+                focusBorderColor="primary.500"
+                errorBorderColor="error.500"
+                isInvalid={formErrors.description}
+                h="144px"
+                {...register('description', {
+                  required: true,
+                })}
+              />
+              {formErrors.description && errorLabel('This field is required')}
+              {/* <Box h={4} />
+              <Text textStyle="subhead-1" color="secondary.700">
+                Sender email
+              </Text>
+              <Text textStyle="body-2" color="secondary.400">
+                Please fill in a valid email so that we can get back to you
+              </Text>
+              <Box h={3} />
+              <Input
+                focusBorderColor="primary.500"
+                errorBorderColor="error.500"
+                isInvalid={formErrors.senderEmail}
+                placeholder="jony_tan@gmail.com"
+                {...register('senderEmail', {
+                  required: true,
+                  pattern: /^\S+@\S+$/i,
+                })}
+              />
+              {formErrors.senderEmail &&
+                errorLabel('Please enter a valid email')} */}
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <HStack spacing={4}>
+              <Button onClick={onClose}>Cancel</Button>
+              <Button
+                type="submit"
+                color="white"
+                backgroundColor="primary.500"
+                _hover={{
+                  background: 'primary.600',
+                }}
+                isLoading={isLoading}
+              >
+                Submit Enquiry
+              </Button>
+            </HStack>
+          </ModalFooter>
+        </ModalContent>
+      </form>
+    </Modal>
+  )
+}
+
+const errorLabel = (message: string): JSX.Element => (
+  <>
+    <Box h={2} />
+    <HStack color={'error.500'}>
+      <BiErrorCircle />
+      <Text textStyle="body-2">{message}</Text>
+    </HStack>
+  </>
+)

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -58,9 +58,9 @@ export const EnquiryModal = ({
           <ModalBody>
             <VStack align="left" spacing={0}>
               <Text>
-                {`This enquiry form will be sent to ${agency.longname}. Please do
-                note that we would take at least 3 working days to process your
-                enquiry. Thank you.`}
+                {`This enquiry form will generate an email to be sent to 
+                ${agency.longname}. Please note that we would take at 
+                least 3 working days to process your enquiry. Thank you.`}
               </Text>
               <Box h={4} />
               <Text textStyle="subhead-1" color="secondary.700">

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -222,7 +222,19 @@ const HomePage = ({ match }) => {
         </Box>
       </Flex>
       <Spacer />
-      <CitizenRequest className="citizen-request" agency={agency} />
+      <CitizenRequest
+        agency={
+          agency
+            ? agency
+            : {
+                id: '',
+                email: 'askgov@open.gov.sg',
+                shortname: 'AskGov',
+                longname: 'AskGov',
+                logo: '',
+              }
+        }
+      />
     </Flex>
   )
 }

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -222,11 +222,7 @@ const HomePage = ({ match }) => {
         </Box>
       </Flex>
       <Spacer />
-      <CitizenRequest
-        className="citizen-request"
-        email={agency?.email}
-        longName={agency?.longname}
-      />
+      <CitizenRequest className="citizen-request" agency={agency} />
     </Flex>
   )
 }

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -228,7 +228,7 @@ const HomePage = ({ match }) => {
             ? agency
             : {
                 id: '',
-                email: 'enquires@ask.gov.sg',
+                email: 'enquiries@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -228,7 +228,7 @@ const HomePage = ({ match }) => {
             ? agency
             : {
                 id: '',
-                email: 'feedback@ask.gov.sg',
+                email: 'enquires@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -228,7 +228,7 @@ const HomePage = ({ match }) => {
             ? agency
             : {
                 id: '',
-                email: 'askgov@open.gov.sg',
+                email: 'feedback@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -128,7 +128,7 @@ const Post = () => {
             ? agency
             : {
                 id: '',
-                email: 'enquires@ask.gov.sg',
+                email: 'enquiries@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -122,11 +122,7 @@ const Post = () => {
           <AnswerSection post={post} />
         </div>
       </div>
-      <CitizenRequest
-        className="citizen-request"
-        email={agency?.email}
-        longName={agency?.longname}
-      />
+      <CitizenRequest className="citizen-request" agency={agency} />
     </>
   )
 }

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -122,7 +122,19 @@ const Post = () => {
           <AnswerSection post={post} />
         </div>
       </div>
-      <CitizenRequest className="citizen-request" agency={agency} />
+      <CitizenRequest
+        agency={
+          agency
+            ? agency
+            : {
+                id: '',
+                email: 'askgov@open.gov.sg',
+                shortname: 'AskGov',
+                longname: 'AskGov',
+                logo: '',
+              }
+        }
+      />
     </>
   )
 }

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -128,7 +128,7 @@ const Post = () => {
             ? agency
             : {
                 id: '',
-                email: 'askgov@open.gov.sg',
+                email: 'feedback@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -128,7 +128,7 @@ const Post = () => {
             ? agency
             : {
                 id: '',
-                email: 'feedback@ask.gov.sg',
+                email: 'enquires@ask.gov.sg',
                 shortname: 'AskGov',
                 longname: 'AskGov',
                 logo: '',


### PR DESCRIPTION
## Problem
Currently, the enquiry button leads to a mailto:.

- Addresses the second iteration of #17

## Solution

This PR adds a new enquiry modal, which the enquiry button will open up to. To reduce the scope of changes, the submission of the modal will still lead to a prepopulated `mailto:`. Automatic mailing of the enquiry will be another PR. The `Sender Email` design code is added and commented out in anticipation of the next PR.

There are two places where the user can open up the enquiry modal.
In the homepage, it will open up to the specific agency if it is selected, and default to `feedback@ask.gov.sg`.
In the post page, it will always open up the first agency that was tagged with the question. This is because the back button also does the same thing. It might be better to grab all the agencies tagged with it instead.

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/20250559/128158436-9825e0c7-dcd1-46a1-abb0-b51674a975ce.mov


**AFTER**:

https://user-images.githubusercontent.com/20250559/128158242-99b76d64-c000-4651-b953-3a5259b53f20.mov

## Tests
- [x] Modal does not accept empty form
- [x] Modal will clear upon submission
- [x] Modal confirm leads to `mailto:` with address and CC appropriately filled out.
