### PR TITLE
fix(banner): prevent banner height from shrinking

### DIFF
--- a/client/src/components/Banner/Banner.styles.scss
+++ b/client/src/components/Banner/Banner.styles.scss
@@ -3,6 +3,7 @@
 
 .banner {
   height: 50px;
+  min-height: 50px;
   color: $neutral-100;
   z-index: 2000;
   background: $neutral-900;


### PR DESCRIPTION
## Solution
Minor UI fix. Banner height should remain the same size regardless of length of page. Applicable only to staging env

## Before & After Screenshots

**BEFORE**:

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/20250559/131793691-cd2e1c2a-4787-4142-ab2e-465d7fc6cb11.png">

**AFTER**:
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/20250559/131793662-d82f2e9e-4cbf-4ca9-9d4e-9f3d6a7f35ec.png">
