### PR TITLE
fix: convert all id types to number

### DIFF
--- a/client/src/components/EditButton/EditButton.component.tsx
+++ b/client/src/components/EditButton/EditButton.component.tsx
@@ -20,7 +20,7 @@ import { ConfirmDialog } from '../ConfirmDialog/ConfirmDialog.component'
 import { useStyledToast } from '../StyledToast/StyledToast'
 
 interface EditButtonProps {
-  postId: string
+  postId: number
   onDeleteLink?: string
 }
 

--- a/client/src/services/AgencyService.ts
+++ b/client/src/services/AgencyService.ts
@@ -1,7 +1,7 @@
 import { ApiClient } from '../api'
 
 export type Agency = {
-  id: string
+  id: number
   email: string
   shortname: string
   longname: string

--- a/client/src/services/MailService.ts
+++ b/client/src/services/MailService.ts
@@ -7,8 +7,7 @@ export type Enquiry = {
 }
 
 export type Mail = {
-  // TODO change string to number. Currently aligned with AgencyService
-  agencyId: Array<string>
+  agencyId: number[]
   enquiry: Enquiry
   captchaResponse: string
 }

--- a/client/src/services/PostService.ts
+++ b/client/src/services/PostService.ts
@@ -69,6 +69,6 @@ export const createPost = async (
   )
 }
 
-export const deletePost = async (postId: string): Promise<unknown> => {
+export const deletePost = async (postId: number): Promise<unknown> => {
   return ApiClient.delete(`${POST_API_BASE}/${postId}`).then(({ data }) => data)
 }

--- a/client/src/services/tag.service.ts
+++ b/client/src/services/tag.service.ts
@@ -2,7 +2,7 @@ import { ApiClient } from '../api'
 
 // TODO: refactor into shared types between frontend and backend
 export interface Tag {
-  id: string
+  id: number
   tagname: string
   description: string
   link: string
@@ -18,6 +18,6 @@ export const getTagsByUser = async (): Promise<Tag[]> =>
   ApiClient.get(`/tags/user`).then(({ data }) => data)
 export const GET_TAGS_BY_USER_QUERY_KEY = 'getTagsByUser'
 
-export const getTagsUsedByAgency = async (agencyId: string): Promise<Tag[]> =>
+export const getTagsUsedByAgency = async (agencyId: number): Promise<Tag[]> =>
   ApiClient.get(`/tags/agency/${agencyId}`).then((res) => res.data)
 export const GET_TAGS_USED_BY_AGENCY_QUERY_KEY = 'getTagsUsedByAgency'

--- a/server/src/middleware/checkOwnership.ts
+++ b/server/src/middleware/checkOwnership.ts
@@ -10,7 +10,7 @@ import { TagType } from '../types/tag-type'
 import { StatusCodes } from 'http-status-codes'
 
 type AnswerWithRelations = Answer & {
-  userId: string
+  userId: number
   post: Post & {
     tags: Tag[]
   }
@@ -31,7 +31,6 @@ const checkOwnership = async (
       },
     ],
   })) as AnswerWithRelations
