### PR TITLE
feat: show related posts

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -1,7 +1,7 @@
-import { Flex, Spacer, Text } from '@chakra-ui/layout'
+import { Center, Flex, Stack, Spacer, Text, VStack } from '@chakra-ui/layout'
 import { BiArrowBack, BiXCircle } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { useParams, useHistory } from 'react-router-dom'
+import { Link, useParams, useHistory } from 'react-router-dom'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import Spinner from '../../components/Spinner/Spinner.component'
@@ -27,7 +27,7 @@ const Post = () => {
   const { id: postId } = useParams()
   const { data: post, isLoading } = useQuery(
     [GET_POST_BY_ID_QUERY_KEY, postId],
-    () => getPostById(postId),
+    () => getPostById(postId, 3),
   )
   // Similar logic to find agency as login component
   // if post is linked to multiple agencies via agencyTag
@@ -68,62 +68,88 @@ const Post = () => {
   ) : (
     <Flex direction="column" height="100%">
       <PageTitle title={`${post.title} - AskGov`} />
-      <div className="post-page">
-        <Flex pb="14px" align="center">
-          <BackButtonForPostDetail agencyShortName={agencyShortName} />
-          <Spacer />
-          {isAgencyMember && (
-            <div className="post-side-with-edit">
-              <EditButton
-                postId={postId}
-                onDeleteLink={`/agency/${agencyShortName}`}
-              />
-            </div>
-          )}
-        </Flex>
-        <Text textStyle="h1" color="primary.500" pb="14px">
-          {post.title}
-        </Text>
-        <div className="subtitle-bar">
-          <div className="tags-name-time">
-            <div className="post-tags">
-              {post.tags.map((tag, i) => {
-                return (
-                  <TagBadge
-                    key={i}
-                    tagName={tag.tagname}
-                    tagType={tag.tagType}
-                    size={'s-tag'}
-                    float={'left'}
+      <Center>
+        <Stack
+          maxW="1188px"
+          px="48px"
+          direction={{ base: 'column', lg: 'row' }}
+          spacing={{ base: '20px', lg: '88px' }}
+        >
+          <div className="post-page">
+            <Flex pb="14px" align="center">
+              <BackButtonForPostDetail agencyShortName={agencyShortName} />
+              <Spacer />
+              {isAgencyMember && (
+                <div className="post-side-with-edit">
+                  <EditButton
+                    postId={postId}
+                    onDeleteLink={`/agency/${agencyShortName}`}
                   />
-                )
-              })}
-            </div>
-            {/* <div className="post-time">
+                </div>
+              )}
+            </Flex>
+            <Text textStyle="h1" color="primary.500" pb="14px">
+              {post.title}
+            </Text>
+            <div className="subtitle-bar">
+              <div className="tags-name-time">
+                <div className="post-tags">
+                  {post.tags.map((tag, i) => {
+                    return (
+                      <TagBadge
+                        key={i}
+                        tagName={tag.tagname}
+                        tagType={tag.tagType}
+                        size={'s-tag'}
+                        float={'left'}
+                      />
+                    )
+                  })}
+                </div>
+                {/* <div className="post-time">
               <time dateTime={moment(post.createdAt).fromNow(true)}>
                 {moment(post.createdAt).fromNow(true)} ago
               </time>
             </div> */}
-            <ViewCount views={post.views} className="views-info center" />
-          </div>
-          {post.status === PostStatus.Private ? (
-            <div className="private-subtitle">
-              <BiXCircle
-                style={{ marginRight: '4px' }}
-                color="neutral.500"
-                size="24"
-              />
-              <span>
-                This question remains private until an answer is posted.
-              </span>
+                <ViewCount views={post.views} className="views-info center" />
+              </div>
+              {post.status === PostStatus.Private ? (
+                <div className="private-subtitle">
+                  <BiXCircle
+                    style={{ marginRight: '4px' }}
+                    color="neutral.500"
+                    size="24"
+                  />
+                  <span>
+                    This question remains private until an answer is posted.
+                  </span>
+                </div>
+              ) : null}
             </div>
-          ) : null}
-        </div>
-        <div className="question-main">
-          <QuestionSection post={post} />
-          <AnswerSection post={post} />
-        </div>
-      </div>
+            <div className="question-main">
+              <QuestionSection post={post} />
+              <AnswerSection post={post} />
+            </div>
+          </div>
+          <VStack
+            maxW={{ base: 'auto', lg: '240px' }}
+            pt={{ base: '0px', lg: '152px' }}
+            px={{ base: '20px', lg: '0px' }}
+            pb="40px"
+            align="left"
+            color="secondary.400"
+          >
+            <Text textStyle="subhead-3">Related</Text>
+            {post.relatedPosts.map((relatedPost) => (
+              <Link to={`/questions/${relatedPost.id}`}>
+                <Text textStyle="subhead-2" fontWeight="normal">
+                  {relatedPost.title}
+                </Text>
+              </Link>
+            ))}
+          </VStack>
+        </Stack>
+      </Center>
       <Spacer />
       <CitizenRequest
         agency={

--- a/client/src/pages/Post/Post.styles.scss
+++ b/client/src/pages/Post/Post.styles.scss
@@ -7,18 +7,6 @@
 }
 
 .post-page {
-  padding-left: 48px;
-  padding-right: 48px;
-  
-  @media not all and (min-width: $tablet) {
-    padding: 0 32px;
-  }
-
-  @media not all and (max-width: $laptop) {
-    max-width: calc(796px + 48px * 2);
-    margin-left: auto;
-    margin-right: auto;
-  }
 
   .btn-bar {
     @media (min-width: $tablet) {

--- a/client/src/services/PostService.ts
+++ b/client/src/services/PostService.ts
@@ -9,10 +9,13 @@ import {
 
 const POST_API_BASE = '/posts'
 
-export const getPostById = async (id: number): Promise<GetSinglePostDto> => {
-  return ApiClient.get<GetSinglePostDto>(`${POST_API_BASE}/${id}`).then(
-    ({ data }) => data,
-  )
+export const getPostById = async (
+  id: number,
+  noOfRelatedPosts?: number,
+): Promise<GetSinglePostDto> => {
+  return ApiClient.get<GetSinglePostDto>(`${POST_API_BASE}/${id}`, {
+    params: { noOfRelatedPosts },
+  }).then(({ data }) => data)
 }
 export const GET_POST_BY_ID_QUERY_KEY = 'getPostById'
 

--- a/client/src/services/PostService.ts
+++ b/client/src/services/PostService.ts
@@ -11,10 +11,10 @@ const POST_API_BASE = '/posts'
 
 export const getPostById = async (
   id: number,
-  noOfRelatedPosts?: number,
+  relatedPosts?: number,
 ): Promise<GetSinglePostDto> => {
   return ApiClient.get<GetSinglePostDto>(`${POST_API_BASE}/${id}`, {
-    params: { noOfRelatedPosts },
+    params: { relatedPosts },
   }).then(({ data }) => data)
 }
 export const GET_POST_BY_ID_QUERY_KEY = 'getPostById'

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -169,11 +169,15 @@ export class PostController {
    * @return 500 for database error
    */
   getSinglePost: ControllerHandler<
-    { id: string },
+    { id: number },
     PostWithUserTagRelations | PostWithUserTagRelatedPostRelations | Message,
     undefined,
-    { relatedPosts?: string }
+    { relatedPosts?: number }
   > = async (req, res) => {
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      return res.status(StatusCodes.BAD_REQUEST).json(errors.array()[0].msg)
+    }
     let post
     try {
       post = await this.postService.getSinglePost(

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -172,13 +172,13 @@ export class PostController {
     { id: string },
     PostWithUserTagRelations | PostWithUserTagRelatedPostRelations | Message,
     undefined,
-    { noOfRelatedPosts?: string }
+    { relatedPosts?: string }
   > = async (req, res) => {
     let post
     try {
       post = await this.postService.getSinglePost(
         req.params.id,
-        req.query.noOfRelatedPosts,
+        req.query.relatedPosts,
       )
     } catch (error) {
       logger.error({

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -2,7 +2,11 @@ import { validationResult } from 'express-validator'
 import { SortType } from '../../types/sort-type'
 import { createValidationErrMessage } from '../../util/validation-error'
 import { AuthService } from '../auth/auth.service'
-import { PostService } from './post.service'
+import {
+  PostService,
+  PostWithUserTagRelatedPostRelations,
+  PostWithUserTagRelations,
+} from './post.service'
 
 import { Message } from '../../types/message-type'
 import { UpdatePostRequestDto } from '../../types/post-type'
@@ -159,17 +163,23 @@ export class PostController {
   /**
    * Get a single post and all the tags and users associated with it
    * @param postId Id of the post
+   * @query relatedPosts if true, return related posts
    * @return 200 with post
    * @return 403 if user does not have permission to access post
    * @return 500 for database error
    */
-  getSinglePost: ControllerHandler<{ id: string }, Post | Message> = async (
-    req,
-    res,
-  ) => {
+  getSinglePost: ControllerHandler<
+    { id: string },
+    PostWithUserTagRelations | PostWithUserTagRelatedPostRelations | Message,
+    undefined,
+    { noOfRelatedPosts?: string }
+  > = async (req, res) => {
     let post
     try {
-      post = await this.postService.getSinglePost(req.params.id)
+      post = await this.postService.getSinglePost(
+        req.params.id,
+        req.query.noOfRelatedPosts,
+      )
     } catch (error) {
       logger.error({
         message: 'Error while retrieving single post',

--- a/server/src/modules/post/post.routes.ts
+++ b/server/src/modules/post/post.routes.ts
@@ -1,6 +1,6 @@
 import { AuthMiddleware } from '../auth/auth.middleware'
 import express from 'express'
-import { check, query } from 'express-validator'
+import { check, param, query } from 'express-validator'
 import { PostController } from './post.controller'
 import { SortType } from '../../types/sort-type'
 
@@ -67,7 +67,14 @@ export const routePosts = ({
    * @return 500 for database error
    * @access Public
    */
-  router.get('/:id', controller.getSinglePost)
+  router.get(
+    '/:id',
+    [
+      param('id').isInt().toInt(),
+      query('relatedPosts').isInt().toInt().optional({ nullable: true }),
+    ],
+    controller.getSinglePost,
+  )
 
   /**
    * Create a new post

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -388,8 +388,8 @@ export class PostService {
    * @param noOfRelatedPosts number of related posts to show
    */
   getSinglePost = async (
-    postId: string,
-    noOfRelatedPosts = '0',
+    postId: number,
+    noOfRelatedPosts = 0,
   ): Promise<
     PostWithUserTagRelations | PostWithUserTagRelatedPostRelations
   > => {
@@ -427,11 +427,8 @@ export class PostService {
         ],
       ],
     })) as PostWithUserTagRelatedPostRelations
-    if (parseInt(noOfRelatedPosts) > 0) {
-      const relatedPosts = await this.getRelatedPosts(
-        post,
-        parseInt(noOfRelatedPosts),
-      )
+    if (noOfRelatedPosts > 0) {
+      const relatedPosts = await this.getRelatedPosts(post, noOfRelatedPosts)
       post.setDataValue('relatedPosts', relatedPosts)
     }
     if (!post) {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -105,7 +105,6 @@ export class PostService {
           [Op.ne]: post.id,
         },
       },
-      raw: true,
       include: [
         {
           model: this.Tag,

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -386,7 +386,7 @@ export class PostService {
   /**
    * Get a single post and all the tags and users associated with it
    * @param postId Id of the post
-   * @param noOfRelatedPosts
+   * @param noOfRelatedPosts number of related posts to show
    */
   getSinglePost = async (
     postId: string,

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -1,19 +1,23 @@
-import { SortType } from '../../types/sort-type'
-
-import Sequelize, { OrderItem, Op, ProjectionAlias, ModelCtor } from 'sequelize'
+import Sequelize, { ModelCtor, Op, OrderItem, ProjectionAlias } from 'sequelize'
 import { Answer, Post, PostTag, Tag, User } from '../../models'
 import { PostStatus } from '../../types/post-status'
 import { PostEditType } from '../../types/post-type'
-import { PostWithRelations as PostWithUserRelations } from '../auth/auth.service'
+import { SortType } from '../../types/sort-type'
+import { PostWithRelations } from '../auth/auth.service'
 
-export type UserWithRelations = {
+export type UserWithTagRelations = {
   getTags: () => Tag[]
 }
 
-export type PostWithRelations = Post & {
+export type PostWithUserTagRelations = PostWithRelations & {
   countAnswers: () => number
   tags: Tag[]
 }
+
+export type PostWithUserTagRelatedPostRelations = PostWithRelations &
+  PostWithUserTagRelations & {
+    getRelatedPosts: Post[]
+  }
 
 export class PostService {
   private Answer: ModelCtor<Answer>
@@ -59,7 +63,7 @@ export class PostService {
   }
 
   private filterPostsWithoutAnswers = async (
-    data?: PostWithRelations[],
+    data?: PostWithUserTagRelations[],
   ): Promise<Post[]> => {
     if (!data) {
       return []
@@ -74,13 +78,55 @@ export class PostService {
     return arr.some((e) => e.tagType === 'AGENCY')
   }
 
-  getExistingTagsFromRequestTags = async (
-    tagNames: string[],
-  ): Promise<Tag[]> => {
-    const existingTags = await this.Tag.findAll({
-      where: { tagname: tagNames },
+  /**
+   * Get posts related to the one provided
+   * There is room to improve on finding related posts, using a better algorithm
+   * as discussed https://meta.stackexchange.com/questions/20473/how-are-related-questions-selected or
+   * https://medium.com/analytics-vidhya/building-a-simple-stack-overflow-search-engine-to-predict-posts-related-to-given-query-post-56b3e508520c.
+   * As a preliminary step, it finds the posts with the
+   * most number of same tag, followed by number of views.
+   * @param post post to find related posts to
+   * @param numberOfRelatedPosts number of posts to find
+   * @returns posts that are related to the one provided
+   */
+  private getRelatedPosts = async (
+    post: PostWithUserTagRelations,
+    numberOfRelatedPosts: number,
+  ): Promise<Post[]> => {
+    const tags = post.tags.map((tag) => tag.id)
+    const relatedPosts = await this.Post.findAll({
+      attributes: {
+        include: [
+          [Sequelize.fn('COUNT', Sequelize.col('tags.id')), 'relatedTags'],
+        ],
+      },
+      where: {
+        id: {
+          [Op.ne]: post.id,
+        },
+      },
+      raw: true,
+      include: [
+        {
+          model: this.Tag,
+          attributes: [],
+          required: false,
+          through: {
+            attributes: [],
+          },
+          where: {
+            id: tags,
+          },
+        },
+      ],
+      group: 'id',
+      order: [
+        [Sequelize.col('relatedTags'), 'DESC'],
+        ['views', 'DESC'],
+      ],
     })
-    return existingTags
+
+    return relatedPosts.slice(0, numberOfRelatedPosts)
   }
 
   /**
@@ -108,6 +154,15 @@ export class PostService {
       posts: returnPosts,
       totalItems: totalItems,
     }
+  }
+
+  getExistingTagsFromRequestTags = async (
+    tagNames: string[],
+  ): Promise<Tag[]> => {
+    const existingTags = await this.Tag.findAll({
+      where: { tagname: tagNames },
+    })
+    return existingTags
   }
 
   /**
@@ -169,7 +224,7 @@ export class PostService {
         this.Answer,
       ],
       attributes: ['id'],
-    })) as PostWithRelations[]
+    })) as PostWithUserTagRelations[]
 
     if (!posts) {
       return { posts: [], totalItems: 0 }
@@ -253,7 +308,7 @@ export class PostService {
   }> => {
     const user = (await this.User.findOne({
       where: { id: userId },
-    })) as UserWithRelations | null
+    })) as UserWithTagRelations | null
     if (!user) {
       throw new Error('Unable to find user with given ID')
     }
@@ -274,7 +329,7 @@ export class PostService {
       },
       order: [this.sortFunction(sort)],
       include: [this.Tag, { model: this.Answer, required: withAnswers }],
-    })) as PostWithRelations[]
+    })) as PostWithUserTagRelations[]
 
     // Duplicate of logic from retrieveAll
     // TODO: Optimize to merge the 2 requests into one
@@ -329,8 +384,14 @@ export class PostService {
   /**
    * Get a single post and all the tags and users associated with it
    * @param postId Id of the post
+   * @param noOfRelatedPosts
    */
-  getSinglePost = async (postId: string): Promise<PostWithUserRelations> => {
+  getSinglePost = async (
+    postId: string,
+    noOfRelatedPosts = '0',
+  ): Promise<
+    PostWithUserTagRelations | PostWithUserTagRelatedPostRelations
+  > => {
     await this.Post.increment(
       {
         views: +1,
@@ -364,8 +425,14 @@ export class PostService {
           'answerCount',
         ],
       ],
-    })) as PostWithUserRelations
-
+    })) as PostWithUserTagRelatedPostRelations
+    if (parseInt(noOfRelatedPosts) > 0) {
+      const relatedPosts = await this.getRelatedPosts(
+        post,
+        parseInt(noOfRelatedPosts),
+      )
+      post.setDataValue('relatedPosts', relatedPosts)
+    }
     if (!post) {
       throw new Error('No post with this id')
     } else {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -124,9 +124,11 @@ export class PostService {
         [Sequelize.col('relatedTags'), 'DESC'],
         ['views', 'DESC'],
       ],
+      subQuery: false,
+      limit: numberOfRelatedPosts,
     })
 
-    return relatedPosts.slice(0, numberOfRelatedPosts)
+    return relatedPosts
   }
 
   /**

--- a/server/src/modules/tags/tags.service.ts
+++ b/server/src/modules/tags/tags.service.ts
@@ -8,7 +8,7 @@ import {
 import { PostStatus } from '../../types/post-status'
 import { countBy, uniqBy } from 'lodash'
 import { Tag } from '../../models'
-import { PostWithRelations } from '../post/post.service'
+import { PostWithUserTagRelations } from '../post/post.service'
 import { TagType } from '../../types/tag-type'
 
 export class TagsService {
@@ -85,7 +85,7 @@ export class TagsService {
     const posts = (await PostModel.findAll({
       where: { id: postIds },
       include: TagModel,
-    })) as PostWithRelations[]
+    })) as PostWithUserTagRelations[]
 
     const existingTopicTags = posts.reduce<Tag[]>(
       (acc, post) => acc.concat(post.tags),
@@ -142,7 +142,7 @@ export class TagsService {
     const posts = (await PostModel.findAll({
       where: { id: postIds },
       include: TagModel,
-    })) as PostWithRelations[]
+    })) as PostWithUserTagRelations[]
 
     const combinedTags = posts.reduce<Tag[]>(
       (acc, post) => acc.concat(post.tags),


### PR DESCRIPTION
## Problem

User should be able to view and go to related questions in case the current one does not answer their question, or if they just want to read up more about the topic.

- Part of #19

## Solution

Find the posts with the most number of shared tags, and order them in terms of number of views. More complex logic to find similar posts is suggested in comments.

## Before & After Screenshots

**BEFORE**:
![Screen Shot 2021-09-06 at 14 02 44](https://user-images.githubusercontent.com/20250559/132168106-26ee3ac1-4548-475f-901e-ff3c82738b40.png)


**AFTER**:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/20250559/132168363-2cebe739-8c0a-4210-92bb-04b0595e0022.png">

https://user-images.githubusercontent.com/20250559/132167937-8ac9d81b-7835-463a-a98a-3c76fe66dd20.mov

https://user-images.githubusercontent.com/20250559/132167955-1c2daaf3-04dc-43af-8e50-794723767985.mov




