### PR TITLE
Chore(post): remove responseHandler

### DIFF
--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -31,25 +31,24 @@ export class PostController {
     const { query } = req
     const { sort = SortType.Top, tags = '' } = query
     try {
-      const [err, data] = await this.postService.retrieveAll({
+      const data = await this.postService.retrieveAll({
         sort: sort as SortType,
         tags: tags as string,
       })
-      if (err) {
-        return res.status(err.code).json(err)
-      }
-      return res.status(data?.code || 200).json(data?.data)
+      return res.status(200).json(data)
     } catch (error) {
-      logger.error({
-        message: 'Error while listing posts',
-        meta: {
-          function: 'listPosts',
-        },
-        error,
-      })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(true, 500, 'Server Error', null))
+      if (error === 'Invalid tags used in request') {
+        return res.status(422).json({ message: error })
+      } else {
+        logger.error({
+          message: 'Error while listing posts',
+          meta: {
+            function: 'listPosts',
+          },
+          error,
+        })
+        return res.status(500).json({ message: 'Server Error' })
+      }
     }
   }
 

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -37,7 +37,7 @@ export class PostController {
       })
       return res.status(200).json(data)
     } catch (error) {
-      if (error === 'Invalid tags used in request') {
+      if (error.message === 'Invalid tags used in request') {
         return res.status(422).json({ message: error })
       } else {
         logger.error({

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -55,18 +55,7 @@ export class PostController {
   getSinglePost = async (req: Request, res: Response): Promise<Response> => {
     let post
     try {
-      const [error, data] = await this.postService.retrieveOne(req.params.id)
-      if (error) {
-        logger.error({
-          message: 'Error while retrieving single post',
-          meta: {
-            function: 'getSinglePost',
-          },
-          error,
-        })
-        return res.status(error.code).json(error)
-      }
-      post = data?.data
+      post = await this.postService.retrieveOne(req.params.id)
     } catch (error) {
       logger.error({
         message: 'Error while retrieving single post',
@@ -75,14 +64,12 @@ export class PostController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
 
     try {
       await this.authService.verifyUserCanViewPost(
-        post.toJSON(),
+        post,
         req.header('x-auth-token') ?? '',
       )
     } catch (error) {

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -107,16 +107,7 @@ export class PostController {
   addPost = async (req: Request, res: Response): Promise<Response> => {
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
-      return res
-        .status(400)
-        .json(
-          helperFunction.responseHandler(
-            false,
-            400,
-            errors.array()[0].msg,
-            null,
-          ),
-        )
+      return res.status(400).json(errors.array()[0].msg)
     }
     if (!req.user) {
       return res.status(401).json({ message: 'User not signed in' })
@@ -132,37 +123,21 @@ export class PostController {
           ),
         )
       if (listOfDisallowedTags.length > 0) {
-        return res
-          .status(403)
-          .json(
-            helperFunction.responseHandler(
-              false,
-              403,
-              'You do not have permissions to post this question with the following tags: ' +
-                listOfDisallowedTags.map((x) => x.tagname).join(', '),
-              null,
-            ),
-          )
+        return res.status(403).json({
+          message:
+            'You do not have permissions to post this question with the following tags: ' +
+            listOfDisallowedTags.map((x) => x.tagname).join(', '),
+        })
       }
 
-      const [error, data] = await this.postService.createPostWithTag({
+      const data = await this.postService.createPostWithTag({
         title: req.body.title,
         description: req.body.description,
         userId: req.user?.id,
         tagname: req.body.tagname,
       })
 
-      if (error) {
-        logger.error({
-          message: 'Error while creating post',
-          meta: {
-            function: 'addPost',
-          },
-          error,
-        })
-        return res.status(error.code).json(error)
-      }
-      return res.status(data?.code || 200).json(data)
+      return res.status(200).json({ data: data })
     } catch (error) {
       logger.error({
         message: 'Error while creating post',
@@ -171,9 +146,7 @@ export class PostController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server error' })
     }
   }
 

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -223,23 +223,13 @@ export class PostController {
 
     try {
       const { sort, withAnswers, tags } = req.query
-      const [error, data] = await this.postService.listAnswerablePosts({
+      const data = await this.postService.listAnswerablePosts({
         userId,
         sort: sort as SortType,
         withAnswers,
         tags,
       })
-      if (error) {
-        logger.error({
-          message: 'Error while retrieving answerable posts',
-          meta: {
-            function: 'listAnswerablePosts',
-          },
-          error,
-        })
-        return res.status(error.code).json(error)
-      }
-      return res.status(data?.code || 200).json(data?.data)
+      return res.status(200).json(data)
     } catch (error) {
       logger.error({
         message: 'Error while retrieving answerable posts',

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -170,31 +170,8 @@ export class PostController {
           .status(403)
           .json({ message: 'You do not have permission to delete this post.' })
       }
-    } catch (error) {
-      logger.error({
-        message: 'Error while determining permissions to delete post',
-        meta: {
-          function: 'deletePost',
-        },
-        error,
-      })
-      return res
-        .status(500)
-        .json({ message: 'Something went wrong, please try again.' })
-    }
-    try {
-      const [error, data] = await this.postService.remove(postId)
-      if (error) {
-        logger.error({
-          message: 'Error while deleting post',
-          meta: {
-            function: 'deletePost',
-          },
-          error,
-        })
-        return res.status(error.code).json(error)
-      }
-      return res.status(data?.code || 200).json(data)
+      await this.postService.remove(postId)
+      return res.sendStatus(200)
     } catch (error) {
       logger.error({
         message: 'Error while deleting post',
@@ -203,9 +180,7 @@ export class PostController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -90,11 +90,8 @@ export class PostController {
 
   getTopPosts = async (req: Request, res: Response): Promise<Response> => {
     try {
-      const [err, data] = await this.postService.getTopPosts()
-      if (err) {
-        return res.status(err.code).json(err)
-      }
-      return res.status(data?.code || 200).json(data?.data)
+      const data = await this.postService.getTopPosts()
+      return res.status(200).json(data)
     } catch (error) {
       logger.error({
         message: 'Error while retrieving top posts',
@@ -103,9 +100,7 @@ export class PostController {
         },
         error,
       })
-      return res
-        .status(500)
-        .json(helperFunction.responseHandler(false, 500, 'Server Error', null))
+      return res.status(500).json({ message: 'Server Error' })
     }
   }
 

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -114,7 +114,7 @@ export class PostService {
     })
 
     if (!posts) {
-      return Array<Post>()
+      return []
     } else if (withAnswers) {
       return returnPosts
     } else {
@@ -127,7 +127,7 @@ export class PostService {
     data?: PostWithRelations[],
   ): Promise<Post[]> => {
     if (!data) {
-      return Array<Post>()
+      return []
     } else {
       const answerPromises = data.map((p) => p.countAnswers())
       const answerCounts = await Promise.all(answerPromises)

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -14,6 +14,7 @@ import {
 import { HelperResult } from '../../types/response-handler'
 import { Post, Tag } from '../../models'
 import { PostEditType } from '../../types/post-type'
+import { PostWithRelations as PostWithUserRelations } from '../auth/auth.service'
 
 export type UserWithRelations = {
   getTags: () => Tag[]
@@ -309,7 +310,7 @@ export class PostService {
     return false
   }
 
-  retrieveOne = async (postId: string): Promise<HelperResult> => {
+  retrieveOne = async (postId: string): Promise<PostWithUserRelations> => {
     await PostModel.increment(
       {
         views: +1,
@@ -321,7 +322,7 @@ export class PostService {
       },
     )
 
-    const post = await PostModel.findOne({
+    const post = (await PostModel.findOne({
       where: {
         id: postId,
       },
@@ -343,20 +344,12 @@ export class PostService {
           'answer_count',
         ],
       ],
-    })
+    })) as PostWithUserRelations
 
     if (!post) {
-      return [
-        helperFunction.responseHandler(
-          false,
-          404,
-          'No post with this id',
-          null,
-        ),
-        null,
-      ]
+      throw 'No post with this id'
     } else {
-      return [null, helperFunction.responseHandler(true, 200, 'Success', post)]
+      return post
     }
   }
 

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -366,7 +366,7 @@ export class PostService {
   }: {
     sort: SortType
     tags: string
-  }): Promise<HelperResult> => {
+  }): Promise<Post[]> => {
     // basic
     let tags_unchecked: string[] = []
 
@@ -381,15 +381,7 @@ export class PostService {
 
     // prevent search if query is invalid
     if (tagList.length != tags_unchecked.length) {
-      return [
-        helperFunction.responseHandler(
-          false,
-          422,
-          'Invalid tags used in request',
-          null,
-        ),
-        null,
-      ]
+      throw 'Invalid tags used in request'
     }
 
     const whereobj = {
@@ -416,10 +408,7 @@ export class PostService {
     })) as PostWithRelations[]
 
     if (!posts) {
-      return [
-        helperFunction.responseHandler(false, 200, 'No posts found', null),
-        null,
-      ]
+      return []
     } else {
       // TODO: Optimize to merge the 2 requests into one
       // Two queries used as when I search for specific tags, the response
@@ -467,10 +456,7 @@ export class PostService {
           ],
         ],
       })
-      return [
-        null,
-        helperFunction.responseHandler(true, 200, 'Success', returnPosts),
-      ]
+      return returnPosts
     }
   }
 }

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -46,7 +46,7 @@ export class PostService {
       where: { id: userId },
     })) as UserWithRelations | null
     if (!user) {
-      throw 'Unable to find user with given ID'
+      throw new Error('Unable to find user with given ID')
     }
 
     const tagInstances = await user.getTags()
@@ -188,11 +188,11 @@ export class PostService {
     const tagList = await this.getExistingTagsFromRequestTags(newPost.tagname)
 
     if (newPost.tagname.length !== tagList.length) {
-      throw 'At least one tag does not exist'
+      throw new Error('At least one tag does not exist')
     } else {
       // check if at least one agency tag exists
       if (!this.checkOneAgency(tagList)) {
-        throw 'At least one tag must be an agency tag'
+        throw new Error('At least one tag must be an agency tag')
       }
       // Only create post if tag exists
       const post = await PostModel.create({
@@ -218,7 +218,7 @@ export class PostService {
       { where: { id: id } },
     )
     if (!update) {
-      throw 'Update failed'
+      throw new Error('Update failed')
     } else {
       return
     }
@@ -291,7 +291,7 @@ export class PostService {
     })) as PostWithUserRelations
 
     if (!post) {
-      throw 'No post with this id'
+      throw new Error('No post with this id')
     } else {
       return post
     }
@@ -318,7 +318,7 @@ export class PostService {
 
     // prevent search if query is invalid
     if (tagList.length != tags_unchecked.length) {
-      throw 'Invalid tags used in request'
+      throw new Error('Invalid tags used in request')
     }
 
     const whereobj = {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -163,7 +163,7 @@ export class PostService {
     }
   }
 
-  getTopPosts = async (): Promise<HelperResult> => {
+  getTopPosts = async (): Promise<Post[]> => {
     const posts = await PostModel.findAll({
       include: [TagModel],
       order: [['views', 'DESC']],
@@ -187,12 +187,9 @@ export class PostService {
       where: { status: PostStatus.PUBLIC },
     })
     if (!posts) {
-      return [
-        helperFunction.responseHandler(false, 404, 'No posts found', null),
-        null,
-      ]
+      return []
     } else {
-      return [null, helperFunction.responseHandler(true, 200, 'Success', posts)]
+      return posts
     }
   }
 

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -212,31 +212,15 @@ export class PostService {
     description: string
     userId: string
     tagname: string[]
-  }): Promise<HelperResult> => {
+  }): Promise<string> => {
     const tagList = await this.getExistingTagsFromRequestTags(newPost.tagname)
 
     if (newPost.tagname.length !== tagList.length) {
-      return [
-        helperFunction.responseHandler(
-          false,
-          400,
-          'At least one tag does not exist',
-          null,
-        ),
-        null,
-      ]
+      throw 'At least one tag does not exist'
     } else {
       // check if at least one agency tag exists
       if (!this.checkOneAgency(tagList)) {
-        return [
-          helperFunction.responseHandler(
-            false,
-            400,
-            'At least one tag must be an agency tag',
-            null,
-          ),
-          null,
-        ]
+        throw 'At least one tag must be an agency tag'
       }
       // Only create post if tag exists
       const post = await PostModel.create({
@@ -252,10 +236,7 @@ export class PostService {
           tagId: tag.id,
         })
       }
-      return [
-        null,
-        helperFunction.responseHandler(true, 200, 'Post Created', post.id),
-      ]
+      return post.id
     }
   }
 

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -240,21 +240,15 @@ export class PostService {
     }
   }
 
-  remove = async (id: string): Promise<HelperResult> => {
+  remove = async (id: string): Promise<void> => {
     const update = await PostModel.update(
       { status: 'ARCHIVED' },
       { where: { id: id } },
     )
     if (!update) {
-      return [
-        helperFunction.responseHandler(false, 400, 'Update failed', null),
-        null,
-      ]
+      throw 'Update failed'
     } else {
-      return [
-        null,
-        helperFunction.responseHandler(true, 200, 'Post Removed', null),
-      ]
+      return
     }
   }
 


### PR DESCRIPTION
## Problem

`responseHandler` provides very little value, and the patterns involving its use in the codebase are dated and confusing.

## Solution
To keep changes small, this PR only removes responseHandler under `posts`