### PR TITLE
Revert "build(deps): bump @aws-sdk/client-s3 from 3.28.0 to 3.29.0 in /server"

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -53,11 +53,11 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
-      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.25.0.tgz",
+      "integrity": "sha512-uEVKqKkPVz6atbCxCNJY5O7V+ieSK8crUswXo8/WePyEbGEgxJ4t9x/WG4lV8kBjelmvQHDR4GqfJmb5Sh9xSg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -69,9 +69,9 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.29.0.tgz",
-      "integrity": "sha512-s24ycAMo8rY60gGw9aH29QhpPJKD9M/0oCZ1cf9IZj1u2e896Q4Q/wknwfanaWS7thF5AcTdjNMfvny9QVJJBA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.23.0.tgz",
+      "integrity": "sha512-gmJhCuXrKOOumppviE4K30NvsIQIqqxbGDNptrJrMYBO0qXCbK8/BypZ/hS/oT3loDzlSIxG2z5GDL/va9lbFw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -84,11 +84,11 @@
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.29.0.tgz",
-      "integrity": "sha512-m/zLdRz5AR5y8NblhYEXmoAAIQkad73D7tIkT1PvgPoC0wmSurBsbDCx2NYNi8CF5nRJjofq0MNduU0al/o8yg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.23.0.tgz",
+      "integrity": "sha512-Ya5f8Ntv0EyZw+AHkpV6n6qqHzpCDNlkX50uj/dwFCMmPiHFWsWMvd0Qu04Y7miycJINEatRrJ5V8r/uVvZIDg==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -100,54 +100,54 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.29.0.tgz",
-      "integrity": "sha512-Tpc3scjBXLeZAQoOB6f1WZniXTQ++5pCTsPjzS2IaRFYvapjFm4tvbSUGTnj99CQBvMi2aFMT/HOTeM6+yBPTw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.28.0.tgz",
+      "integrity": "sha512-kbz17iQSrdHbUIpC3BiAgyws4uu2buOyBPFb/ttbYS8cVGqo2a8fina0TcguV2D1O4GZ4WtR0ymZ3kOarGga+A==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/client-sts": "3.29.0",
-        "@aws-sdk/config-resolver": "3.29.0",
-        "@aws-sdk/credential-provider-node": "3.29.0",
-        "@aws-sdk/eventstream-serde-browser": "3.29.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.29.0",
-        "@aws-sdk/eventstream-serde-node": "3.29.0",
-        "@aws-sdk/fetch-http-handler": "3.29.0",
-        "@aws-sdk/hash-blob-browser": "3.29.0",
-        "@aws-sdk/hash-node": "3.29.0",
-        "@aws-sdk/hash-stream-node": "3.29.0",
-        "@aws-sdk/invalid-dependency": "3.29.0",
-        "@aws-sdk/md5-js": "3.29.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.29.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.29.0",
-        "@aws-sdk/middleware-content-length": "3.29.0",
-        "@aws-sdk/middleware-expect-continue": "3.29.0",
-        "@aws-sdk/middleware-host-header": "3.29.0",
-        "@aws-sdk/middleware-location-constraint": "3.29.0",
-        "@aws-sdk/middleware-logger": "3.29.0",
-        "@aws-sdk/middleware-retry": "3.29.0",
-        "@aws-sdk/middleware-sdk-s3": "3.29.0",
-        "@aws-sdk/middleware-serde": "3.29.0",
-        "@aws-sdk/middleware-signing": "3.29.0",
-        "@aws-sdk/middleware-ssec": "3.29.0",
-        "@aws-sdk/middleware-stack": "3.29.0",
-        "@aws-sdk/middleware-user-agent": "3.29.0",
-        "@aws-sdk/node-config-provider": "3.29.0",
-        "@aws-sdk/node-http-handler": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/smithy-client": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/url-parser": "3.29.0",
-        "@aws-sdk/util-base64-browser": "3.29.0",
-        "@aws-sdk/util-base64-node": "3.29.0",
-        "@aws-sdk/util-body-length-browser": "3.29.0",
-        "@aws-sdk/util-body-length-node": "3.29.0",
-        "@aws-sdk/util-user-agent-browser": "3.29.0",
-        "@aws-sdk/util-user-agent-node": "3.29.0",
-        "@aws-sdk/util-utf8-browser": "3.29.0",
-        "@aws-sdk/util-utf8-node": "3.29.0",
-        "@aws-sdk/util-waiter": "3.29.0",
-        "@aws-sdk/xml-builder": "3.29.0",
+        "@aws-sdk/client-sts": "3.28.0",
+        "@aws-sdk/config-resolver": "3.28.0",
+        "@aws-sdk/credential-provider-node": "3.28.0",
+        "@aws-sdk/eventstream-serde-browser": "3.25.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.25.0",
+        "@aws-sdk/eventstream-serde-node": "3.25.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-blob-browser": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/hash-stream-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/md5-js": "3.25.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.25.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.28.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-expect-continue": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-location-constraint": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.28.0",
+        "@aws-sdk/middleware-sdk-s3": "3.25.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.28.0",
+        "@aws-sdk/middleware-ssec": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.28.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.28.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/util-waiter": "3.25.0",
+        "@aws-sdk/xml-builder": "3.23.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
@@ -161,37 +161,37 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.29.0.tgz",
-      "integrity": "sha512-hYWVn+yvYG0txIO0k9yh22FE+9ye5EBW3CbfS9IWLsziGyQPWOCBwdTKrHR/Fax9ypmAr1dh0ArM7oE/FTyQvQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.28.0.tgz",
+      "integrity": "sha512-tpbuA7L0iz+dEPp+xIdKkM81TjJNU18W94nI6l9AWzA+uueSztx72lVJ3MWT21mlNn7oLE+Uia4uO/K5Jb1PSA==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.29.0",
-        "@aws-sdk/fetch-http-handler": "3.29.0",
-        "@aws-sdk/hash-node": "3.29.0",
-        "@aws-sdk/invalid-dependency": "3.29.0",
-        "@aws-sdk/middleware-content-length": "3.29.0",
-        "@aws-sdk/middleware-host-header": "3.29.0",
-        "@aws-sdk/middleware-logger": "3.29.0",
-        "@aws-sdk/middleware-retry": "3.29.0",
-        "@aws-sdk/middleware-serde": "3.29.0",
-        "@aws-sdk/middleware-stack": "3.29.0",
-        "@aws-sdk/middleware-user-agent": "3.29.0",
-        "@aws-sdk/node-config-provider": "3.29.0",
-        "@aws-sdk/node-http-handler": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/smithy-client": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/url-parser": "3.29.0",
-        "@aws-sdk/util-base64-browser": "3.29.0",
-        "@aws-sdk/util-base64-node": "3.29.0",
-        "@aws-sdk/util-body-length-browser": "3.29.0",
-        "@aws-sdk/util-body-length-node": "3.29.0",
-        "@aws-sdk/util-user-agent-browser": "3.29.0",
-        "@aws-sdk/util-user-agent-node": "3.29.0",
-        "@aws-sdk/util-utf8-browser": "3.29.0",
-        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/config-resolver": "3.28.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.28.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.28.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.28.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -203,40 +203,40 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.29.0.tgz",
-      "integrity": "sha512-geiDdR47bDusfXjerX5qEX5b+1Ct3eVZZZAFckrCd7LdyCaH6dv87mSZ8+Vh9vM5HX/qVbhqRaJgQawg6EbcoA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.28.0.tgz",
+      "integrity": "sha512-lT6Qr1dt3TpSHfUKe0MjgUBJkUbjXYyMqn+vuoGNV3K5ImRi6FUbmlKwFWQwk0t3fSdpX9xBML98aZOc6/YEgA==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.29.0",
-        "@aws-sdk/credential-provider-node": "3.29.0",
-        "@aws-sdk/fetch-http-handler": "3.29.0",
-        "@aws-sdk/hash-node": "3.29.0",
-        "@aws-sdk/invalid-dependency": "3.29.0",
-        "@aws-sdk/middleware-content-length": "3.29.0",
-        "@aws-sdk/middleware-host-header": "3.29.0",
-        "@aws-sdk/middleware-logger": "3.29.0",
-        "@aws-sdk/middleware-retry": "3.29.0",
-        "@aws-sdk/middleware-sdk-sts": "3.29.0",
-        "@aws-sdk/middleware-serde": "3.29.0",
-        "@aws-sdk/middleware-signing": "3.29.0",
-        "@aws-sdk/middleware-stack": "3.29.0",
-        "@aws-sdk/middleware-user-agent": "3.29.0",
-        "@aws-sdk/node-config-provider": "3.29.0",
-        "@aws-sdk/node-http-handler": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/smithy-client": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/url-parser": "3.29.0",
-        "@aws-sdk/util-base64-browser": "3.29.0",
-        "@aws-sdk/util-base64-node": "3.29.0",
-        "@aws-sdk/util-body-length-browser": "3.29.0",
-        "@aws-sdk/util-body-length-node": "3.29.0",
-        "@aws-sdk/util-user-agent-browser": "3.29.0",
-        "@aws-sdk/util-user-agent-node": "3.29.0",
-        "@aws-sdk/util-utf8-browser": "3.29.0",
-        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/config-resolver": "3.28.0",
+        "@aws-sdk/credential-provider-node": "3.28.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.28.0",
+        "@aws-sdk/middleware-sdk-sts": "3.28.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.28.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.28.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.28.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
@@ -250,12 +250,12 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.29.0.tgz",
-      "integrity": "sha512-3OVWdftUrHTjVzXqlPSqJ7sHWOP5nww7DaYTJxWuMEROljLCRhyt1oTm3QJDbWH+jEpa/zxPe7M8IBxN+oYNRA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.28.0.tgz",
+      "integrity": "sha512-UrvuyZF4c1tuEbWrlmOallqLAD6ZHuhG4BHG54FkY42hzbqhmgvBkvehPxG2okSahRN8/A6ujlFX79D+tzJSCA==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -267,12 +267,12 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
-      "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.28.0.tgz",
+      "integrity": "sha512-bKM0yE9jeKFu4xYyi3hXUHB4MbjDf4mCjVxj/eZSwckn/HflvShAfLuMWPKjNC/8p2A7OyqztPRQW5OWGMsmcQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -284,14 +284,14 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
-      "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.28.0.tgz",
+      "integrity": "sha512-qZ0K/Og4B3jDovl5MeDILSwq4Yf1EFfYvLNCROJwrIhbYC5+sT8BxtxD3LVaw4O0no//XNuXYrFlWvXZi2j15Q==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.29.0",
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.28.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -303,18 +303,18 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.29.0.tgz",
-      "integrity": "sha512-dBnKOZcbHimQhr3gR0S3n75r4Tev9oiXQo1e+miq7a0Z1GCg/H9k2xorV1ECtLvT/zrTeTqUGNCMkxZ13VSiwg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.28.0.tgz",
+      "integrity": "sha512-j8Opxa57vFDE0JfCUkZSgA2KrN6sYyn8oysj/XWuUrPwdO+qa73U5icTdGx/4zYge3jDgsEGoVI9IPoRTFNUsA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.29.0",
-        "@aws-sdk/credential-provider-imds": "3.29.0",
-        "@aws-sdk/credential-provider-sso": "3.29.0",
-        "@aws-sdk/credential-provider-web-identity": "3.29.0",
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-credentials": "3.29.0",
+        "@aws-sdk/credential-provider-env": "3.28.0",
+        "@aws-sdk/credential-provider-imds": "3.28.0",
+        "@aws-sdk/credential-provider-sso": "3.28.0",
+        "@aws-sdk/credential-provider-web-identity": "3.28.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -326,20 +326,20 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.29.0.tgz",
-      "integrity": "sha512-1KZhsKqiQ1+FHzeBDoTZ9N0/Xi9s3SM2ugiSolw0XCC1+5F9BzkUA3KHoD5wSeNboR6+/1+xbqZ+nRtRMOtlqg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.28.0.tgz",
+      "integrity": "sha512-G29UpUXQ1SHtlUQCNJPRxBiCL7i+sVDwqaKGaReUiCznbCX3KSOkFsTrCIuVUu456821WmHB6QDspbOKn2U1QA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.29.0",
-        "@aws-sdk/credential-provider-imds": "3.29.0",
-        "@aws-sdk/credential-provider-ini": "3.29.0",
-        "@aws-sdk/credential-provider-process": "3.29.0",
-        "@aws-sdk/credential-provider-sso": "3.29.0",
-        "@aws-sdk/credential-provider-web-identity": "3.29.0",
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-credentials": "3.29.0",
+        "@aws-sdk/credential-provider-env": "3.28.0",
+        "@aws-sdk/credential-provider-imds": "3.28.0",
+        "@aws-sdk/credential-provider-ini": "3.28.0",
+        "@aws-sdk/credential-provider-process": "3.28.0",
+        "@aws-sdk/credential-provider-sso": "3.28.0",
+        "@aws-sdk/credential-provider-web-identity": "3.28.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -351,14 +351,14 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
-      "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.28.0.tgz",
+      "integrity": "sha512-/uTD11FvuU4owVxih+uORyXghnSBAwwMxq8EuNMLT/p68gD9pRPDdnqBiNuHY+VVBbGyJqAUy+bWZqPnkmmU5w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-credentials": "3.29.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -370,15 +370,15 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.29.0.tgz",
-      "integrity": "sha512-cye/blIzuT8XVHVu+fnEvkEEcfWt2KATIA/Qrvqg5q1bQHFp0w3waCwwE12mBrIx7Gfs7+zI9spfhJpR6oG1JQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.28.0.tgz",
+      "integrity": "sha512-T/+s9iUIygFYvJVgZdPWre92OL7iODYoZ7lP6TjdMPMRnCl6qPQ+Q7YAKxhdfQRex6xHxLa9ggemVDd4Pijr2w==",
       "requires": {
-        "@aws-sdk/client-sso": "3.29.0",
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-credentials": "3.29.0",
+        "@aws-sdk/client-sso": "3.28.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -390,12 +390,12 @@
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.29.0.tgz",
-      "integrity": "sha512-TwICG9y/iw08urlCymroQfRRJY++4JZwdhR0/2ycU+/Cgac6u4MfZsB1qD+u9+Q39/TqSz6QwtNhKLNdf0N23A==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.28.0.tgz",
+      "integrity": "sha512-8PQYOqAXTDUqAs6inNiu5opEpTLKdc1bjJaef1TgNfv5fJG8Ufl0nAsb+t26piMuBRwyh2ImKuW+qfyrFX2vtw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -407,13 +407,13 @@
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.29.0.tgz",
-      "integrity": "sha512-yRcWAVSPEcZ8l/iYTJHdo3/aAEsrbY1X3M7N0eQbF/awAXTtrbZ0Fg213xWWgdydP1+TdFv13GeluqhKq/oBBg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.25.0.tgz",
+      "integrity": "sha512-gUZIIxupgCIGyspiIV6bEplSRWnhAR9MkyrCJbHhbs4GjWIYlFqp7W0+Y7HY1tIeeXCUf0O8KE3paUMszKPXtg==",
       "requires": {
         "@aws-crypto/crc32": "^1.0.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -425,13 +425,13 @@
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.29.0.tgz",
-      "integrity": "sha512-rzy5caqRjuRXpcbWRC6fGNm4/wt53noYz2Y5Adko+x4X9fSmOBkS+6BCo2I1wQ/RlLyhh+9jrC/ySnD/6Gsd7g==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.25.0.tgz",
+      "integrity": "sha512-QJF08OIZiufoBPPoVcRwBPvZIpKMSZpISZfpCHcY1GaTpMIzz35N7Nkd10JGpfzpUO9oFcgcmm2q3XHo1XJyyw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.29.0",
-        "@aws-sdk/eventstream-serde-universal": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/eventstream-marshaller": "3.25.0",
+        "@aws-sdk/eventstream-serde-universal": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -443,11 +443,11 @@
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.29.0.tgz",
-      "integrity": "sha512-q286hf5EJXcJy6NKeAvPReajGsqELRlV48Wz2Q6hG3n2FTRYO6JQC4pi/YrabnK+oeLZ3UZFye4Ph8BTL5/xnw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.25.0.tgz",
+      "integrity": "sha512-Fb4VS3waKNzc6pK6tQBmWM+JmCNQJYNG/QBfb8y4AoJOZ+I7yX0Qgo90drh8IiUcIKDeprUFjSi/cGIa/KHIsg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -459,13 +459,13 @@
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.29.0.tgz",
-      "integrity": "sha512-859ZHD2FyBSEV4RpYl562i/ddcxNAHcrEsKJE430MNiNuiG324/RE/vIIOb5rleHZI+a62yfU1b/BjUrgVc6IQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.25.0.tgz",
+      "integrity": "sha512-gPs+6w0zXf+p0PuOxxmpAlCvP/7E7+8oAar8Ys27exnLXNgqJJK1k5hMBSrfR9GLVti3EhJ1M9x5Seg1SN0/SA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.29.0",
-        "@aws-sdk/eventstream-serde-universal": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/eventstream-marshaller": "3.25.0",
+        "@aws-sdk/eventstream-serde-universal": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -477,12 +477,12 @@
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.29.0.tgz",
-      "integrity": "sha512-GOXf5s1mKf0aCtl+Um4kDDPrwZa1A9jx7vZ/cHSCc3mb/W/Nqn/CP0mMw4r3YCOkHLdil4TqoQ70/1/kHsq9YQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.25.0.tgz",
+      "integrity": "sha512-NgsQk5dXg7NlRDEKGRUdiAx7WESQGD1jEhXitklL3/PHRZ7Y9BJugEFlBvKpU7tiHZBcomTbl/gE2o6i2op/jA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/eventstream-marshaller": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -494,14 +494,14 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.29.0.tgz",
-      "integrity": "sha512-rx+YlHFYzgGsCZMEvJBUdRsqfMGW4RY6J3USQvz63a32jVlMC3Kw9xINaXGhCEmOlUlzdeeIMQOZW5VxavLnjQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.25.0.tgz",
+      "integrity": "sha512-792kkbfSRBdiFb7Q2cDJts9MKxzAwuQSwUIwRKAOMazU8HkKbKnXXAFSsK3T7VasOFOh7O7YEGN0q9UgEw1q+g==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/querystring-builder": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -513,13 +513,13 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.29.0.tgz",
-      "integrity": "sha512-8nD1A0w7aPQ0Mzij7+X95GwapMm2MfrN6bLa1iCn5PNdQ5Zn+tK70NUL/s9X6KaEQi3Lh7S0xGN9paEZ5o4+sg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.25.0.tgz",
+      "integrity": "sha512-dsvV/nkW8v9wIotd3xJn3TQ8AxVLl56H82WkGkHcfw61csRxj3eSUNv0apUBopCcQPK8OK4l2nHAg08r0+LWXg==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.29.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/chunked-blob-reader": "3.23.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -531,12 +531,12 @@
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
-      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.25.0.tgz",
+      "integrity": "sha512-qRn6iqG9VLt8D29SBABcbauDLn92ssMjtpyVApiOhDYyFm2VA2avomOHD6y2PRBMwM5FMQAygZbpA2HIN2F96w==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-buffer-from": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -548,11 +548,11 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.29.0.tgz",
-      "integrity": "sha512-2ha+yzpJCoR23NoCfP/9OMBF5jgg76xAQo14/ItRWLnn0np7eRTGM+OFnNuAfvDRbzM4UcJoGDbUreAhaoSOBQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.25.0.tgz",
+      "integrity": "sha512-pzScUO9pPEEHQ5YQk1sl1bPlU2tt0OCblxUwboZJ9mRgNnWwkMWxe7Mec5IfyMWVUcbIznUHn7qRYEvJQ9JXmw==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -564,11 +564,11 @@
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.29.0.tgz",
-      "integrity": "sha512-0TyZZbPs5SWCF2tT1DXccK5SUx7/bDJCVojgBuW3QRJn9ta3US/u5l7w8k6jwWFU3CQhLAWuG0TD7FhATiM2HQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.25.0.tgz",
+      "integrity": "sha512-ZBXjBAF2JSiO/wGBa1oaXsd1q5YG3diS8TfIUMXeQoe9O66R5LGoGOQeAbB/JjlwFot6DZfAcfocvl6CtWwqkw==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -580,9 +580,9 @@
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
-      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
+      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -595,13 +595,13 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.29.0.tgz",
-      "integrity": "sha512-6wsT7zM9qEIbf+FI1QzKXG1o1z91u3zF6tPiXtdopVOs2m2I0emG2c1cEzqFwqB4HhiaR6PejBhn/tDxfc7oNw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.25.0.tgz",
+      "integrity": "sha512-97MtL1VF3JCkyJJnwi8LcXpqItnH1VtgoqtVqmaASYp5GXnlsnA1WDnB0754ufPHlssS1aBj/gkLzMZ0Htw/Rg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-utf8-browser": "3.29.0",
-        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -613,13 +613,13 @@
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.29.0.tgz",
-      "integrity": "sha512-csHiQKvxSJWxQx7lbla3Wgs+lWuNQ/DEFid5SxBZBhsqKz5FPBJr6kMPWIopmIL/vCxrYhMaS4ARloQBUkLoyQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.25.0.tgz",
+      "integrity": "sha512-162qFG7eap4vDKuKrpXWQYE4tbIETNrpTQX6jrPgqostOy1O0Nc5Bn1COIoOMgeMVnkOAZV7qV1J/XAYGz32Yw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -631,13 +631,13 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.29.0.tgz",
-      "integrity": "sha512-xQmucefIcntHicb4UvzdnmscRMsoB50NbOOSud8TSfalamzoRLkW8vUgfYVj+BxfAuQzKengFltiQlaho3maiA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.28.0.tgz",
+      "integrity": "sha512-YCL9SK+XiWG7/euKXGVDyHU43pVRut0AoF66+WoVLrl5UyuRwv3sqXT5AUh3JpHHw35oUCClTVpldm3iRDNhig==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-arn-parser": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-arn-parser": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -649,12 +649,12 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
-      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.25.0.tgz",
+      "integrity": "sha512-uOXus0MmZi/mucRIr5yfwM1vDhYG66CujNfnhyEaq5f4kcDA1Q5qPWSn9dkQPV9JWTZK3WTuYiOPSgtmlAYTAg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -666,13 +666,13 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.29.0.tgz",
-      "integrity": "sha512-5SzOhxF1rO2ajlMkLYklTD9XnAcsDxKfAyRZeHCH5pYVdskjWphpJ61IS+/rWv+1L0qDsxYum7Ig50R853c4Cw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.25.0.tgz",
+      "integrity": "sha512-o3euv8NIO0zlHML81krtfs4TrF5gZwoxBYtY+6tRHXlgutsHe1yfg1wrhWnJNbJg1QhPwXxbMNfYX7MM83D8Ng==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/middleware-header-default": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -684,12 +684,12 @@
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.29.0.tgz",
-      "integrity": "sha512-DoTQvcmqhgTcPdkJi1+To/esmURd0HGaP3oUoIYxnoWK+hC1zJmq9hb+0oi1wdXX79l5iz2DkjH3sm547rJIuQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.25.0.tgz",
+      "integrity": "sha512-xkFfZcctPL0VTxmEKITf6/MSDv/8rY+8uA9OMt/YZqfbg0RfeqR2+R1xlDNDxeHeK/v+g5gTNIYTQLM8L2unNA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -701,12 +701,12 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.29.0.tgz",
-      "integrity": "sha512-aBifr86Owrhvy29cvZD17JzdoTtKMxzdjCkMA7ckNP+9Lg7kLI/6ws1yZ6BJlmcOnKxtNSnkvunGmJy8BU8EWQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.25.0.tgz",
+      "integrity": "sha512-xKD/CfsUS3ul2VaQ3IgIUXgA7jU2/Guo/DUhYKrLZTOxm0nuvsIFw0RqSCtRBCLptE5Qi+unkc1LcFDbfqrRbg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -718,11 +718,11 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.29.0.tgz",
-      "integrity": "sha512-c7aOFU7AEzLXTIen5VIBm45KrRHLVuHewIpotwApFFSpLjxroPogsT0MSFyGDR9cHLl5QCiJ777Zu6L2x6819A==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.25.0.tgz",
+      "integrity": "sha512-diwmJ+MRQrq3H9VH+8CNAT4dImf2j3CLewlMrUEY+HsJN9xl2mtU6GQaluQg60iw6FjurLUKKGTTZCul4PGkIQ==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -734,11 +734,11 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.29.0.tgz",
-      "integrity": "sha512-0rLvuTvfaMWNb7+FApXAH0111FEp/AfG3fO7QkyVrXmHlTrNIJozilhkd0FwEMcQqqM9UK5lPLXwloH9Rkp9vw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.25.0.tgz",
+      "integrity": "sha512-M1F7BlAsDKoEM8hBaU2pHlLSM40rzzgtZ6jFNhfmTwGcjxe1N7JXCH5QPa7aI8wnJq2RoIRHVfVsUH4GwvOZnA==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -750,13 +750,13 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.29.0.tgz",
-      "integrity": "sha512-yRQ48UIGPmK3/jWMJ2LC4trltFevMDEXyvtT6knwDnwXxmuwv7K6udk6TnGaUU5TlLVI1XdRQHaZY7xZH1KbGw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.28.0.tgz",
+      "integrity": "sha512-8a59/JaKxCa/IJWQOnfuTPAeYdwIqeIkzJ974pZUjoQR9KFBlxROV9pYLjanN8B1be8oV6Xhhl2n3i3rN0CL1w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/service-error-classification": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/service-error-classification": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       },
@@ -769,15 +769,13 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.29.0.tgz",
-      "integrity": "sha512-/wOZv7ORvlOosS+XLRV34+3FStiPnFfLgPkYzm1QGKPtnQXr+3GQsqFQZAP12XqL7B0AyHLxCgBfCZCCvewd4g==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.25.0.tgz",
+      "integrity": "sha512-Y1P6JnpAdj7p5Q43aSLSuYBCc3hKpZ/mrqFSGN8VFXl7Tzo7tYfjpd9SVRxNGJK7O7tDAUsPNmuGqBrdA2tj8w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/signature-v4": "3.29.0",
-        "@aws-sdk/signature-v4-crt": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-arn-parser": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-arn-parser": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -789,15 +787,15 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.29.0.tgz",
-      "integrity": "sha512-U1gmzmnVvoIVjYgPXp1mSdKrmBVMKfJCodLEL4cKzn4ScfivNVX31qzrJkSezL/10QUNrcpkswt3VzD6jBweWw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.28.0.tgz",
+      "integrity": "sha512-uJO70AoU6Xzh4Br1aj6Dsqo8S/g1S1wkz9k6PWOclEGeGEL0XnCMyGqnlBW+Sk723DdQ0XzvWly1KURuuZ5FMA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.29.0",
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/signature-v4": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.28.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -809,11 +807,11 @@
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.29.0.tgz",
-      "integrity": "sha512-jN6zuaXg3k9HiWJZjBROiVJEdFaZrMikhyVdqYTT3hR+i08M/9UgVuX84HP/dALChZazOn9MPhvPWGvxrMOr9A==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.25.0.tgz",
+      "integrity": "sha512-065Kugo8yXzBkcVAxctxFCHKlHcINnaQRsJ8ifvgc+UOEgvTG9+LfGWDwfdgarW9CkF7RkCoZOyaqFsO+HJWsg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -825,14 +823,14 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.29.0.tgz",
-      "integrity": "sha512-Z5N2N8noUxzaUOliodq6vuf/77l30Gn7ukLw53k40tlILZ8+JGOa8pdZ3zAl+vlUwQtDtQtCRqoEb+znK6Rmvw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.28.0.tgz",
+      "integrity": "sha512-LFiQ2xTIvof44p1dbXEB7YJSOQ8Vd5NsseDXv70JMRm88PMH2iGwxcb4ZbAjhjfRmJ6uiCxLnDHpz49BCj9a/w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/signature-v4": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -844,11 +842,11 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.29.0.tgz",
-      "integrity": "sha512-XJC00iN3sqJ5ZH05VpP/bimRHfS1aWGs5/Vuz4swdyKGwez725ZBfof0lg6LSnP4G+me6ZqwsbUxHkdrupcWAA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.25.0.tgz",
+      "integrity": "sha512-bnrHb8oddW+vDexbNzZtpfshshKru+skcmq3dyXlL8LB/NlJsMiQJE8xoGbq5odTLiflIgaDBt527m5q58i+fg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -860,9 +858,9 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
-      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.25.0.tgz",
+      "integrity": "sha512-s2VgdsasOVKHY3/SIGsw9AeZMMsdcIbBGWim9n5IO3j8C8y54EdRLVCEja8ePvMDZKIzuummwatYPHaUrnqPtQ==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -875,12 +873,12 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.29.0.tgz",
-      "integrity": "sha512-AVbn9QEbqBgScaD3cxLv7/yi9Up10vYKy/AWIwgTrW0LxOuy9+Za2hdk5eZRP/QpqS/Ibz2/CqcmK1GQ/03kmg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.25.0.tgz",
+      "integrity": "sha512-HXd/Qknq8Cp7fzJYU7jDDpN7ReJ3arUrnt+dAPNaDDrhmrBbCZp+24UXN6X6DAj0JICRoRuF/l7KxjwdF5FShw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -892,13 +890,13 @@
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.29.0.tgz",
-      "integrity": "sha512-ANRnPz4IT4FiSAc+9p0HqGSjL+cdzB2E68BFmbbGin0fZwhflX1BksjuUEibw8Emf8jvhvbUxdtAIUWctTYxOA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.28.0.tgz",
+      "integrity": "sha512-FtK8c5wKYAHNMs8nnWCTjF/E4puII62g3Phov2LgVpvJbPWYvFL2J+n0fFaFr2+e7YTKhqhOyJYN/vne4XJ0kQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.29.0",
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/property-provider": "3.28.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -910,14 +908,14 @@
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
-      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.25.0.tgz",
+      "integrity": "sha512-zVeAM/bXewZiuMtcUZI/xGDID6knkzOv73ueVkzUbP0Ki8bfao7diR3hMbIt5Fy/r8cAVjJce9v6zFqo4sr1WA==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.29.0",
-        "@aws-sdk/protocol-http": "3.29.0",
-        "@aws-sdk/querystring-builder": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -929,11 +927,11 @@
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
-      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.28.0.tgz",
+      "integrity": "sha512-U+Y/y91ERFW6O4ghrIl6KvvNLW173V9hnAW9HQc+2Cf47aCoXR1PGOzqcqNWFmX1vBjI9WXUPop0JC9aAvgPGw==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -945,11 +943,11 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.29.0.tgz",
-      "integrity": "sha512-OIeJ7ukfgGkaIL0/NNM5sxIlfxtOqQN+KoaQ89YeLBlJPVoKnptAw+eWjjLwxLs+r/SbyZHXbBawP+sbzq0mSQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.25.0.tgz",
+      "integrity": "sha512-4Jebt5G8uIFa+HZO7KOgOtA66E/CXysQekiV5dfAsU8ca+rX5PB6qhpWZ2unX/l6He+oDQ0zMoW70JkNiP4/4w==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -961,12 +959,12 @@
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
-      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.25.0.tgz",
+      "integrity": "sha512-o/R3/viOxjWckI+kepkxJSL7fIdg1hHYOW/rOpo9HbXS0CJrHVnB8vlBb+Xwl1IFyY2gg+5YZTjiufcgpgRBkw==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-uri-escape": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -978,11 +976,11 @@
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.29.0.tgz",
-      "integrity": "sha512-v22PBXafAHw+wMaSGbq4B9wEsSYV2e0nZgGHZBNML3HPDiAYJqsQHiYEbiz8nzkmoayU0wrVFZ/XfKNXXcXGbw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.25.0.tgz",
+      "integrity": "sha512-FCNyaOLFLVS5j43MhVA7/VJUDX0t/9RyNTNulHgzFjj6ffsgqcY0uwUq1RO3QCL4asl56zOrLVJgK+Z7wMbvFg==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -994,14 +992,14 @@
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.29.0.tgz",
-      "integrity": "sha512-VqOjXXTLTGbifzg3Fg2g/Ac6W3uzC3llPZjm/b0goM17KLWMGU7JKiem2l+CFyN4sxkver7InNlIUJCJAPB6+Q=="
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.25.0.tgz",
+      "integrity": "sha512-66FfIab87LnnHtOLrGrVOht9Pw6lE8appyOpBdtoeoU5DP7ARSWuDdsYmKdGdRCWvn/RaVFbSYua9k0M1WsGqg=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
-      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
+      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1014,35 +1012,14 @@
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.29.0.tgz",
-      "integrity": "sha512-h39TC9FNi74wojvhVzkEkeqVzRvIiyQLSn6IFYwXaAE9X/wlkUt80fzvADjHAy9BNATu5GO54aKR3kLsG9/LLg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.25.0.tgz",
+      "integrity": "sha512-6KDRRz9XVrj9RxrBLC6dzfnb2TDl3CjIzcNpLdRuKFgzEEdwV+5D+EZuAQU3MuHG5pWTIwG72k/dmCbJ2MDPUQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
-        "@aws-sdk/util-hex-encoding": "3.29.0",
-        "@aws-sdk/util-uri-escape": "3.29.0",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
-    },
-    "@aws-sdk/signature-v4-crt": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.29.0.tgz",
-      "integrity": "sha512-0suw2CXfsxN7Oqh98WvfVPjUMZ5ZUb0JNkMBIV380DnWBPs5CfK1JVwCmBxnJfWO+J16v5bfGG8sEbIfq1exrQ==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.29.0",
-        "@aws-sdk/querystring-parser": "3.29.0",
-        "@aws-sdk/signature-v4": "3.29.0",
-        "@aws-sdk/util-hex-encoding": "3.29.0",
-        "@aws-sdk/util-uri-escape": "3.29.0",
-        "aws-crt": "^1.9.0",
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1054,12 +1031,12 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.29.0.tgz",
-      "integrity": "sha512-QRTYdFcORkJMgDk5DJ661cttnrukoDS/FKXhsCX0tkrgCQsgG6SUOdfWBmyPFC3cXts1GKlwanTqAIiWp/yJ0w==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.28.0.tgz",
+      "integrity": "sha512-ChlO4jPvfw05mNsJgfVqvMNH6jtRKi6ySj5HuZ0LcX644hUcEljPhN0hdFr8XtaGKsxbfkBHILhKFs/W42J+2A==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1071,17 +1048,17 @@
       }
     },
     "@aws-sdk/types": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.29.0.tgz",
