### PR TITLE
build(server): avoid compiling test files

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -15,6 +15,7 @@
   "include": [
     "src"
   ],
+  "exclude": ["**/__tests__/"],
   "references": [
     { "path": "../shared" }
   ]


### PR DESCRIPTION
## Problem

Test files are being compiled by `npm run build-backend`. This adds bloat to the server build and blocks Typescript compilation when there are type errors in the tests, which is unnecessary because type safety in tests is merely a convenience and does not contribute to production stability.

## Solution

Ignore test files when compiling the server.