### PR TITLE
Feat: Pagination in frontend

### DIFF
--- a/client/src/components/AnswerableQuestions/AnswerableQuestions.component.jsx
+++ b/client/src/components/AnswerableQuestions/AnswerableQuestions.component.jsx
@@ -1,23 +1,58 @@
-import React from 'react'
+import { Center } from '@chakra-ui/layout'
+import { useEffect, useState } from 'react'
 import { useQuery } from 'react-query'
 import Spinner from '../../components/Spinner/Spinner.component'
 import {
   listAnswerablePosts,
   LIST_ANSWERABLE_POSTS_WITH_ANSWERS_QUERY_KEY,
 } from '../../services/PostService'
+import Pagination from '../Pagination'
 import PostListComponent from '../PostList/PostList.component'
 import './AnswerableQuestions.styles.scss'
 
-const AnswerableQuestions = ({ sort, tags }) => {
-  const { data: postsWithAnswers, isLoading: isWithAnswersLoading } = useQuery(
+const AnswerableQuestions = ({ sort, tags, pageSize }) => {
+  // Pagination
+  const [postsTotal, setPostsTotal] = useState(0)
+  const [currentPage, setCurrentPage] = useState(1)
+  const {
+    data: postsWithAnswers,
+    isLoading: isWithAnswersLoading,
+    isSuccess,
+  } = useQuery(
     [LIST_ANSWERABLE_POSTS_WITH_ANSWERS_QUERY_KEY, { sort, tags }],
     () => listAnswerablePosts({ withAnswers: true, sort, tags }),
   )
+  useEffect(() => {
+    if (isSuccess) {
+      setPostsTotal(postsWithAnswers.length)
+    }
+  }, [isSuccess, postsWithAnswers])
+
+  const handlePageChange = (nextPage) => {
+    // -> request new data using the page number
+    setCurrentPage(nextPage)
+    window.scrollTo(0, 0)
+  }
 
   return isWithAnswersLoading ? (
     <Spinner type="page" width="75px" height="200px" />
   ) : (
-    <PostListComponent posts={postsWithAnswers} />
+    <>
+      <PostListComponent
+        posts={postsWithAnswers.slice(
+          (currentPage - 1) * pageSize,
+          currentPage * pageSize,
+        )}
+      />
+      <Center mt={5}>
+        <Pagination
+          totalCount={postsTotal}
+          pageSize={pageSize}
+          onPageChange={handlePageChange}
+          currentPage={currentPage}
+        ></Pagination>
+      </Center>
+    </>
   )
 }
 

--- a/client/src/components/OfficerDashboard/OfficerDashboard.component.jsx
+++ b/client/src/components/OfficerDashboard/OfficerDashboard.component.jsx
@@ -3,10 +3,14 @@ import AnswerableQuestionsComponent from '../AnswerableQuestions/AnswerableQuest
 
 import './OfficerDashboard.styles.scss'
 
-const OfficerDashboard = ({ sort, tags }) => {
+const OfficerDashboard = ({ sort, tags, pageSize }) => {
   return (
     <div className="officer-dashboard">
-      <AnswerableQuestionsComponent sort={sort} tags={tags} />
+      <AnswerableQuestionsComponent
+        sort={sort}
+        tags={tags}
+        pageSize={pageSize}
+      />
     </div>
   )
 }

--- a/client/src/components/Pagination/Pagination.tsx
+++ b/client/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,57 @@
+import { useBreakpointValue } from '@chakra-ui/react'
+
+import { PaginationDesktop } from './PaginationDesktop'
+import { PaginationMobile } from './PaginationMobile'
+
+export interface PaginationProps {
+  /**
+   * Number of pages to display to left and right of current page.
+   * Defaults to `1`.
+   */
+  siblingCount?: number
+
+  /**
+   * Total number of elements to paginate.
+   */
+  totalCount: number
+
+  /**
+   * Size of each page. Determines the number of rendered page counts.
+   */
+  pageSize: number
+
+  /**
+   * Callback function invoked with the updated page when the page is changed.
+   */
+  onPageChange: (page: number) => void
+
+  /**
+   * Represents the current active page. Note that a `1-based index` is used.
+   */
+  currentPage: number
+
+  /**
+   * Whether pagination buttons are disabled.
+   */
+  isDisabled?: boolean
+}
+
+export const Pagination = (props: PaginationProps): JSX.Element => {
+  const isShowMobileVariant = useBreakpointValue({
+    base: true,
+    xs: true,
+    sm: true,
+    md: false,
+    lg: false,
+    xl: false,
+  })
+
+  return isShowMobileVariant ? (
+    <Pagination.Mobile {...props} />
+  ) : (
+    <Pagination.Desktop {...props} />
+  )
+}
+
+Pagination.Desktop = PaginationDesktop
+Pagination.Mobile = PaginationMobile

--- a/client/src/components/Pagination/PaginationDesktop.tsx
+++ b/client/src/components/Pagination/PaginationDesktop.tsx
@@ -1,0 +1,118 @@
+/**
+ * Desktop variant for the Pagination component.
+ */
+
+import { useCallback } from 'react'
+import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Text,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
+
+import { PAGINATION_THEME_KEY } from '../../theme/components/Pagination'
+import { usePaginationRange } from '../../hooks/usePaginationRange'
+
+import { PaginationProps } from './Pagination'
+
+// Separate constant to denote a separator in the pagination component.
+const SEPARATOR = '\u2026'
+
+interface DesktopPageButtonProps {
+  selectedPage: PaginationProps['currentPage']
+  page: number | typeof SEPARATOR
+  onClick: PaginationProps['onPageChange']
+  isDisabled: PaginationProps['isDisabled']
+}
+
+const DesktopPageButton = ({
+  selectedPage,
+  page,
+  onClick,
+  isDisabled,
+}: DesktopPageButtonProps) => {
+  const isSelected = page === selectedPage
+
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isSelected })
+
+  const handleClick = useCallback(() => {
+    if (page === SEPARATOR) return
+    onClick(page)
+  }, [onClick, page])
+
+  if (page === SEPARATOR) {
+    return <Text sx={styles.separator}>{page}</Text>
+  }
+
+  return (
+    <Button sx={styles.button} onClick={handleClick} isDisabled={isDisabled}>
+      {page}
+    </Button>
+  )
+}
+
+export const PaginationDesktop = ({
+  siblingCount = 1,
+  pageSize,
+  onPageChange,
+  totalCount,
+  currentPage,
+  isDisabled,
+}: PaginationProps): JSX.Element => {
+  const paginationRange = usePaginationRange<typeof SEPARATOR>({
+    totalCount,
+    pageSize,
+    currentPage,
+    siblingCount,
+    separator: SEPARATOR,
+  })
+
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, {})
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+  const isDisableNextPage = isDisabled || currentPage >= totalPageCount
+  const isDisablePrevPage = isDisabled || currentPage <= 1
+
+  const handlePageBack = useCallback(() => {
+    if (isDisablePrevPage) return
+    onPageChange(currentPage - 1)
+  }, [currentPage, isDisablePrevPage, onPageChange])
+
+  const handlePageNext = useCallback(() => {
+    if (isDisableNextPage) return
+    onPageChange(currentPage + 1)
+  }, [currentPage, isDisableNextPage, onPageChange])
+
+  return (
+    <Box __css={styles.container}>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Previous page"
+        isDisabled={isDisablePrevPage}
+        onClick={handlePageBack}
+        icon={<BiChevronLeft />}
+      />
+      <HStack spacing="0.125rem">
+        {paginationRange.map((p, i) => (
+          <DesktopPageButton
+            key={i}
+            page={p}
+            isDisabled={isDisabled}
+            selectedPage={currentPage}
+            onClick={onPageChange}
+          />
+        ))}
+      </HStack>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Next page"
+        isDisabled={isDisableNextPage}
+        onClick={handlePageNext}
+        icon={<BiChevronRight />}
+      />
+    </Box>
+  )
+}