-      "integrity": "sha512-8ilWQU5ZTdiRfblmmjl38+6JZKKM8EqA5Sbn8djgDLShCLeVJ2TsL2guzNi+WHcL7BHdv1pI/NNmTcgRUo6yOw=="
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.25.0.tgz",
+      "integrity": "sha512-vS0+cTKwj6CujlR07HmeEBxzWPWSrdmZMYnxn/QC9KW9dFu0lsyCGSCqWsFluI6GI0flsnYYWNkP5y4bfD9tqg=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.29.0.tgz",
-      "integrity": "sha512-385f+g4xeRym2S4bzF+Nc0MB8addAlCSb5hIUJu1JKH6FwFLrNRuixeaelGLyWr77xv25P0ruyXQAFf2ISxzKw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.25.0.tgz",
+      "integrity": "sha512-qZ3Vq0NjHsE7Qq6R5NVRswIAsiyYjCDnAV+/Vt4jU/K0V3mGumiasiJyRyblW4Da8R6kfcJk0mHSMFRJfoHh8Q==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/querystring-parser": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1093,9 +1070,9 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.29.0.tgz",
-      "integrity": "sha512-NK4xAU7EGp0H4oYIICAJL49BzGvezkWD6rQdfJpXrPoqXviXXDq0nmFEoP9k4PsT+mDBEFiuvXhQlrHhBPVx5g==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.23.0.tgz",
+      "integrity": "sha512-J3+/wnC21kbb3UAHo7x31aCZxzIa7GBijt6Q7nad/j2aF38EZtE3SI0aZpD8250Vi+9zsZ4672QDUeSZ5BR5kg==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1108,9 +1085,9 @@
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.29.0.tgz",
-      "integrity": "sha512-yMgn5vZ7laVO/497iPDjTdmia3sDdFBDq6k42EZxVTpkUcd8JS2nWJ+9ePuIMwqOgPjhhkOOXiidrbZaUQ+L6Q==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
+      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1123,11 +1100,11 @@
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
-      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
+      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1139,9 +1116,9 @@
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.29.0.tgz",
-      "integrity": "sha512-cKSwlDlZkcxuhSdoiq1TxleaBvveEgKA2Yo4TYP4DKVPHZuYZtbFv8r1driml1SaIKXg4GQpe+pJit3mxDRxAg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
+      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1154,9 +1131,9 @@
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
-      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
+      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1169,11 +1146,11 @@
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
-      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
+      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/is-array-buffer": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1185,11 +1162,11 @@
       }
     },
     "@aws-sdk/util-credentials": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.29.0.tgz",
