### PR TITLE
feat(ga): record creating and sending of enquiries

### DIFF
--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -22,7 +22,6 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
       agency.email,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY, {
-      // property name uses `ident_type` pattern
       enquiry_str: agency.email,
     })
   }

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -8,9 +8,9 @@ import { useStyledToast } from '../StyledToast/StyledToast'
 const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
   const toast = useStyledToast()
   const {
-    onOpen: onDeleteModalOpen,
-    onClose: onDeleteModalClose,
-    isOpen: isDeleteModalOpen,
+    onOpen: onEnquiryModalOpen,
+    onClose: onEnquiryModalClose,
+    isOpen: isEnquiryModalOpen,
   } = useDisclosure()
   const onPostConfirm = async (
     enquiry: Enquiry,
@@ -55,13 +55,13 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
         }}
         borderRadius="4px"
         color="white"
-        onClick={onDeleteModalOpen}
+        onClick={onEnquiryModalOpen}
       >
         Submit an enquiry
       </Button>
       <EnquiryModal
-        isOpen={isDeleteModalOpen}
-        onClose={onDeleteModalClose}
+        isOpen={isEnquiryModalOpen}
+        onClose={onEnquiryModalClose}
         onConfirm={onPostConfirm}
         agency={agency}
       />

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -19,10 +19,10 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
   const sendOpenEnquiryEventToAnalytics = () => {
     googleAnalytics.sendUserEvent(
       googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY,
-      agency.email,
+      agency.shortname,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY, {
-      enquiry_str: agency.email,
+      enquiry_str: agency.shortname,
     })
   }
 

--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -4,6 +4,8 @@ import { Agency } from '../../services/AgencyService'
 import { Enquiry, Mail, postMail } from '../../services/MailService'
 import { EnquiryModal } from '../EnquiryModal/EnquiryModal.component'
 import { useStyledToast } from '../StyledToast/StyledToast'
+import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
+import * as FullStory from '@fullstory/browser'
 
 const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
   const toast = useStyledToast()
@@ -12,6 +14,24 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
     onClose: onEnquiryModalClose,
     isOpen: isEnquiryModalOpen,
   } = useDisclosure()
+  const googleAnalytics = useGoogleAnalytics()
+
+  const sendOpenEnquiryEventToAnalytics = () => {
+    googleAnalytics.sendUserEvent(
+      googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY,
+      agency.email,
+    )
+    FullStory.event(googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY, {
+      // property name uses `ident_type` pattern
+      enquiry_str: agency.email,
+    })
+  }
+
+  const onClick = async () => {
+    onEnquiryModalOpen()
+    sendOpenEnquiryEventToAnalytics()
+  }
+
   const onPostConfirm = async (
     enquiry: Enquiry,
     captchaResponse: string,
@@ -55,7 +75,7 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
         }}
         borderRadius="4px"
         color="white"