--- a/client/src/components/Pagination/PaginationMobile.tsx
+++ b/client/src/components/Pagination/PaginationMobile.tsx
@@ -1,0 +1,58 @@
+/**
+ * Mobile variant for the Pagination component.
+ */
+
+import { useCallback } from 'react'
+import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
+import { Box, IconButton, Text, useMultiStyleConfig } from '@chakra-ui/react'
+
+import { PAGINATION_THEME_KEY } from '../../theme/components/Pagination'
+import { PaginationProps } from './Pagination'
+
+type PaginationMobileProps = Omit<PaginationProps, 'siblingCount'>
+
+export const PaginationMobile = ({
+  pageSize,
+  onPageChange,
+  totalCount,
+  currentPage,
+  isDisabled,
+}: PaginationMobileProps): JSX.Element => {
+  const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isDisabled })
+
+  const totalPageCount = Math.ceil(totalCount / pageSize)
+  const isDisableNextPage = isDisabled || currentPage >= totalPageCount
+  const isDisablePrevPage = isDisabled || currentPage <= 1
+
+  const handlePageBack = useCallback(() => {
+    if (isDisablePrevPage) return
+    onPageChange(currentPage - 1)
+  }, [currentPage, isDisablePrevPage, onPageChange])
+
+  const handlePageNext = useCallback(() => {
+    if (isDisableNextPage) return
+    onPageChange(currentPage + 1)
+  }, [currentPage, isDisableNextPage, onPageChange])
+
+  return (
+    <Box __css={styles.container}>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Previous page"
+        isDisabled={isDisablePrevPage}
+        onClick={handlePageBack}
+        icon={<BiChevronLeft />}
+      />
+      <Text sx={styles.text} aria-disabled={isDisabled}>
+        Page {currentPage} of {totalPageCount}
+      </Text>
+      <IconButton
+        sx={styles.stepper}
+        aria-label="Next page"
+        isDisabled={isDisableNextPage}
+        onClick={handlePageNext}
+        icon={<BiChevronRight />}
+      />
+    </Box>
+  )
+}

