### PR TITLE
fix: scroll to top on privacy and terms pages

### DIFF
--- a/client/src/components/PrivacyTerms/AgencyPrivacy.component.tsx
+++ b/client/src/components/PrivacyTerms/AgencyPrivacy.component.tsx
@@ -1,8 +1,10 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
+import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const AgencyPrivacy = (): JSX.Element => (
   <>
+    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/AgencyTerms.component.tsx
+++ b/client/src/components/PrivacyTerms/AgencyTerms.component.tsx
@@ -1,8 +1,10 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
+import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const AgencyTerms = (): JSX.Element => (
   <>
+    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/CitizenPrivacy.component.tsx
+++ b/client/src/components/PrivacyTerms/CitizenPrivacy.component.tsx
@@ -1,8 +1,10 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
+import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const CitizenPrivacy = (): JSX.Element => (
   <>
+    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/CitizenTerms.component.tsx
+++ b/client/src/components/PrivacyTerms/CitizenTerms.component.tsx
@@ -1,8 +1,10 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
+import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const CitizenTerms = (): JSX.Element => (
   <>
+    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/ScrollToTop/ScrollToTop.component.tsx
+++ b/client/src/components/ScrollToTop/ScrollToTop.component.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+
+// Where added, scroll to top of component
+// https://reactrouter.com/web/guides/scroll-restoration
+export function ScrollToTopOnMount(): null {
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  return null
+}


### PR DESCRIPTION

## Problem

Closes #30

## Solution

Add scroll to top `useEffect` upon page rendering. Only for the pages that require it (privacy and terms pages). 

## Before

https://user-images.githubusercontent.com/20250559/129309518-fed3a6d4-602a-4415-a8a3-e89e411aaad1.mov



## After
https://user-images.githubusercontent.com/20250559/129309411-78421c18-0d0a-44a3-9bbc-744afb34663c.mov
