### PR TITLE
fix: remove nested form of linkcontrol

### DIFF
--- a/client/src/components/RichText/LinkControl.tsx
+++ b/client/src/components/RichText/LinkControl.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Input, Text } from '@chakra-ui/react'
-import React, { useState } from 'react'
+import React, { MouseEventHandler, useState } from 'react'
 import { BiLink } from 'react-icons/bi'
 import { useStyledToast } from '../StyledToast/StyledToast'
 import styles from './RichTextEditor.module.scss'
@@ -50,43 +50,41 @@ export const LinkControl = ({
     e.stopPropagation()
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  const handleSubmit: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault()
     e.stopPropagation()
     onChange('link', title, url, '_blank')
   }
 
   const renderModal = () => (
-    <div onClick={stopPropagation}>
-      <form onSubmit={handleSubmit} className={styles.form}>
-        <Box w="376px" h="128px" p="24px">
-          <Text textStyle="subhead1" color="secondary.700">
-            Add Target Link
-          </Text>
-          <HStack spacing="16px" my="12px">
-            <Input
-              value={url}
-              type="text"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setURL(e.target.value)
-              }
-            />
-            <Button
-              textStyle="body1"
-              backgroundColor="primary.500"
-              color="white"
-              type="submit"
-              name="link_button"
-              isDisabled={!title || !url}
-              _hover={undefined}
-              _active={undefined}
-              _focus={undefined}
-            >
-              Save
-            </Button>
-          </HStack>
-        </Box>
-      </form>
+    <div onClick={stopPropagation} className={styles.form}>
+      <Box w="376px" h="128px" p="24px">
+        <Text textStyle="subhead1" color="secondary.700">
+          Add Target Link
+        </Text>
+        <HStack spacing="16px" my="12px">
+          <Input
+            value={url}
+            type="text"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setURL(e.target.value)
+            }
+          />
+          <Button
+            textStyle="body1"
+            backgroundColor="primary.500"
+            color="white"
+            onClick={handleSubmit}
+            name="link_button"
+            isDisabled={!title || !url}
+            _hover={undefined}
+            _active={undefined}
+            _focus={undefined}
+          >
+            Save
+          </Button>
+        </HStack>
+      </Box>
     </div>
   )
   return (

--- a/client/src/components/RichText/LinkControl.tsx
+++ b/client/src/components/RichText/LinkControl.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Input, Text } from '@chakra-ui/react'
-import React, { MouseEventHandler, useState } from 'react'
+import { MouseEventHandler, useState } from 'react'
 import { BiLink } from 'react-icons/bi'
 import { useStyledToast } from '../StyledToast/StyledToast'
 import styles from './RichTextEditor.module.scss'


### PR DESCRIPTION
## Problem

Closes #110 

## Solution

When react was upgraded from v16 to v17, nested form elements no longer fires onSubmit. LinkControl was originally a nested form inside its rich text editor, so this PR removes the form element.
https://github.com/facebook/react/issues/20741

##BEFORE

https://user-images.githubusercontent.com/20250559/130004716-c5d412f2-423a-470d-ab95-7ecdb943d58a.mov

##AFTER

https://user-images.githubusercontent.com/20250559/130023868-935c0932-227e-4ec8-a38c-eec72569214c.mov


