### PR TITLE
fix(enquiry): actually await on `EnquiryService.emailEnquiry()`

### DIFF
--- a/server/src/modules/enquiry/__tests__/enquiry.controller.spec.ts
+++ b/server/src/modules/enquiry/__tests__/enquiry.controller.spec.ts
@@ -50,9 +50,7 @@ describe('EnquiryController', () => {
       // Arrange
       const errorMessage = 'One or more agency IDs are invalid'
       recaptchaService.verifyCaptchaResponse.mockReturnValue(okAsync(true))
-      enquiryService.emailEnquiry.mockImplementation(() => {
-        throw new Error(errorMessage)
-      })
+      enquiryService.emailEnquiry.mockRejectedValue(new Error(errorMessage))
 
       // Act
       const response = await request.post(path).send(data)

--- a/server/src/modules/enquiry/enquiry.controller.ts
+++ b/server/src/modules/enquiry/enquiry.controller.ts
@@ -56,7 +56,7 @@ export class EnquiryController {
 
     // Send enquiry
     try {
-      this.enquiryService.emailEnquiry({
+      await this.enquiryService.emailEnquiry({
         agencyId: req.body.agencyId,
         enquiry: req.body.enquiry,
       })


### PR DESCRIPTION

## Problem

A bug was uncovered during testing, where the backend rejected the sending of emails, 
but was also reporting successful sending of enquiry to the user

## Solution

Given that the abovementioned function is asynchronous, ensure that
we await on it, updating the test suite to reflect this

- Ensure that mocks of `EnquiryService.emailEnquiry()` either resolves
  or rejects
- Ensure that we await on the async `EnquiryService.emailEnquiry()`
