### PR TITLE
feat(auth): make login otp email informational

### DIFF
--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -111,10 +111,7 @@ export class AuthController {
 
     const otp = generateRandomDigits(OTP_LENGTH)
     const hashedOtp = await hashData(otp)
-    const ip =
-      ((req.headers['x-forwarded-for'] as string) || '').split(',')[0] ||
-      req.socket.remoteAddress ||
-      ''
+    const ip = req.header('CF-Connecting-IP') || req.ip
     try {
       await Token.destroy({ where: { contact: email } })
       await Token.create({ contact: email, hashedOtp })

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -111,10 +111,14 @@ export class AuthController {
 
     const otp = generateRandomDigits(OTP_LENGTH)
     const hashedOtp = await hashData(otp)
+    const ip =
+      ((req.headers['x-forwarded-for'] as string) || '').split(',')[0] ||
+      req.socket.remoteAddress ||
+      ''
     try {
       await Token.destroy({ where: { contact: email } })
       await Token.create({ contact: email, hashedOtp })
-      await this.mailService.sendLoginOtp(email, otp)
+      await this.mailService.sendLoginOtp(email, otp, ip)
     } catch (error) {
       logger.error({
         message: 'Error while sending login OTP',

--- a/server/src/modules/mail/__tests__/mail.service.spec.ts
+++ b/server/src/modules/mail/__tests__/mail.service.spec.ts
@@ -26,7 +26,7 @@ describe('MailService', () => {
         from: mailFromEmail,
         subject: `One-Time Password for AskGov`,
         html: `Your OTP for AskGov is <b>${otp}</b>. Please use this to login to your AskGov account.<br><br>\
-If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/">https://ask.gov.sg/</a>.<br><br>\
+If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/login">https://ask.gov.sg/login</a>.<br><br>\
 This login attempt was made from the IP: <u>${ip}</u>. If you did not attempt to log in to AskGov, you may choose to investigate this IP to address further. <br><br>\
 <br>\
 The AskGov Support Team`,

--- a/server/src/modules/mail/__tests__/mail.service.spec.ts
+++ b/server/src/modules/mail/__tests__/mail.service.spec.ts
@@ -15,16 +15,21 @@ describe('MailService', () => {
       // Arrange
       const email = 'user@agency.gov.sg'
       const otp = '123456'
+      const ip = '127.0.0.1'
 
       // Act
-      await mailService.sendLoginOtp(email, otp)
+      await mailService.sendLoginOtp(email, otp, ip)
 
       // Assert
       expect(transport.sendMail).toHaveBeenCalledWith({
         to: email,
         from: mailFromEmail,
         subject: `One-Time Password for AskGov`,
-        html: `Your OTP for AskGov is <b>${otp}</b>.`,
+        html: `Your OTP for AskGov is <b>${otp}</b>. Please use this to login to your AskGov account.<br><br>\
+If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/">https://ask.gov.sg/</a>.<br><br>\
+This login attempt was made from the IP: <u>${ip}</u>. If you did not attempt to log in to AskGov, you may choose to investigate this IP to address further. <br><br>\
+<br>\
+The AskGov Support Team`,
       })
     })
   })

--- a/server/src/modules/mail/mail.service.ts
+++ b/server/src/modules/mail/mail.service.ts
@@ -15,12 +15,16 @@ export class MailService {
     this.mailFromEmail = mailFromEmail
   }
 
-  sendLoginOtp = async (email: string, otp: string): Promise<unknown> => {
+  sendLoginOtp = async (
+    email: string,
+    otp: string,
+    ip: string,
+  ): Promise<unknown> => {
     return this.transport.sendMail({
       to: email,
       from: this.mailFromEmail,
       subject: `One-Time Password for AskGov`,
-      html: renderLoginOtpBody(otp),
+      html: renderLoginOtpBody(otp, ip),
     })
   }
 

--- a/server/src/modules/mail/mail.util.ts
+++ b/server/src/modules/mail/mail.util.ts
@@ -1,6 +1,6 @@
 export const renderLoginOtpBody = (otp: string, ip: string): string =>
   `Your OTP for AskGov is <b>${otp}</b>. Please use this to login to your AskGov account.<br><br>\
-If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/">https://ask.gov.sg/</a>.<br><br>\
+If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/login">https://ask.gov.sg/login</a>.<br><br>\
 This login attempt was made from the IP: <u>${ip}</u>. If you did not attempt to log in to AskGov, you may choose to investigate this IP to address further. <br><br>\
 <br>\
 The AskGov Support Team`

--- a/server/src/modules/mail/mail.util.ts
+++ b/server/src/modules/mail/mail.util.ts
@@ -1,2 +1,6 @@
-export const renderLoginOtpBody = (otp: string): string =>
-  `Your OTP for AskGov is <b>${otp}</b>.`
+export const renderLoginOtpBody = (otp: string, ip: string): string =>
+  `Your OTP for AskGov is <b>${otp}</b>. Please use this to login to your AskGov account.<br><br>\
+If your OTP does not work, please request for a new OTP at <a href="https://ask.gov.sg/">https://ask.gov.sg/</a>.<br><br>\
+This login attempt was made from the IP: <u>${ip}</u>. If you did not attempt to log in to AskGov, you may choose to investigate this IP to address further. <br><br>\
+<br>\
+The AskGov Support Team`


### PR DESCRIPTION
- add more general information i.e. where email is coming from
- add IP address where login request is coming from

closes #39

## Problem

Closes #39.

## Solution

**Features**:

- add client machine's IP address information which sent tried to login

**Improvements**:

- add information on what OTP is for
- add fallback instructions if OTP does not work

## Before & After Screenshots

**BEFORE**:
<img width="228" alt="Screenshot 2021-09-07 at 4 44 11 PM" src="https://user-images.githubusercontent.com/37061143/132314127-50955f7b-4923-4036-a533-1bf1370511f2.png">

**AFTER**:
<img width="1014" alt="Screenshot 2021-09-07 at 8 55 59 PM" src="https://user-images.githubusercontent.com/37061143/132428005-d62f44e5-bca3-4ace-84f4-6416c1deaf3c.png">

## Tests

- (In test suite) `sendLoginOtp` in `src/modules/mail/__tests__/mail.service.spec.ts`.
- When user enters their email into the form (at https://ask.gov.sg/login), they should receive an email similar to what is seen in the after screenshot.
  - User should be able to login by entering the OTP in the login form.
  - User should be able to match the IP address to their own IP address, or find the rough location where the IP is from on the internet.
