### PR TITLE
feat: display tags in lexicographical order

### DIFF
--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -76,6 +76,7 @@ const TagPanel = (): ReactElement => {
             <VStack align="left" spacing={0} marginLeft="-1px">
               {tags
                 .filter(({ tagType }) => tagType === TagType.Topic)
+                .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
                 .map((tag) => {
                   const { tagType, tagname } = tag
                   return (


### PR DESCRIPTION
Display tags in lexicographical order
Closes #89 

## Before
<img width="328" alt="image" src="https://user-images.githubusercontent.com/20250559/129319459-fadc6adf-cf00-4f79-adf7-d6cbbb05536f.png">

## After
<img width="371" alt="image" src="https://user-images.githubusercontent.com/20250559/129319438-36ab51dc-4788-404c-885b-cec7519139bf.png">

