### PR TITLE
fix(footer): stick enquiry button to bottom of post page

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -66,7 +66,7 @@ const Post = () => {
   return isLoading ? (
     <Spinner type="page" width="75px" height="200px" />
   ) : (
-    <>
+    <Flex direction="column" height="100%">
       <PageTitle title={`${post.title} - AskGov`} />
       <div className="post-page">
         <Flex pb="14px" align="center">
@@ -124,6 +124,7 @@ const Post = () => {
           <AnswerSection post={post} />
         </div>
       </div>
+      <Spacer />
       <CitizenRequest
         agency={
           agency
@@ -137,7 +138,7 @@ const Post = () => {
               }
         }
       />
-    </>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
## Problem and Solution
Enquiry button component sticks to the footer of homepage (expected behaviour) but not on postpage.

## Before
![Screen Shot 2021-09-02 at 14 35 49](https://user-images.githubusercontent.com/20250559/131794370-52c3a503-baa9-4c17-8230-097c9c4f245a.png)



## After
![Screen Shot 2021-09-02 at 14 34 51](https://user-images.githubusercontent.com/20250559/131794260-ee34e15a-d890-4b5a-932d-e183d430dcd5.png)
