### PR TITLE
fix(search): update search to use new post api

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -21,7 +21,7 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
   client-side search 
   */
   const { agency: agencyShortName } = useParams()
-  const { data: posts } = useQuery(
+  const { data: data } = useQuery(
     [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agencyShortName],
     // TODO: refactor to better split between when agencyShortName is present
     () => listPosts(undefined, agencyShortName),
@@ -75,7 +75,7 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
 
   const itemToString = (item) => (item ? item.title : '')
 
-  const fuse = new Fuse(posts, {
+  const fuse = new Fuse(data?.posts, {
     keys: ['title', 'description'],
   })
 

--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -21,7 +21,7 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
   client-side search 
   */
   const { agency: agencyShortName } = useParams()
-  const { data: data } = useQuery(
+  const { data } = useQuery(
     [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agencyShortName],
     // TODO: refactor to better split between when agencyShortName is present
     () => listPosts(undefined, agencyShortName),

--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -13,14 +13,14 @@ import './SearchResults.styles.scss'
 import { sortByCreatedAt } from '../../util/date'
 
 const SearchResults = () => {
-  const { data: posts, isLoading } = useQuery([LIST_POSTS_QUERY_KEY], () =>
+  const { data: data, isLoading } = useQuery([LIST_POSTS_QUERY_KEY], () =>
     listPosts(),
   )
 
   let searchQuery =
     new URLSearchParams(useLocation().search).get('search') ?? ''
 
-  const foundPosts = new Fuse(posts ?? [], {
+  const foundPosts = new Fuse(data?.posts ?? [], {
     keys: ['title', 'description'],
   })
     .search(searchQuery)

--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -13,7 +13,7 @@ import './SearchResults.styles.scss'
 import { sortByCreatedAt } from '../../util/date'
 
 const SearchResults = () => {
-  const { data: data, isLoading } = useQuery([LIST_POSTS_QUERY_KEY], () =>
+  const { data, isLoading } = useQuery([LIST_POSTS_QUERY_KEY], () =>
     listPosts(),
   )
 


### PR DESCRIPTION
## Problem
 
Fixed bug introduced by #141 . 
The `/posts` endpoint returns a different type of response, and the search boxes were not updated for them.

## Solution
Update the search box components, pages.

## After
https://user-images.githubusercontent.com/20250559/131435640-78eaa52a-3801-47b0-9412-bce35eac5539.mov