-
   if (!results) {
     return res
       .status(StatusCodes.BAD_REQUEST)

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -3,7 +3,7 @@ import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
 import { User } from './users.model'
 
 export interface Agency extends Model {
-  id: string
+  id: number
   shortname: string
   longname: string
   email: string

--- a/server/src/models/answers.model.ts
+++ b/server/src/models/answers.model.ts
@@ -4,7 +4,7 @@ import { User } from './users.model'
 import { Post } from './posts.model'
 
 export interface Answer extends Model {
-  id: string
+  id: number
   body: string
 }
 

--- a/server/src/models/posts.model.ts
+++ b/server/src/models/posts.model.ts
@@ -5,7 +5,7 @@ import { Tag } from './tags.model'
 import { PostStatus } from '../types/post-status'
 
 export interface Post extends Model {
-  id: string
+  id: number
   title: string
   description?: string
   views: number
@@ -13,8 +13,8 @@ export interface Post extends Model {
 }
 
 export interface PostTag extends Model {
-  postId: string
-  tagId: string
+  postId: number
+  tagId: number
 }
 
 // constructor

--- a/server/src/models/tags.model.ts
+++ b/server/src/models/tags.model.ts
@@ -3,7 +3,7 @@ import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
 import { TagType } from '../types/tag-type'
 
 export interface Tag extends Model {
-  id: string
+  id: number
   tagname: string
   description: string
   link: string

--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -34,14 +34,16 @@ export class AnswersController {
     | {
         body: string
         username: string
-        userId: string
+        userId: number
         agencyLogo: string
       }[]
     | undefined
     | Message
   > = async (req, res) => {
     try {
-      const answers = await this.answersService.listAnswers(req.params.id)
+      const answers = await this.answersService.listAnswers(
+        Number(req.params.id),
+      )
       return res.status(StatusCodes.OK).json(answers)
     } catch (error) {
       logger.error({
@@ -70,7 +72,7 @@ export class AnswersController {
    */
   createAnswer: ControllerHandler<
     { id: string },
-    string | Message,
+    number | Message,
     { text: string },
     undefined
   > = async (req, res) => {
@@ -90,7 +92,7 @@ export class AnswersController {
       // Check permissions
       const hasAnswerPermissions = await this.authService.hasPermissionToAnswer(
         req.user.id,
-        req.params.id,
+        Number(req.params.id),
       )
       if (!hasAnswerPermissions) {
         return res
@@ -100,8 +102,8 @@ export class AnswersController {
       // Save Answer in the database
       const data = await this.answersService.createAnswer({
         body: req.body.text,
-        userId: req.user.id,
-        postId: req.params.id,
+        userId: Number(req.user.id),
+        postId: Number(req.params.id),
       })
 
       return res.status(StatusCodes.OK).json(data)
@@ -145,7 +147,7 @@ export class AnswersController {
       // Update Answer in the database
       const data = await this.answersService.updateAnswer({
         body: req.body.text,
-        id: req.params.id,
+        id: Number(req.params.id),
       })
       return res.status(StatusCodes.OK).json(data)
     } catch (error) {
@@ -175,7 +177,7 @@ export class AnswersController {
     res,
   ) => {
     try {
-      await this.answersService.deleteAnswer(req.params.id)
+      await this.answersService.deleteAnswer(Number(req.params.id))
       return res.status(StatusCodes.OK).end()
     } catch (error) {
       logger.error({

--- a/server/src/modules/answers/answers.routes.ts
+++ b/server/src/modules/answers/answers.routes.ts
@@ -21,7 +21,7 @@ export const routeAnswers = ({
    * @returns 500 if database error occurs
    * @access  Public
    */
-  router.get('/:id', controller.listAnswers)
+  router.get('/:id([0-9]+$)', controller.listAnswers)
 
   /**
    * Create an answer attached to a post
@@ -34,7 +34,7 @@ export const routeAnswers = ({
    * @access  Private
    */
   router.post(
-    '/:id',
+    '/:id([0-9]+$)',
     [authenticate, check('text', 'Answer is required').not().isEmpty()],
     controller.createAnswer,
   )
@@ -48,7 +48,7 @@ export const routeAnswers = ({
    * @access  Private
    */
   router.put(
-    '/:id',
+    '/:id([0-9]+$)',
     [
       authenticate,
       checkOwnership,
@@ -65,6 +65,10 @@ export const routeAnswers = ({
    * @returns 500 on database error
    * @access  Private
    */
-  router.delete('/:id', [authenticate, checkOwnership], controller.deleteAnswer)
+  router.delete(
+    '/:id([0-9]+$)',
+    [authenticate, checkOwnership],
+    controller.deleteAnswer,
+  )
   return router
 }

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -9,8 +9,8 @@ import { Answer, Post } from '../../models'
 import { FindOptions } from 'sequelize/types'
 
 type AnswerWithRelations = Answer & {
-  postId: string
-  userId: string
+  postId: number
+  userId: number
 }
 
 type PostWithRelations = Post & {
@@ -20,7 +20,7 @@ type PostWithRelations = Post & {
 type AnswerJSON = Pick<Answer, 'body'> & {
   user: {
     displayname: string
-    id: string
+    id: number
     agency: {
       logo: string
     }
@@ -33,12 +33,12 @@ export class AnswersService {
    * @returns an array of answers
    */
   listAnswers = async (
-    postId: string,
+    postId: number,
   ): Promise<
     | {
         body: string
         username: string
-        userId: string
+        userId: number
         agencyLogo: string
       }[]
     | undefined
@@ -91,7 +91,7 @@ export class AnswersService {
   }: Pick<
     AnswerWithRelations,
     'body' | 'postId' | 'userId'
-  >): Promise<string> => {
+  >): Promise<number> => {
     const answer = await AnswerModel.create({
       postId: postId,
       body: body,
@@ -110,7 +110,7 @@ export class AnswersService {
    * @returns number of rows changed in answer database
    */
   updateAnswer = async (updatedAnswer: {
-    id: string
+    id: number
     body: string
   }): Promise<number> => {
     const res = await AnswerModel.update(
@@ -126,7 +126,7 @@ export class AnswersService {
    * will archive the post and will not touch the answer.
    * @param id of answer to delete
    */
-  deleteAnswer = async (id: string): Promise<void> => {
+  deleteAnswer = async (id: number): Promise<void> => {
     await AnswerModel.destroy({ where: { id: id } })
   }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -13,15 +13,15 @@ import { createLogger } from '../../bootstrap/logging'
 const logger = createLogger(module)
 
 export type PermissionWithRelations = Permission & {
-  tagId: string
+  tagId: number
 }
 
 export type PostTagWithRelations = PostTag & {
-  tagId: string
+  tagId: number
 }
 
 export type PostWithRelations = Post & {
-  userId: string
+  userId: number
 }
 
 export class AuthService {
@@ -45,7 +45,7 @@ export class AuthService {
    * @returns a JWT token containing the user id
    * and signed with a secret known to the AuthService
    */
-  createToken = (userId: string): string => {
+  createToken = (userId: number): string => {
     const payload = {
       user: {
         id: userId,
@@ -71,13 +71,13 @@ export class AuthService {
    * @param token the JWT containing the user id
    * @returns user id if it is verified and found, else null
    */
-  getUserIdFromToken = async (token: string): Promise<string | null> => {
+  getUserIdFromToken = async (token: string): Promise<number | null> => {
     if (!token) return null
 
     return new Promise((resolve, reject) => {
       // TODO: refactor to use synchronous verify
       jwt.verify(token, this.jwtSecret, (error, decoded) => {
-        const decodedCasted = decoded as { user: { id: string } }
+        const decodedCasted = decoded as { user: { id: number } }
         if (error) {
           return reject(new Error('Unable to verify JWT'))
         } else if (!decoded || !decodedCasted.user || !decodedCasted.user.id) {
@@ -94,7 +94,7 @@ export class AuthService {
    * @param userId userId of the user to retrieve
    * @returns user with the user id
    */
-  getOfficerUser = async (userId: string): Promise<User> => {
+  getOfficerUser = async (userId: number): Promise<User> => {
     if (!userId) {
       throw new Error('User must be signed in')
     }
@@ -137,8 +137,8 @@ export class AuthService {
    * @returns true if user has permission to answer post
    */
   hasPermissionToAnswer = async (
-    userId: string,
-    postId: string,
+    userId: number,
+    postId: number,
   ): Promise<boolean> => {
     const userTags = (await PermissionModel.findAll({
       where: { userId },
@@ -162,7 +162,7 @@ export class AuthService {
    * @returns subset of tagList that user is not allowed to add
    */
   getDisallowedTagsForUser = async (
-    userId: string,
+    userId: number,
     tagList: Tag[],
   ): Promise<Tag[]> => {
     const userTags = (await PermissionModel.findAll({

--- a/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
+++ b/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
@@ -67,7 +67,7 @@ describe('EnquiryService', () => {
 
     it('should send an enquiry email to AskGov if no agency is specified', async () => {
       // Arrange
-      const agencyId: string[] = []
+      const agencyId: number[] = []
 
       // Act
       await enquiryService.emailEnquiry({ agencyId, enquiry })
@@ -82,7 +82,7 @@ describe('EnquiryService', () => {
 
     it('should return error when a agency ID is invalid', async () => {
       // Arrange
-      const agencyId = ['1234']
+      const agencyId = [1234]
 
       try {
         // Act

--- a/server/src/modules/enquiry/enquiry.controller.ts
+++ b/server/src/modules/enquiry/enquiry.controller.ts
@@ -34,7 +34,7 @@ export class EnquiryController {
     unknown,
     Message,
     {
-      agencyId: string[]
+      agencyId: number[]
       enquiry: Enquiry
       captchaResponse: string
     }

--- a/server/src/modules/enquiry/enquiry.service.ts
+++ b/server/src/modules/enquiry/enquiry.service.ts
@@ -20,7 +20,7 @@ export class EnquiryService {
     agencyId,
     enquiry,
   }: {
-    agencyId: Array<string>
+    agencyId: number[]
     enquiry: Enquiry
   }): Promise<void> => {
     const agencyEmail = await Promise.all(

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -117,7 +117,7 @@ describe('PostService', () => {
     it('should return error when the user ID is invalid', async () => {
       try {
         await postService.listAnswerablePosts({
-          userId: '2',
+          userId: 2,
           sort: SortType.Top,
           withAnswers: false,
         })

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -231,7 +231,7 @@ export class PostController {
    */
   createPost: ControllerHandler<
     undefined,
-    { data: string } | Message,
+    { data: number } | Message,
     {
       title: string
       tagname: string[]
@@ -297,7 +297,7 @@ export class PostController {
    * @return 500 if database error
    */
   deletePost: ControllerHandler<{ id: string }, Message> = async (req, res) => {
-    const postId = req.params.id
+    const postId = Number(req.params.id)
     try {
       const userId = await this.authService.getUserIdFromToken(
         req.header('x-auth-token') ?? '',
@@ -348,7 +348,7 @@ export class PostController {
     UpdatePostRequestDto,
     undefined
   > = async (req, res) => {
-    const postId = req.params.id
+    const postId = Number(req.params.id)
     try {
       const userId = await this.authService.getUserIdFromToken(
         req.header('x-auth-token') ?? '',

--- a/server/src/modules/post/post.routes.ts
+++ b/server/src/modules/post/post.routes.ts
@@ -115,7 +115,7 @@ export const routePosts = ({
    * @return 500 if database error
    * @access Private
    */
-  router.delete('/:id', controller.deletePost)
+  router.delete('/:id([0-9]+$)', controller.deletePost)
 
   /**
    * Update a post
@@ -127,7 +127,7 @@ export const routePosts = ({
    * @return 500 if database error
    * @access Private
    */
-  router.put('/:id', controller.updatePost)
+  router.put('/:id([0-9]+$)', controller.updatePost)
 
   return router
 }

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -298,7 +298,7 @@ export class PostService {
     page,
     size,
   }: {
-    userId: string
+    userId: number
     sort: SortType
     withAnswers: boolean
     tags?: string[]
@@ -447,9 +447,9 @@ export class PostService {
   createPost = async (newPost: {
     title: string
     description: string
-    userId: string
+    userId: number
     tagname: string[]
-  }): Promise<string> => {
+  }): Promise<number> => {
     const tagList = await this.getExistingTagsFromRequestTags(newPost.tagname)
 
     if (newPost.tagname.length !== tagList.length) {
@@ -482,7 +482,7 @@ export class PostService {
    * @param id Post to be deleted
    * @returns void if successful
    */
-  deletePost = async (id: string): Promise<void> => {
+  deletePost = async (id: number): Promise<void> => {
     const update = await this.Post.update(
       { status: 'ARCHIVED' },
       { where: { id: id } },

--- a/server/src/modules/tags/tags.controller.ts
+++ b/server/src/modules/tags/tags.controller.ts
@@ -97,7 +97,9 @@ export class TagsController {
   > = async (req, res) => {
     const { agencyId } = req.params
     try {
-      const result = await this.tagsService.listTagsUsedByAgency(agencyId)
+      const result = await this.tagsService.listTagsUsedByAgency(
+        Number(agencyId),
+      )
       return res.json(result)
     } catch (error) {
       logger.error({

--- a/server/src/modules/tags/tags.routes.ts
+++ b/server/src/modules/tags/tags.routes.ts
@@ -40,7 +40,7 @@ export const routeTags = ({
    * @returns 400 with database error
    * @access  public
    */
-  router.get('/agency/:agencyId', controller.listTagsUsedByAgency)
+  router.get('/agency/:agencyId([0-9]+$)', controller.listTagsUsedByAgency)
 
   /**
    * Get a single tag by name

--- a/server/src/modules/tags/tags.service.ts
+++ b/server/src/modules/tags/tags.service.ts
@@ -55,7 +55,7 @@ export class TagsService {
    * @param userId id of the user
    * @returns list of tags
    */
-  listTagsUsedByUser = async (userId: string): Promise<Tag[]> => {
+  listTagsUsedByUser = async (userId: number): Promise<Tag[]> => {
     const userAgencyTags = await TagModel.findAll({
       where: {
         tagType: TagType.AGENCY,
@@ -121,7 +121,7 @@ export class TagsService {
    * @param agencyId id of agency
    * @returns list of tags
    */
-  listTagsUsedByAgency = async (agencyId: string): Promise<Tag[]> => {
+  listTagsUsedByAgency = async (agencyId: number): Promise<Tag[]> => {
     const agency = await AgencyModel.findByPk(agencyId)
     // If agency is not found, there are no tags used by it
     if (!agency) return []

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -10,7 +10,7 @@ export class UserService {
     })
   }
 
-  loadUser = async (userId: string): Promise<User | null> => {
+  loadUser = async (userId: number): Promise<User | null> => {
     return UserModel.findByPk(userId, { include: TagModel })
   }
 }

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace Express {
   interface User {
-    id: string
+    id: number
   }
 }

--- a/server/src/types/post-type.ts
+++ b/server/src/types/post-type.ts
@@ -1,7 +1,7 @@
 import { Post } from '../models'
 
 export type PostEditType = {
-  id: string
+  id: number
   tagname: Array<string>
   description: string
   title: string

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const User = z.object({
-  id: z.string(),
+  id: z.number(),
   username: z.string(),
   displayname: z.string(),
   views: z.number().nonnegative(),


### PR DESCRIPTION
## Problem

`id`s are typed as `string` throughout the codebase, but in reality they are of type `number` at runtime. I verified this on the client by checking the types of API responses as well as on the server by logging `typeof` in several services for several model IDs (`post`, `answer`, `tag` etc). I also verified that in the authentication JWT, the type of the user ID is also `number`.

Prerequisite for #218 

## Solution

Convert all `id` types to `number`. Note that for React Router, `match.params.id` is of type `string` at runtime and this is already typed correctly in the code, so I left this alone.

### Type of `req.params.id`

One wrinkle was that Express always types route parameters as `string`. This means that in the controller layer, `id`s are strings when they are derived from the route parameters, but they are numbers in the model layer. This inconsistency might cause confusion for future developers.

I decided to type all IDs in the **service layer and below** as `number`. This made sense to me because IDs should be numbers from the perspective of a service, whose job is to implement business logic and interface with the model layer, not to deal with HTTP requests. Since IDs being strings in the controller layer is a peculiarity of Express requests, it should be the controller's job to format the ID in a manner which the service can understand.

In turn, this brought up questions of type safety in the services, since calling the `Number` constructor on a non-number in the controller could result in `NaN` being passed to the service. Hence I introduced additional regex guards in the relevant routes to ensure that the `Number` constructor could be called safely in the controllers.