### PR TITLE
refactor(user): move `UserService.login` to `AuthService.createToken`

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -101,9 +101,7 @@ const apiOptions = {
     controller: new AuthController({
       mailService,
       authService,
-      userService: new UserService({
-        jwtSecret,
-      }),
+      userService: new UserService(),
     }),
     middleware: authMiddleware,
   },

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -176,13 +176,13 @@ export class AuthController {
       let jwt
       let displayname
       if (user) {
-        jwt = this.userService.login(user.id)
+        jwt = this.authService.createToken(user.id)
         displayname = user.displayname
       } else {
         if (this.authService.isOfficerEmail(email)) {
           const officer = await this.userService.createOfficer(email)
           displayname = officer.displayname
-          jwt = this.userService.login(officer.id)
+          jwt = this.authService.createToken(officer.id)
         }
       }
 

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -1,13 +1,16 @@
 import jwt from 'jsonwebtoken'
-import { PostStatus } from '../../types/post-status'
+import minimatch from 'minimatch'
 
+import { PostStatus } from '../../types/post-status'
 import {
   User as UserModel,
   Permission as PermissionModel,
   PostTag as PostTagModel,
 } from '../../bootstrap/sequelize'
-import minimatch from 'minimatch'
 import { Permission, Post, PostTag, Tag, User } from '../../models'
+import { createLogger } from '../../bootstrap/logging'
+
+const logger = createLogger(module)
 
 export type PermissionWithRelations = Permission & {
   tagId: string
@@ -34,6 +37,26 @@ export class AuthService {
   }) {
     this.emailValidator = emailValidator
     this.jwtSecret = jwtSecret
+  }
+
+  createToken = (userId: string): string => {
+    const payload = {
+      user: {
+        id: userId,
+      },
+    }
+    try {
+      return jwt.sign(payload, this.jwtSecret, { expiresIn: 86400 })
+    } catch (error) {
+      logger.error({
+        message: 'Error while signing JWT',
+        meta: {
+          function: 'createToken',
+        },
+        error,
+      })
+      throw error
+    }
   }
 
   /**

--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -7,6 +7,7 @@ import { PostController } from '../post.controller'
 describe('PostController', () => {
   const path = '/posts'
   const authService = {
+    createToken: jest.fn(),
     getUserIdFromToken: jest.fn(),
     getOfficerUser: jest.fn(),
     checkIfWhitelistedOfficer: jest.fn(),

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -38,6 +38,7 @@ describe('/posts', () => {
 
   // Set up service, controller and route
   const authService = {
+    createToken: jest.fn(),
     getUserIdFromToken: jest.fn(),
     getOfficerUser: jest.fn(),
     checkIfWhitelistedOfficer: jest.fn(),

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -1,39 +1,8 @@
-import jwt from 'jsonwebtoken'
-
 import { getOfficerDisplayName } from './user.util'
 import { User as UserModel, Tag as TagModel } from '../../bootstrap/sequelize'
 import { User } from '../../models'
-import { createLogger } from '../../bootstrap/logging'
-
-const logger = createLogger(module)
 
 export class UserService {
-  private jwtSecret
-
-  constructor({ jwtSecret }: { jwtSecret: string }) {
-    this.jwtSecret = jwtSecret
-  }
-
-  login = (userId: string): string => {
-    const payload = {
-      user: {
-        id: userId,
-      },
-    }
-    try {
-      return jwt.sign(payload, this.jwtSecret, { expiresIn: 86400 })
-    } catch (error) {
-      logger.error({
-        message: 'Error while signing JWT',
-        meta: {
-          function: 'login',
-        },
-        error,
-      })
-      throw error
-    }
-  }
-
   createOfficer = async (username: string): Promise<User> => {
     return UserModel.create({
       username,


### PR DESCRIPTION
## Problem

The UserService should only concern itself with user-related admin
tasks. In addition, AuthService should be the authoritative service 
for handling authentication

Groundwork for #100 

## Solution
Hence, move `login()`, which creates signed JWT tokens, to
AuthService, where it should be. This allows us to simplify our
dependencies by having everything JWT-related in AuthService.