### PR TITLE
fix(convict): allow logoHost to be configured

### DIFF
--- a/server/src/bootstrap/config/base.ts
+++ b/server/src/bootstrap/config/base.ts
@@ -29,6 +29,7 @@ const baseSchema: Schema<BaseConfig> = {
     doc: 'Host for agency logo images',
     format: String,
     default: 'https://s3-ap-southeast-1.amazonaws.com/',
+    env: 'LOGOS_HOST',
   },
 }
 


### PR DESCRIPTION
## Problem

The logo host is currently hardcoded to S3 on AWS. This is problematic when trying to specify another host, 
say one behind a CDN, for the same

## Solution

Allow `baseConfig.logoHost` to be configured by `LOGOS_HOST` env var