--- a/client/src/components/Pagination/index.ts
+++ b/client/src/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination as default } from './Pagination'

--- a/client/src/components/QuestionsList/QuestionsList.component.jsx
+++ b/client/src/components/QuestionsList/QuestionsList.component.jsx
@@ -1,20 +1,54 @@
-import React from 'react'
+import { Center } from '@chakra-ui/layout'
+import { useEffect, useState } from 'react'
 import { useQuery } from 'react-query'
 import { listPosts, LIST_POSTS_QUERY_KEY } from '../../services/PostService'
 import PostListComponent from '../PostList/PostList.component'
 import Spinner from '../Spinner/Spinner.component'
 import './QuestionsList.styles.scss'
+import Pagination from '../Pagination'
 
-const QuestionsList = ({ sort, tags }) => {
-  const { data: posts, isLoading } = useQuery(
-    [LIST_POSTS_QUERY_KEY, { sort, tags }],
-    () => listPosts(sort, tags),
+const QuestionsList = ({ sort, tags, pageSize }) => {
+  // Pagination
+  const [postsTotal, setPostsTotal] = useState(0)
+  const [currentPage, setCurrentPage] = useState(1)
+  const {
+    data: posts,
+    isLoading,
+    isSuccess,
+  } = useQuery([LIST_POSTS_QUERY_KEY, { sort, tags }], () =>
+    listPosts(sort, tags),
   )
+  useEffect(() => {
+    if (isSuccess) {
+      setPostsTotal(posts.length)
+    }
+  }, [isSuccess, posts])
+
+  const handlePageChange = (nextPage) => {
+    // -> request new data using the page number
+    setCurrentPage(nextPage)
+    window.scrollTo(0, 0)
+  }
 
   return isLoading ? (
     <Spinner type="page" width="75px" height="200px" />
   ) : (
-    <PostListComponent posts={posts} />
+    <>
+      <PostListComponent
+        posts={posts.slice(
+          (currentPage - 1) * pageSize,
+          currentPage * pageSize,
+        )}
+      />
+      <Center mt={5}>
+        <Pagination
+          totalCount={postsTotal}
+          pageSize={pageSize}
+          onPageChange={handlePageChange}
+          currentPage={currentPage}
+        ></Pagination>
+      </Center>
+    </>
   )
 }
 

--- a/client/src/hooks/usePaginationRange.ts
+++ b/client/src/hooks/usePaginationRange.ts
@@ -1,0 +1,118 @@
+/**
+ * Custom hook to generate page ranges for any pagination component.
+ * Referenced from
+ * https://www.freecodecamp.org/news/build-a-custom-pagination-component-in-react/
+ */
+
+import { useMemo } from 'react'
+import range from 'lodash/range'
+
+interface UsePaginationRangeProps<T extends unknown = string> {
+  /**
+   * Number of pages to display to left and right of current page.
+   */
+  siblingCount: number
+
+  /**
+   * Total number of elements to paginate.
+   */
+  totalCount: number
+
+  /**
+   * Size of each page. Determines the number of rendered page counts.
+   */
+  pageSize: number
+
+  /**
+   * Represents the current active page. Note that a `1-based index` is used.
+   */
+  currentPage: number
+
+  /**
+   * A constant to denote a separator in the pagination component.
+   */
+  separator: T
+}
+
+export const usePaginationRange = <T extends unknown = string>({
+  totalCount,
+  pageSize,
+  siblingCount,
+  currentPage,
+  separator,
+}: UsePaginationRangeProps<T>): (T | number)[] => {
+  const paginationRange = useMemo(() => {
+    const totalPageCount = Math.ceil(totalCount / pageSize)
+
+    // Only show separators if the currently shown numbers have at least a gap
+    // of 2 numbers to the first or last page numbers.
+    const minGapSize = 2
+    // The maximum number of pages to display is determined as
+    // firstPage + (2 * siblingCount) + currentPage + (2 * separator) + lastPage.
+    // E.g. [1, ..., 5, 6, 7, ..., 15] for siblingCount of 1, and
+    // [1, ..., 5, 6, 7, 8, 9, ..., 15] for siblingCount of 2.
+    const numPageDisplaySlots = 2 * siblingCount + 5
+
+    /**
+     * Case 1:
+     * If the number of pages is less than the page numbers we want to show in
+     * the component, we return the range [1..totalPageCount]
+     */
+    if (numPageDisplaySlots >= totalPageCount) {
+      return range(1, totalPageCount + 1)
+    }
+
+    // Calculate left and right sibling index and make sure they are within
+    // range [1..totalPageCount]
+    const leftSiblingIndex = Math.max(currentPage - siblingCount, 1)
+    const rightSiblingIndex = Math.min(
+      currentPage + siblingCount,
+      totalPageCount,
+    )
+
+    // Do not show separator just when there is just one page number to be
+    // inserted between the extremes of sibling and the page limits
+    // i.e 1 and totalPageCount.
+    const shouldShowLeftSeparator = leftSiblingIndex - 1 > minGapSize
+    const shouldShowRightSeparator =
+      totalPageCount - rightSiblingIndex > minGapSize
+
+    /**
+     * Case 2: No left separator to show, but right separator to be shown.
+     */
+    if (!shouldShowLeftSeparator && shouldShowRightSeparator) {
+      // 2 indicates separator and final page number.
+      const leftItemCount = numPageDisplaySlots - 2
+      const leftRange = range(1, leftItemCount + 1)
+
+      return [...leftRange, separator, totalPageCount]
+    }
+
+    /**
+     * Case 3: No right separator to show, but left separator to be shown.
+     */
+    if (shouldShowLeftSeparator && !shouldShowRightSeparator) {
+      // 2 indicates first page number and the separator.
+      const rightItemCount = numPageDisplaySlots - 2
+      const rightRange = range(
+        totalPageCount - rightItemCount + 1,
+        totalPageCount + 1,
+      )
+      return [1, separator, ...rightRange]
+    }
+
+    /**
+     * Case 4: Both left and right separator to be shown
+     */
+    if (shouldShowLeftSeparator && shouldShowRightSeparator) {
+      const middleRange = range(leftSiblingIndex, rightSiblingIndex + 1)
+      return [1, separator, ...middleRange, separator, totalPageCount]
+    }
+
+    // This should never be reached, but in case it is, return the range
+    // [1..totalPageCount]
+    return range(1, totalPageCount + 1)
+  }, [totalCount, pageSize, siblingCount, currentPage, separator])
+
+  return paginationRange
+}

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -213,11 +213,13 @@ const HomePage = ({ match }) => {
             <OfficerDashboardComponent
               sort={sortState.value}
               tags={agencyAndTags}
+              pageSize={10}
             />
           ) : (
             <QuestionsListComponent
               sort={sortState.value}
               tags={agencyAndTags}
+              pageSize={10}
             />
           )}
         </Box>

--- a/client/src/theme/components/Pagination.ts
+++ b/client/src/theme/components/Pagination.ts
@@ -1,0 +1,78 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/react'
+
+export const PAGINATION_THEME_KEY = 'Pagination'
+
+const baseButtonStyling = (props: Record<string, any>) => {
+  const { isSelected } = props
+  return {
+    p: '0.25rem 0.625rem',
+    minH: '2rem',
+    minW: '2rem',
+    border: 'none',
+    borderRadius: '0.25rem',
+    bg: isSelected ? 'secondary.500' : 'transparent',
+    _active: {
+      bg: isSelected ? 'secondary.700' : 'secondary.200',
+    },
+    _hover: {
+      bg: isSelected ? 'secondary.600' : 'secondary.100',
+    },
+    _focus: {
+      boxShadow: `0 0 0 2px var(--chakra-colors-secondary-300)`,
+    },
+    _disabled: {
+      bg: isSelected ? 'secondary.300' : 'transparent',
+      cursor: 'not-allowed',
+      color: isSelected ? 'white' : 'secondary.300',
+      _hover: {
+        bg: isSelected ? 'secondary.300' : 'transparent',
+        color: isSelected ? 'white' : 'secondary.300',
+      },
+    },
+    color: isSelected ? 'white' : 'secondary.500',
+  }
+}
+
+export const Pagination: ComponentMultiStyleConfig = {
+  parts: ['button', 'container', 'separator', 'stepper', 'text'],
+  variants: {
+    solid: (props) => {
+      const buttonStyling = baseButtonStyling(props)
+      const { isDisabled } = props
+
+      return {
+        container: {
+          display: 'flex',
+          textStyle: 'body-2',
+        },
+        separator: {
+          display: 'inline-block',
+          p: '0.25rem 0.75rem',
+          minH: '2rem',
+          minW: '2rem',
+        },
+        text: {
+          alignSelf: 'center',
+          p: '0.25rem 0.75rem',
+          color: isDisabled ? 'secondary.300' : 'secondary.500',
+        },
+        stepper: {
+          ...buttonStyling,
+          fontSize: '1.5rem',
+          pl: 0,
+          pr: 0,
+          _first: {
+            mr: '0.25rem',
+          },
+          _last: {
+            ml: '0.25rem',
+          },
+        },
+        button: buttonStyling,
+      }
+    },
+  },
+  defaultProps: {
+    variant: 'solid',
+  },
+}

--- a/client/src/theme/components/Pagination.ts
+++ b/client/src/theme/components/Pagination.ts
@@ -2,7 +2,7 @@ import { ComponentMultiStyleConfig } from '@chakra-ui/react'
 
 export const PAGINATION_THEME_KEY = 'Pagination'
 
-const baseButtonStyling = (props: Record<string, any>) => {
+const baseButtonStyling = (props: Record<string, unknown>) => {
   const { isSelected } = props
   return {
     p: '0.25rem 0.625rem',

--- a/client/src/theme/components/index.ts
+++ b/client/src/theme/components/index.ts
@@ -1,7 +1,9 @@
 import { Button } from './Button'
 import { StyledToast } from './StyledToast'
+import { Pagination, PAGINATION_THEME_KEY } from './Pagination'
 
 export const components = {
   Button,
   StyledToast,
+  [PAGINATION_THEME_KEY]: Pagination,
 }


### PR DESCRIPTION
## Problem and solution

This is the first part of adding pagination to the homepage. It only makes changes to the frontend, and still queries the whole list of posts for now.

- Add the paginate component from FormSG. Change to using the Forms package when it publishes.
- Add paging to both user and agency home page

- Partially addresses #20 

## Before & After Screenshots
**AFTER**:

https://user-images.githubusercontent.com/20250559/130574504-5d29af0f-3438-4981-b9e6-5311595e6a27.mov


