### PR TITLE
fix(search): handle abandon only if searchbox on homepage

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -121,7 +121,7 @@ const SearchBox = ({
           }) => (
             <div
               className="search-autocomplete"
-              onBlur={() => onAbandon(inputValue)}
+              onBlur={() => searchOnEnter && onAbandon(inputValue)}
             >
               <InputGroup className="search-box">
                 {showSearchIcon ? (


### PR DESCRIPTION
## Problem && Solution

`handleAbandon` is fired regardless of `searchbox` in homepage or enquiry form. If it is in enquiry form and user clicks out of search box in order to continue typing, it should not be considered an abandon event.