### PR TITLE
fix(search): ensure input is preserved on `touchEnd` event

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -97,6 +97,7 @@ const SearchBox = ({
     return [
       Downshift.stateChangeTypes.blurInput,
       Downshift.stateChangeTypes.mouseUp,
+      Downshift.stateChangeTypes.touchEnd,
     ].includes(changes.type)
       ? { isOpen: false } // no-changes
       : changes


### PR DESCRIPTION
## Problem

The SearchBox currently has to manipulate state manually on certain events corresponding to input blur,
to ensure that input remains preserved. This currently listens for `blurInput` and `mouseInput` events, but
not the `touchEnd` event, which fires for mobile devices

## Solution

Listen and handle the `touchEnd` event