### PR TITLE
fix(search): have agency-specific results from agency page

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -79,7 +79,10 @@ const SearchBox = ({ placeholder, value, handleSubmit }) => {
   if (!handleSubmit) {
     handleSubmit = (data) => {
       sendSearchEventToAnalytics(data[name])
-      history.push(`/questions?search=${data[name]}`)
+      history.push(
+        `/questions?search=${data[name]}` +
+          (agencyShortName ? `&agency=${agencyShortName}` : ''),
+      )
     }
   }
 

--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -8,17 +8,22 @@ import PostItem from '../../components/PostItem/PostItem.component'
 import SearchBox from '../../components/SearchBox/SearchBox.component'
 import { Spacer } from '@chakra-ui/react'
 import Spinner from '../../components/Spinner/Spinner.component'
-import { listPosts, LIST_POSTS_QUERY_KEY } from '../../services/PostService'
+import {
+  listPosts,
+  LIST_POSTS_FOR_SEARCH_QUERY_KEY,
+} from '../../services/PostService'
 import './SearchResults.styles.scss'
 import { sortByCreatedAt } from '../../util/date'
 
 const SearchResults = () => {
-  const { data, isLoading } = useQuery([LIST_POSTS_QUERY_KEY], () =>
-    listPosts(),
+  const { search } = useLocation()
+  const searchParams = new URLSearchParams(search)
+  const searchQuery = searchParams.get('search') ?? ''
+  const agency = searchParams.get('agency')
+  const { data, isLoading } = useQuery(
+    [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agency],
+    listPosts(undefined, agency),
   )
-
-  let searchQuery =
-    new URLSearchParams(useLocation().search).get('search') ?? ''
 
   const foundPosts = new Fuse(data?.posts ?? [], {
     keys: ['title', 'description'],

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -22,7 +22,7 @@ const HomePageComponent = withPageTitle({
 
 const SearchResultsComponent = withPageTitle({
   component: SearchResults,
-  title: 'All Questions - AskGov',
+  title: 'Search Results - AskGov',
 })
 
 const LoginComponent = withPageTitle({


### PR DESCRIPTION
## Problem

Closes #178 

## Solution

If a user is searching from an agency page, the user expects to see
results specific to that agency, so pass this to the SearchResults
component so that the appropriate posts are fetched for searching

## Screenshot


https://user-images.githubusercontent.com/10572368/131606034-a0dd6384-58c9-4aa0-bd8d-6345d3a46bcb.mov


