### PR TITLE
fix: remove duplicate view count on posts

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -120,7 +120,7 @@ const Post = () => {
           ) : null}
         </div>
         <div className="question-main">
-          <QuestionSection postId={postId} />
+          <QuestionSection post={post} />
           <AnswerSection post={post} />
         </div>
       </div>

--- a/client/src/pages/Post/QuestionSection/PostCell/PostCell.component.jsx
+++ b/client/src/pages/Post/QuestionSection/PostCell/PostCell.component.jsx
@@ -1,18 +1,7 @@
-import { useQuery } from 'react-query'
 import { RichTextPreview } from '../../../../components/RichText/RichTextEditor.component'
-import {
-  getPostById,
-  GET_POST_BY_ID_QUERY_KEY,
-} from '../../../../services/PostService'
 import './PostCell.styles.scss'
 
-const PostCell = ({ postId }) => {
-  // TODO: review if it makes more sense to receive post as a prop from Post parent
-  const { data: post, isLoading } = useQuery(
-    [GET_POST_BY_ID_QUERY_KEY, postId],
-    () => getPostById(postId),
-  )
-
+const PostCell = ({ post }) => {
   return (
     <>
       <div className="post-cell">

--- a/client/src/pages/Post/QuestionSection/QuestionSection.component.jsx
+++ b/client/src/pages/Post/QuestionSection/QuestionSection.component.jsx
@@ -1,14 +1,13 @@
-import React from 'react'
 import PostCell from './PostCell/PostCell.component'
 
 import './QuestionSection.styles.scss'
 
-const QuestionSection = ({ postId }) => {
+const QuestionSection = ({ post }) => {
   return (
     <>
       <div className="question">
         <div className="post-layout">
-          <PostCell postId={postId} />
+          <PostCell post={post} />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Problem

Closes #33

## Solution

Pass in `post` as a prop instead of fetching post again in `PostCell`

## Before

https://user-images.githubusercontent.com/20250559/129227742-7a6cc66b-c645-41d2-8840-40b7d759bc19.mov


## After
https://user-images.githubusercontent.com/20250559/129227682-9be22235-066f-4d61-9bfa-6163f94c3286.mov