-      "integrity": "sha512-xCWQizP5d6SwbwB2HmxpDqu0WYY7/E7pNrZ+7tSMrJxZlT8Zsd+lFaO23JVFMEBqjjBnpLBr+XkNZgOpD1BYwA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
+      "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
       "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1201,9 +1178,9 @@
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
-      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
+      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1216,9 +1193,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
-      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.23.0.tgz",
+      "integrity": "sha512-mM8kWW7SWIxCshkNllpYqCQi5SzwJ+sv5nURhtquOB5/H3qGqZm0V5lUE3qpE1AYmqKwk6qbGUy1woFn1T5nrw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1231,9 +1208,9 @@
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
-      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
+      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1246,11 +1223,11 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.29.0.tgz",
-      "integrity": "sha512-se9WLQS3H36u8FUA3/DfnzH3LU77QBRpJN4FmQtcQHR3A5mR2tRty+eOrvIf2R4QtveMWXrQbvScTrca7ZFZug==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.25.0.tgz",
+      "integrity": "sha512-qGqiWfs49NRmQVXPsBXgMRVkjDZocicU0V2wak98e0t7TOI+KmP8hnwsTkE6c4KwhsFOOUhAzjn5zk3kOwi6tQ==",
       "requires": {
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/types": "3.25.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       },
@@ -1263,12 +1240,12 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
-      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.28.0.tgz",
+      "integrity": "sha512-i2wjRrNKIi1s4Tu0LaZUFxoVaYbJFqkabE6FEjfGlLr5cgHG6Pn+3mAA2QFifIeG0CbM8vnhMB6U06R0eSmZVw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.28.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1280,9 +1257,9 @@
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.29.0.tgz",
-      "integrity": "sha512-ZIHbBYByMq5vadQ1SZOQTHVtrkGAFiuypATYF5ST8YB3j7XKvflv+fiBX2xQ8xpqb28noEg6dNPnvqkQQ1n/aw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
+      "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1295,11 +1272,11 @@
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
-      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
+      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1311,12 +1288,12 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.29.0.tgz",
-      "integrity": "sha512-9qNsX+yRpX8xE0eW9qHZCy7W6+MFkYFR10umSPVl9gc5p+RViQwS0D2wVYmQblrqGK6VpK+wAb3faFf6KaDesg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.25.0.tgz",
+      "integrity": "sha512-rhJ7Q2fcPD8y4H0qNEpaspkSUya0OaNcVrca9wCZKs7jWnropPzrQ+e2MH7fWJ/8jgcBV890+Txr4fWkD4J01g==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.29.0",
-        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1328,9 +1305,9 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.29.0.tgz",
-      "integrity": "sha512-lixmZNupjRsfAxCZh3CshqWSxKJEAPcuPiKhUlW9DhfoIc+YTD9U5G2fzY9LBd7ugDo4N7H5sU3Oa1iYLp2ZDg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.23.0.tgz",
+      "integrity": "sha512-5LEGdhQIJtGTwg4dIYyNtpz5QvPcQoxsqJygmj+VB8KLd+mWorH1IOpiL74z0infeK9N+ZFUUPKIzPJa9xLPqw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -3744,17 +3721,13 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -3845,6 +3818,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -3854,6 +3828,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
       "optional": true
     },
     "astral-regex": {
@@ -3867,39 +3842,24 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-crt": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.9.1.tgz",
-      "integrity": "sha512-nsWTwK1W2ZlJqrPQbfdqvewrt8J4WNO5/FVc2jMArib7viLNdEywBtf3qfbRjhO4GRKimHKggDmOv7Qa6PAWrw==",
-      "requires": {
-        "axios": "^0.21.1",
-        "cmake-js": "6.1.0",
-        "crypto-js": "^4.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.2.8",
-        "websocket-stream": "^5.5.2"
-      }
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
       "optional": true
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true,
       "optional": true
     },
     "axios": {
@@ -4072,11 +4032,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -4098,6 +4053,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -4108,52 +4064,16 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
-    "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
-    },
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
       "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
