### PR TITLE
fix: show only related posts that are not archived

### DIFF
--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -101,6 +101,7 @@ export class PostService {
         ],
       },
       where: {
+        status: PostStatus.PUBLIC,
         id: {
           [Op.ne]: post.id,
         },


### PR DESCRIPTION
## Problem & Solution

Related post shows archived and private posts as well. Filter them out so user does not click on posts they do not have permissions to.