-        onClick={onEnquiryModalOpen}
+        onClick={onClick}
       >
         Submit an enquiry
       </Button>

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -42,15 +42,15 @@ export const EnquiryModal = ({
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [captchaResponse, setCaptchaResponse] = useState<string | null>(null)
   const googleAnalytics = useGoogleAnalytics()
-  const agencyEmail = agency.email
+  const agencyName = agency.shortname
 
-  const sendSubmitEnquiryEventToAnalytics = (agencyEmail: string) => {
+  const sendSubmitEnquiryEventToAnalytics = (agencyName: string) => {
     googleAnalytics.sendUserEvent(
       googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY,
-      agencyEmail,
+      agencyName,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY, {
-      enquiry_str: agencyEmail,
+      enquiry_str: agencyName,
     })
   }
 
@@ -59,7 +59,7 @@ export const EnquiryModal = ({
       setIsLoading(true)
       await onConfirm(enquiry, captchaResponse)
       setIsLoading(false)
-      sendSubmitEnquiryEventToAnalytics(agencyEmail)
+      sendSubmitEnquiryEventToAnalytics(agencyName)
       reset()
       onClose()
     }

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -42,15 +42,16 @@ export const EnquiryModal = ({
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [captchaResponse, setCaptchaResponse] = useState<string | null>(null)
   const googleAnalytics = useGoogleAnalytics()
+  const agencyEmail = agency.email
 
-  const sendSubmitEventToAnalytics = (enquiryTitle: string) => {
+  const sendSubmitEnquiryEventToAnalytics = (agencyEmail: string) => {
     googleAnalytics.sendUserEvent(
       googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY,
-      enquiryTitle,
+      agencyEmail,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY, {
       // property name uses `ident_type` pattern
-      enquiry_str: enquiryTitle,
+      enquiry_str: agencyEmail,
     })
   }
 
@@ -59,7 +60,7 @@ export const EnquiryModal = ({
       setIsLoading(true)
       await onConfirm(enquiry, captchaResponse)
       setIsLoading(false)
-      sendSubmitEventToAnalytics(enquiry.questionTitle)
+      sendSubmitEnquiryEventToAnalytics(agencyEmail)
       reset()
       onClose()
     }

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -50,7 +50,6 @@ export const EnquiryModal = ({
       agencyEmail,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY, {
-      // property name uses `ident_type` pattern
       enquiry_str: agencyEmail,
     })
   }

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -24,6 +24,8 @@ import { BiErrorCircle } from 'react-icons/bi'
 import { Enquiry } from '../../services/MailService'
 import ReCAPTCHA from 'react-google-recaptcha'
 import SearchBox from '../SearchBox/SearchBox.component'
+import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
+import * as FullStory from '@fullstory/browser'
 interface EnquiryModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
   onConfirm: (enquiry: Enquiry, captchaResponse: string) => Promise<void>
   agency: Agency
@@ -39,12 +41,25 @@ export const EnquiryModal = ({
   const { errors: formErrors } = formState
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [captchaResponse, setCaptchaResponse] = useState<string | null>(null)
+  const googleAnalytics = useGoogleAnalytics()
+
+  const sendSubmitEventToAnalytics = (enquiryTitle: string) => {
+    googleAnalytics.sendUserEvent(
+      googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY,
+      enquiryTitle,
+    )
+    FullStory.event(googleAnalytics.GA_USER_EVENTS.SUBMIT_ENQUIRY, {
+      // property name uses `ident_type` pattern
+      enquiry_str: enquiryTitle,
+    })
+  }
 
   const onSubmit: SubmitHandler<Enquiry> = async (enquiry) => {
     if (captchaResponse) {
       setIsLoading(true)
       await onConfirm(enquiry, captchaResponse)
       setIsLoading(false)
+      sendSubmitEventToAnalytics(enquiry.questionTitle)
       reset()
       onClose()
     }

--- a/client/src/services/googleAnalytics.tsx
+++ b/client/src/services/googleAnalytics.tsx
@@ -4,6 +4,7 @@ const GA_USER_EVENTS = {
   SEARCH: 'Search',
   ABANDONED: 'Abandoned Search',
   SUBMIT_ENQUIRY: 'Submit Enquiry',
+  OPEN_ENQUIRY: 'Open Enquiry',
 }
 
 const initializeGA = (trackingId: string): void => {

--- a/client/src/services/googleAnalytics.tsx
+++ b/client/src/services/googleAnalytics.tsx
@@ -3,6 +3,7 @@ import ReactGA from 'react-ga'
 const GA_USER_EVENTS = {
   SEARCH: 'Search',
   ABANDONED: 'Abandoned Search',
+  SUBMIT_ENQUIRY: 'Submit Enquiry',
 }
 
 const initializeGA = (trackingId: string): void => {


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/askgovsg/issues/206.

## Solution

**Features**:

- Record create enquiry events on GA and FullStory.
- Record send enquiry events on GA and FullStory.

**Improvements**:

- Rename `DeleteModal` to `EnquiryModal` in `CitizenRequest` component.

## Before & After Screenshots

**BEFORE**:
No "Open Enquiry" or "Submit Enquiry" events recorded on Google Analytics' Realtime Dashboard when the enquiry form is opened and submitted respectively.

**AFTER**:
<img width="1003" alt="Screenshot 2021-09-08 at 9 10 58 PM" src="https://user-images.githubusercontent.com/37061143/132515726-cc57f880-1f1f-41e2-a8db-726f8f07aa9e.png">
"Open Enquiry" and "Submit Enquiry" events should be logged on Google Analytics, along with the short name of the agency which the enquiry would be directed to.

## Tests

- When an enquiry form is opened, a "Open Enquiry" event should be sent to both Google Analytics and FullStory.
  - GET request should be observed to be made to the `/collect` endpoint.
  - Event should be captured on the "Realtime > Events" section of the analytics dashboard.
- When an enquiry form is submitted, a "Submit Enquiry" event should be sent to both Google Analytics and FullStory.
  - GET request should be observed to be made to the `/collect` endpoint.
  - Event should be captured on the "Realtime > Events" section of the analytics dashboard.