-    "binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -4271,15 +4191,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -4289,21 +4200,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
-    "buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "busboy": {
       "version": "0.2.14",
@@ -4379,15 +4275,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
       "optional": true
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": ">=0.3.0 <0.4"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4609,181 +4498,6 @@
         }
       }
     },
-    "cmake-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.1.0.tgz",
-      "integrity": "sha512-utmukLQftpgrCpGRCaHnkv4K27HZNNFqmBl4vnvccy0xp4c1erxjFU/Lq4wn5ngAhFZmpwBPQfoKWKThjSBiwg==",
-      "requires": {
-        "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
-        "rc": "^1.2.7",
-        "request": "^2.54.0",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
-      },
-      "dependencies": {
-        "are-we-there-yet": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.0 || ^1.1.13"
-          }
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "requires": {
-            "ansi": "^0.3.0",
-            "has-unicode": "^2.0.0",
-            "lodash.pad": "^4.1.0",
-            "lodash.padend": "^4.1.0",
-            "lodash.padstart": "^4.1.0"
-          }
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-          "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-          "requires": {
-            "ansi": "~0.3.0",
-            "are-we-there-yet": "~1.0.0",
-            "gauge": "~1.2.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "tar": {
-          "version": "4.4.19",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-          "requires": {
-            "chownr": "^1.1.4",
-            "fs-minipass": "^1.2.7",
-            "minipass": "^2.9.0",
-            "minizlib": "^1.3.3",
-            "mkdirp": "^0.5.5",
-            "safe-buffer": "^5.2.1",
-            "yallist": "^3.1.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
-          }
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4856,6 +4570,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4865,22 +4580,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
-    },
-    "commist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
-      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
-      "requires": {
-        "leven": "^2.1.0",
-        "minimist": "^1.1.0"
-      },
-      "dependencies": {
-        "leven": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
-        }
-      }
     },
     "commitizen": {
       "version": "4.2.4",
@@ -5254,11 +4953,6 @@
         }
       }
     },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -5320,6 +5014,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -5370,7 +5065,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5387,7 +5083,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5516,37 +5213,6 @@
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
     },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "requires": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -5560,6 +5226,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -5648,14 +5315,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -6371,6 +6030,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "optional": true
     },
     "external-editor": {
@@ -6388,12 +6048,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
       "optional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -6417,7 +6079,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6434,11 +6097,6 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
-    },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "fastq": {
       "version": "1.11.1",
@@ -6586,6 +6244,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
       "optional": true
     },
     "form-data": {
@@ -6650,6 +6309,8 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -6661,6 +6322,7 @@
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -6670,6 +6332,7 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
@@ -6757,6 +6420,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -6841,18 +6505,21 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
       "optional": true
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
       "optional": true,
       "requires": {
         "ajv": "^6.12.3",
@@ -6888,27 +6555,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
       "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
-    },
-    "help-me": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
-      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
-      "requires": {
-        "glob": "^7.1.6",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -6974,6 +6620,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -7008,11 +6655,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -7091,7 +6733,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "inquirer": {
       "version": "6.5.2",
@@ -7166,11 +6809,6 @@
         }
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7238,11 +6876,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-iojs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE="
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7286,7 +6919,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -7314,12 +6948,14 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
       "optional": true
     },
     "istanbul-lib-coverage": {
@@ -9762,6 +9398,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -9823,12 +9460,14 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
       "optional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9840,6 +9479,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true,
       "optional": true
     },
     "json5": {
@@ -9854,6 +9494,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -9886,6 +9527,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
@@ -9923,14 +9565,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
     },
     "leven": {
       "version": "3.1.0",
@@ -10026,11 +9660,6 @@
           }
         }
       }
