### PR TITLE
feat(enquiries): suggest existing questions to the user

### DIFF
--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -23,6 +23,7 @@ import { Agency } from '../../services/AgencyService'
 import { BiErrorCircle } from 'react-icons/bi'
 import { Enquiry } from '../../services/MailService'
 import ReCAPTCHA from 'react-google-recaptcha'
+import SearchBox from '../SearchBox/SearchBox.component'
 interface EnquiryModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
   onConfirm: (enquiry: Enquiry, captchaResponse: string) => Promise<void>
   agency: Agency
@@ -49,6 +50,9 @@ export const EnquiryModal = ({
     }
   }
 
+  const { ref, ...questionTitleProps } = register('questionTitle', {
+    required: true,
+  })
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -72,13 +76,13 @@ export const EnquiryModal = ({
                 Question Title
               </Text>
               <Box h={3} />
-              <Input
-                focusBorderColor="primary.500"
-                errorBorderColor="error.500"
+              <SearchBox
+                placeholder=""
+                value=""
+                showSearchIcon={false}
                 isInvalid={formErrors.questionTitle}
-                {...register('questionTitle', {
-                  required: true,
-                })}
+                inputRef={ref}
+                {...questionTitleProps}
               />
               {formErrors.questionTitle && errorLabel('This field is required')}
               <Box h={4} />

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -77,6 +77,8 @@ export const EnquiryModal = ({
               </Text>
               <Box h={3} />
               <SearchBox
+                focusBorderColor="primary.500"
+                errorBorderColor="error.500"
                 placeholder=""
                 value=""
                 showSearchIcon={false}

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -80,6 +80,7 @@ export const EnquiryModal = ({
                 placeholder=""
                 value=""
                 showSearchIcon={false}
+                searchOnEnter={false}
                 isInvalid={formErrors.questionTitle}
                 inputRef={ref}
                 {...questionTitleProps}

--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -107,11 +107,21 @@ const SearchBox = ({
     keys: ['title', 'description'],
   })
 
+  const stateReducer = (_state, changes) => {
+    return [
+      Downshift.stateChangeTypes.blurInput,
+      Downshift.stateChangeTypes.mouseUp,
+    ].includes(changes.type)
+      ? { isOpen: false } // no-changes
+      : changes
+  }
+
   return (
     <div className="search-container">
       <form className="search-form" onSubmit={handleSubmitHook(onSubmit)}>
         <Downshift
           onChange={(selection) => history.push(`/questions/${selection.id}`)}
+          stateReducer={stateReducer}
           itemToString={itemToString}
         >
           {({

--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -18,6 +18,7 @@ const SearchBox = ({
   inputRef,
   handleSubmit = undefined,
   handleAbandon = (_inputValue) => {},
+  searchOnEnter = true,
   showSearchIcon = true,
   ...inputProps
 }) => {
@@ -142,12 +143,17 @@ const SearchBox = ({
                     ref: inputRef,
                     ...inputProps,
                     onKeyDown: (event) => {
+                      // when selecting option using keyboard
                       if (event.key === 'Enter') {
-                        // when selecting option using keyboard
-                        // downshift prevents form submission which is used to submit analytics event
-                        // detect such event and separately send analytics event
-                        sendSearchEventToAnalytics(inputValue)
-                        if (highlightedIndex === null) {
+                        if (
+                          highlightedIndex !== null ||
+                          (highlightedIndex === null && searchOnEnter)
+                        ) {
+                          sendSearchEventToAnalytics(inputValue)
+                        }
+                        if (highlightedIndex === null && searchOnEnter) {
+                          // downshift prevents form submission which is used to submit analytics event
+                          // detect such event and explicitly invoke handler
                           handleSubmit(inputValue)
                         }
                       }


### PR DESCRIPTION
## Problem

Closes #173 

## Solution

- refine default handleSubmit flag to just push history; regardless of
  specified hook, GA event will be sent
- add handleAbandon hook, capturing when a search is abandoned
- allow search icon to be disabled by setting `showSearchIcon` to false
- retain search text value even on abandoning
- make SearchBox a component, not a form
- introduce also the means to open search items in new window to retain user context as much as possible
- use SearchBox to suggest questions

## Screenshot

![image](https://user-images.githubusercontent.com/10572368/131657184-33662dc0-de5b-4985-b1c1-5fdc17b6292d.png)

