### PR TITLE
fix(pages): scroll to top on loading all pages

### DIFF
--- a/client/src/components/PrivacyTerms/AgencyPrivacy.component.tsx
+++ b/client/src/components/PrivacyTerms/AgencyPrivacy.component.tsx
@@ -1,10 +1,8 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
-import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const AgencyPrivacy = (): JSX.Element => (
   <>
-    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/AgencyTerms.component.tsx
+++ b/client/src/components/PrivacyTerms/AgencyTerms.component.tsx
@@ -1,10 +1,8 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
-import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const AgencyTerms = (): JSX.Element => (
   <>
-    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/CitizenPrivacy.component.tsx
+++ b/client/src/components/PrivacyTerms/CitizenPrivacy.component.tsx
@@ -1,10 +1,8 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
-import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const CitizenPrivacy = (): JSX.Element => (
   <>
-    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/PrivacyTerms/CitizenTerms.component.tsx
+++ b/client/src/components/PrivacyTerms/CitizenTerms.component.tsx
@@ -1,10 +1,8 @@
 import { Box, Center, Container, Text } from '@chakra-ui/react'
-import { ScrollToTopOnMount } from '../ScrollToTop/ScrollToTop.component'
 import './PrivacyTerms.styles.scss'
 
 const CitizenTerms = (): JSX.Element => (
   <>
-    <ScrollToTopOnMount />
     <Box bg="primary.500" h="174px">
       <Text
         textStyle="display-2"

--- a/client/src/components/ScrollToTop/ScrollToTop.component.tsx
+++ b/client/src/components/ScrollToTop/ScrollToTop.component.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 
-// Where added, scroll to top of component
+// Where added, scroll to top on each new page
 // https://reactrouter.com/web/guides/scroll-restoration
-export function ScrollToTopOnMount(): null {
+export default function ScrollToTop(): null {
+  const { pathname } = useLocation()
+
   useEffect(() => {
     window.scrollTo(0, 0)
-  }, [])
+  }, [pathname])
 
   return null
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
+import ScrollToTop from './components/ScrollToTop/ScrollToTop.component'
 
 import App from './App'
 
@@ -14,6 +15,7 @@ ReactDOM.render(
       {/* ReactQueryDevtools will not appear in production builds */}
       <ReactQueryDevtools initialIsOpen={false} />
       <BrowserRouter>
+        <ScrollToTop />
         <App />
       </BrowserRouter>
     </QueryClientProvider>


### PR DESCRIPTION
## Problem

Scroll to top (on new page load, load at the top instead of remembering previous page location) was previously added only onto legalese pages. This was because on the desktop scroll position only affected the long pages ie. legalese. However, on the mobile, many of the pages will be long. If a post starts having multiple answers and comments, then it will require a scroll to top as well.

- Closes #186

## Solution

Change the scroll to top to affect all pages. If more granularity in which page scrolls to top is needed, it is possible to revert the commit and add the `scrollToTopOnMount` component to individual pages.

https://user-images.githubusercontent.com/20250559/131630383-a9d335ba-69e1-4d00-9cb3-a268f007e853.mov


