### PR TITLE
feat(ga): capture when a search is abandoned

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -36,7 +36,17 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
       googleAnalytics.GA_USER_EVENTS.SEARCH,
       searchString,
     )
-    FullStory.event('Search', {
+    FullStory.event(googleAnalytics.GA_USER_EVENTS.SEARCH, {
+      // property name uses `ident_type` pattern
+      searchString_str: searchString,
+    })
+  }
+  const sendAbandonedSearchEventToAnalytics = (searchString) => {
+    googleAnalytics.sendUserEvent(
+      googleAnalytics.GA_USER_EVENTS.ABANDONED,
+      searchString,
+    )
+    FullStory.event(googleAnalytics.GA_USER_EVENTS.ABANDONED, {
       // property name uses `ident_type` pattern
       searchString_str: searchString,
     })
@@ -94,7 +104,10 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
             inputValue,
             highlightedIndex,
           }) => (
-            <div className="search-autocomplete">
+            <div
+              className="search-autocomplete"
+              onBlur={() => sendAbandonedSearchEventToAnalytics(inputValue)}
+            >
               <InputGroup className="search-box">
                 <InputLeftElement
                   children={<BiSearch size="24" color="secondary.500" />}

--- a/client/src/services/googleAnalytics.tsx
+++ b/client/src/services/googleAnalytics.tsx
@@ -2,6 +2,7 @@ import ReactGA from 'react-ga'
 
 const GA_USER_EVENTS = {
   SEARCH: 'Search',
+  ABANDONED: 'Abandoned Search',
 }
 
 const initializeGA = (trackingId: string): void => {


### PR DESCRIPTION
## Problem

Closes #180 

## Solution

- Add Abandoned Search event to GA events
- Make FullStory use the same event names as GA
- If user triggers `onBlur()` on search input box, assume that the
  search is abandoned and log accordingly

## Screenshots

![image](https://user-images.githubusercontent.com/10572368/131473443-d5e004b9-8b37-4332-9675-fee6fee79a59.png)

## Tests
- Open Google Analytics, Staging environment, Realtime, Events
- Navigate to home page or agency-specific page
- Click on search bar, type a search query, then click outside the search bar to cause it to lose focus
- Verify that an Abandoned Search event was triggered