### PR TITLE
feat: preview image in image upload

### DIFF
--- a/client/src/components/RichText/RichTextEditor.component.tsx
+++ b/client/src/components/RichText/RichTextEditor.component.tsx
@@ -40,6 +40,7 @@ const toolbarWithImageUpload = (uploadCallback: UploadCallback) => {
     image: {
       uploadEnabled: true,
       uploadCallback,
+      previewImage: true,
     },
   }
 }


### PR DESCRIPTION
## Problem

The url link overflows when inserting image. It is also specific to the browsers chrome and safari, but wraps as expected in firefox.

![image](https://user-images.githubusercontent.com/3539074/131431220-5378264d-9989-43b4-9a42-71d1ce0690fe.png)

- Closes #172

## Solution

Instead of trying to wrap the url, let the dialog show the preview of the images instead. Not only is the image constrained in the popup, it is also a better visual indicator to the user that the image upload worked. Tested to work on safari, firefox and chrome (on MacOS).

https://github.com/jpuri/react-draft-wysiwyg/issues/346

## After

https://user-images.githubusercontent.com/20250559/132284592-4fb6d142-c63c-4a87-ac09-0a4fedbf5824.mov


