### PR TITLE
refactor(enquiries): use Sequelize convention for Agency model

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -35,7 +35,7 @@ import { requestLoggingMiddleware } from './logging'
 import { helmetOptions } from './helmet-options'
 import { emailValidator } from './email-validator'
 import { EnquiryService } from '../modules/enquiry/enquiry.service'
-import { Agency as agency } from './sequelize'
+import { Agency } from './sequelize'
 export { sequelize } from './sequelize'
 export const app = express()
 
@@ -76,7 +76,7 @@ const mailService = new MailService({
   transport,
   mailFromEmail: mailConfig.senderConfig.mailFrom,
 })
-const enquiryService = new EnquiryService({ agency, mailService })
+const enquiryService = new EnquiryService({ Agency, mailService })
 
 const apiOptions = {
   agency: new AgencyController({ agencyService }),

--- a/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
+++ b/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
@@ -22,12 +22,12 @@ describe('EnquiryService', () => {
     Tag,
     emailValidator,
   })
-  const agency = defineAgency(sequelize, { User })
+  const Agency = defineAgency(sequelize, { User })
   const transport = { sendMail: jest.fn() }
   const mailFromEmail = 'donotreply@mail.ask.gov.sg'
 
   const mailService = new MailService({ transport, mailFromEmail })
-  const enquiryService = new EnquiryService({ agency, mailService })
+  const enquiryService = new EnquiryService({ Agency, mailService })
 
   const enquiry: Enquiry = {
     questionTitle: 'My question',
@@ -47,14 +47,14 @@ describe('EnquiryService', () => {
     it('should send an enquiry email to two agencies', async () => {
       // Arrange
       const agencyId = ['1234', '2233']
-      const mockAgency1 = agency.build({
+      const mockAgency1 = Agency.build({
         email: 'agency1@ask.gov.sg',
       })
-      const mockAgency2 = agency.build({
+      const mockAgency2 = Agency.build({
         email: 'agency2@ask.gov.sg',
       })
       const AgencyModel = jest
-        .spyOn(agency, 'findOne')
+        .spyOn(Agency, 'findOne')
         .mockResolvedValueOnce(mockAgency1)
         .mockResolvedValueOnce(mockAgency2)
 
@@ -77,7 +77,7 @@ describe('EnquiryService', () => {
     it('should send an enquiry email to AskGov if no agency is specified', async () => {
       // Arrange
       const agencyId: string[] = []
-      const AgencyModel = jest.spyOn(agency, 'findOne')
+      const AgencyModel = jest.spyOn(Agency, 'findOne')
 
       // Act
       await enquiryService.emailEnquiry({ agencyId, enquiry })
@@ -98,7 +98,7 @@ describe('EnquiryService', () => {
     it('should return error when a agency ID is invalid', async () => {
       // Arrange
       const agencyId = ['1234']
-      jest.spyOn(agency, 'findOne').mockResolvedValueOnce(null)
+      jest.spyOn(Agency, 'findOne').mockResolvedValueOnce(null)
 
       try {
         // Act

--- a/server/src/modules/enquiry/enquiry.service.ts
+++ b/server/src/modules/enquiry/enquiry.service.ts
@@ -4,16 +4,16 @@ import { Enquiry } from '../../types/mail-type'
 import { MailService } from '../mail/mail.service'
 
 export class EnquiryService {
-  private agency: ModelCtor<Agency>
+  private Agency: ModelCtor<Agency>
   private mailService: Public<MailService>
   constructor({
-    agency,
+    Agency,
     mailService,
   }: {
-    agency: ModelCtor<Agency>
+    Agency: ModelCtor<Agency>
     mailService: Public<MailService>
   }) {
-    this.agency = agency
+    this.Agency = Agency
     this.mailService = mailService
   }
   emailEnquiry = async ({
@@ -27,7 +27,7 @@ export class EnquiryService {
       agencyId.map(
         async (Id) =>
           (
-            await this.agency.findOne({
+            await this.Agency.findOne({
               attributes: ['email'],
               where: { Id },
             })


### PR DESCRIPTION
## Problem and Solution

Per PR title, adhere to conventions established by Sequelize with respect to how models are used