-    },
-    "listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
     },
     "listr2": {
       "version": "3.11.0",
@@ -10188,21 +9817,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -10506,37 +10120,6 @@
         }
       }
     },
-    "memory-stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
-      "requires": {
-        "readable-stream": "~1.0.26-2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "merge": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
@@ -10677,60 +10260,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "mqtt": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.8.tgz",
-      "integrity": "sha512-DJYjlXODVXtSDecN8jnNzi6ItX3+ufGsEs9OB3YV24HtkRrh7kpx8L5M1LuyF0KzaiGtWr2PzDcMGAY60KGOSA==",
-      "requires": {
-        "commist": "^1.0.0",
-        "concat-stream": "^2.0.0",
-        "debug": "^4.1.1",
-        "duplexify": "^4.1.1",
-        "help-me": "^3.0.0",
-        "inherits": "^2.0.3",
-        "minimist": "^1.2.5",
-        "mqtt-packet": "^6.8.0",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
-        "reinterval": "^1.1.0",
-        "split2": "^3.1.0",
-        "ws": "^7.5.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "mqtt-packet": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
-      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
-      "requires": {
-        "bl": "^4.0.2",
-        "debug": "^4.1.1",
-        "process-nextick-args": "^2.0.1"
       }
     },
     "ms": {
@@ -11094,6 +10623,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
       "optional": true
     },
     "object-assign": {
@@ -11164,14 +10694,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -11304,6 +10826,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
       "optional": true
     },
     "picomatch": {
@@ -11466,21 +10989,14 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -11518,6 +11034,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11528,7 +11045,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -11587,15 +11105,12 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
-    "reinterval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
-      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc="
-    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -11623,6 +11138,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -11634,12 +11150,14 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true,
           "optional": true
         },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
           "optional": true,
           "requires": {
             "psl": "^1.1.28",
@@ -11650,6 +11168,7 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true,
           "optional": true
         }
       }
