### PR TITLE
Chore(answers): remove response handler

### DIFF
--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -44,16 +44,7 @@ export class AnswersController {
   addAnswer = async (req: Request, res: Response): Promise<Response> => {
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
-      return res
-        .status(400)
-        .json(
-          helperFunction.responseHandler(
-            false,
-            400,
-            errors.array()[0].msg,
-            null,
-          ),
-        )
+      return res.status(400).json({ message: errors.array()[0].msg })
     }
     if (!req.user) {
       return res.status(401).json({ message: 'User not signed in' })
@@ -68,35 +59,16 @@ export class AnswersController {
       if (!hasAnswerPermissions) {
         return res
           .status(403)
-          .json(
-            helperFunction.responseHandler(
-              false,
-              403,
-              'You do not have permissions to answer question',
-              null,
-            ),
-          )
+          .json({ message: 'You do not have permissions to answer question' })
       }
       // Save Answer in the database
-      const [error, data] = await this.answersService.createAnswer({
+      const data = await this.answersService.createAnswer({
         body: req.body.text,
         userId: req.user.id,
         postId: req.params.id,
       })
 
-      if (error) {
-        logger.error({
-          message: 'Error while adding new answer',
-          meta: {
-            function: 'addAnswer',
-            userId: req.user.id,
-            postId: req.params.id,
-          },
-          error,
-        })
-        return res.status(error.code).json(error)
-      }
-      return res.status(data?.code || 200).json(data)
+      return res.status(200).json(data)
     } catch (error) {
       logger.error({
         message: 'Error while adding new answer',
@@ -107,9 +79,7 @@ export class AnswersController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 

--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -1,5 +1,4 @@
 import { validationResult } from 'express-validator'
-import helperFunction from '../../helpers/helperFunction'
 import { AnswersService } from './answers.service'
 import { AuthService } from '../auth/auth.service'
 import { Request, Response } from 'express'
@@ -35,9 +34,7 @@ export class AnswersController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 

--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -113,21 +113,8 @@ export class AnswersController {
 
   deleteAnswer = async (req: Request, res: Response): Promise<unknown> => {
     try {
-      this.answersService.remove(req.params.id, (error, data) => {
-        if (error) {
-          logger.error({
-            message: 'Error while deleting answer',
-            meta: {
-              function: 'deleteAnswer',
-              answerId: req.params.id,
-            },
-            error,
-          })
-          return res.status(error.code).json(error)
-        }
-        // Assuming that if err returned null then data is defined
-        return res.status(data!.code).json(data)
-      })
+      await this.answersService.remove(req.params.id)
+      return res.status(200).end()
     } catch (error) {
       logger.error({
         message: 'Error while deleting answer',
@@ -137,9 +124,7 @@ export class AnswersController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 }

--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -83,43 +83,21 @@ export class AnswersController {
     }
   }
 
-  updateAnswer = (req: Request, res: Response): Response | undefined => {
+  updateAnswer = async (
+    req: Request,
+    res: Response,
+  ): Promise<Response | undefined> => {
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
-      return res
-        .status(400)
-        .json(
-          helperFunction.responseHandler(
-            false,
-            400,
-            errors.array()[0].msg,
-            null,
-          ),
-        )
+      return res.status(400).json({ message: errors.array()[0].msg })
     }
     try {
       // Update Answer in the database
-      this.answersService.update(
-        {
-          body: req.body.text,
-          id: req.params.id,
-        },
-        (error, data) => {
-          if (error) {
-            logger.error({
-              message: 'Error while updating answer',
-              meta: {
-                function: 'updateAnswer',
-                answerId: req.params.id,
-              },
-              error,
-            })
-            return res.status(error.code).json(error)
-          }
-          // Assuming that if err returned null then data is defined
-          return res.status(data!.code).json(data)
-        },
-      )
+      const data = await this.answersService.update({
+        body: req.body.text,
+        id: req.params.id,
+      })
+      return res.status(200).json(data)
     } catch (error) {
       logger.error({
         message: 'Error while updating answer',
@@ -129,9 +107,7 @@ export class AnswersController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -42,7 +42,7 @@ export class AnswersService {
   }: Pick<
     AnswerWithRelations,
     'body' | 'postId' | 'userId'
-  >): Promise<HelperResult> => {
+  >): Promise<string> => {
     const answer = await AnswerModel.create({
       postId: postId,
       body: body,
@@ -52,10 +52,7 @@ export class AnswersService {
       { status: PostStatus.PUBLIC },
       { where: { id: postId } },
     )
-    return [
-      null,
-      helperFunction.responseHandler(true, 200, 'Answer Added', answer.id),
-    ]
+    return answer.id
   }
 
   update = async (

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -5,16 +5,8 @@ import {
   Answer as AnswerModel,
 } from '../../bootstrap/sequelize'
 import { PostStatus } from '../../types/post-status'
-import helperFunction from '../../helpers/helperFunction'
 import { Answer, Post } from '../../models'
-import {
-  HelperResult,
-  HelperResultCallback,
-} from '../../types/response-handler'
 import { FindOptions } from 'sequelize/types'
-import { createLogger } from '../../bootstrap/logging'
-
-const logger = createLogger(module)
 
 type AnswerWithRelations = Answer & {
   postId: string

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -55,47 +55,16 @@ export class AnswersService {
     return answer.id
   }
 
-  update = async (
-    updatedAnswer: {
-      id: string
-      body: string
-    },
-    result: HelperResultCallback,
-  ): Promise<void> => {
-    try {
-      const res = await AnswerModel.update(
-        { body: updatedAnswer.body },
-        { where: { id: updatedAnswer.id } },
-      )
-      const changedRows = res[0]
-      result(
-        null,
-        helperFunction.responseHandler(
-          true,
-          200,
-          'Answer updated',
-          changedRows,
-        ),
-      )
-    } catch (error) {
-      logger.error({
-        message: 'Error while updating answer',
-        meta: {
-          function: 'update',
-          answerId: updatedAnswer.id,
-        },
-        error,
-      })
-      result(
-        helperFunction.responseHandler(
-          false,
-          error.statusCode,
-          error.message,
-          null,
-        ),
-        null,
-      )
-    }
+  update = async (updatedAnswer: {
+    id: string
+    body: string
+  }): Promise<number> => {
+    const res = await AnswerModel.update(
+      { body: updatedAnswer.body },
+      { where: { id: updatedAnswer.id } },
+    )
+    const changedRows = res[0]
+    return changedRows
   }
 
   remove = async (id: string, result: HelperResultCallback): Promise<void> => {

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -67,32 +67,8 @@ export class AnswersService {
     return changedRows
   }
 
-  remove = async (id: string, result: HelperResultCallback): Promise<void> => {
-    try {
-      await AnswerModel.destroy({ where: { id: id } })
-      result(
-        null,
-        helperFunction.responseHandler(true, 200, 'Answer Removed', null),
-      )
-    } catch (error) {
-      logger.error({
-        message: 'Error while deleting answer',
-        meta: {
-          function: 'deleteAnswer',
-          answerId: id,
-        },
-        error,
-      })
-      result(
-        helperFunction.responseHandler(
-          false,
-          error.statusCode,
-          error.message,
-          null,
-        ),
-        null,
-      )
-    }
+  remove = async (id: string): Promise<void> => {
+    await AnswerModel.destroy({ where: { id: id } })
   }
 
   retrieveAll = async (


### PR DESCRIPTION
## Problem

`responseHandler` provides very little value, and the patterns involving its use in the codebase are dated and confusing.

## Solution
To keep changes small, this PR only removes responseHandler under `answers`