### PR TITLE
fix(post): ensure min width of related qns, not max

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -132,7 +132,7 @@ const Post = () => {
             </div>
           </div>
           <VStack
-            maxW={{ base: 'auto', lg: '240px' }}
+            minW={{ base: 'auto', lg: '240px' }}
             pt={{ base: '0px', lg: '152px' }}
             px={{ base: '20px', lg: '0px' }}
             pb="40px"


### PR DESCRIPTION
## Problem

Closes #269

## Solution

- Ensure min width of related qns, not max

### Before
#### Desktop
![image](https://user-images.githubusercontent.com/10572368/133017294-5aabcd8b-0ad1-4ebd-a1d4-8c36e8532558.png)
#### Mobile
![image](https://user-images.githubusercontent.com/10572368/133029069-24b25bac-d587-4a78-a960-2002645ad803.png)

### After
#### Desktop
![image](https://user-images.githubusercontent.com/10572368/133017222-9d23be9a-124a-4894-9e55-3eb10b2324bf.png)
#### Mobile
![image](https://user-images.githubusercontent.com/10572368/133029098-39154a07-e7b9-494f-bcce-b2a95fe56efb.png)