@@ -12012,11 +11531,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -12191,31 +11705,6 @@
       "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
       "dev": true
     },
-    "split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "requires": {
-        "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "splitargs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -12357,6 +11846,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -12396,11 +11886,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -12815,11 +12300,6 @@
         "punycode": "^2.1.1"
       }
     },
-    "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
-    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -12942,6 +12422,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -12951,6 +12432,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type": {
@@ -13017,11 +12499,6 @@
         "random-bytes": "~1.0.0"
       }
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
     "umzug": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.3.0.tgz",
@@ -13034,72 +12511,22 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-      "requires": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -13165,6 +12592,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -13205,42 +12633,6 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "dev": true
     },
-    "websocket-stream": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.2.tgz",
-      "integrity": "sha512-8z49MKIHbGk3C4HtuHWDtYX8mYej1wWabjthC/RupM9ngeukU4IWoM46dgth1UOS/T4/IqgEdCDJuMe2039OQQ==",
-      "requires": {
-        "duplexify": "^3.5.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "safe-buffer": "^5.1.2",
-        "ws": "^3.2.0",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "duplexify": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
-      }
-    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -13271,6 +12663,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -13288,11 +12681,6 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
-    },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
       "version": "3.3.3",
@@ -13441,7 +12829,8 @@
     "ws": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg=="
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.29.0",
+    "@aws-sdk/client-s3": "^3.28.0",
     "axios": "^0.21.3",
     "bcrypt": "^5.0.0",
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
## Problem
3.29.0 of @aws-sdk/client-s3 introduces libraries that are not supported in alpine linux, per aws/aws-sdk-js-v3#2750.

## Solution
Revert opengovsg/askgovsg#210