### PR TITLE
fix: increase spacing between related posts

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -139,10 +139,12 @@ const Post = () => {
             align="left"
             color="secondary.400"
           >
-            <Text textStyle="subhead-3">Related</Text>
+            <Text mb="8px" textStyle="subhead-3">
+              Related
+            </Text>
             {post.relatedPosts.map((relatedPost) => (
               <Link to={`/questions/${relatedPost.id}`}>
-                <Text textStyle="subhead-2" fontWeight="normal">
+                <Text mb="24px" textStyle="subhead-2" fontWeight="normal">
                   {relatedPost.title}
                 </Text>
               </Link>


### PR DESCRIPTION
## Problem & Solution

Increase spacing between related post links as per design standard.

## Before

<img width="357" alt="image" src="https://user-images.githubusercontent.com/20250559/132439368-51f08fb0-5d2b-4e2d-a87b-b61a7a3092ad.png">

## After

<img width="308" alt="image" src="https://user-images.githubusercontent.com/20250559/132439381-8eefc296-f8be-4900-8417-1adf4280e2b1.png">
