### PR TITLE
fix(searchbox): inject agencyShortName, don't derive from params

### DIFF
--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -7,7 +7,7 @@ import { useStyledToast } from '../StyledToast/StyledToast'
 import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import * as FullStory from '@fullstory/browser'
 
-const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
+const CitizenRequest = ({ agency }: { agency?: Agency }): JSX.Element => {
   const toast = useStyledToast()
   const {
     onOpen: onEnquiryModalOpen,
@@ -15,14 +15,15 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
     isOpen: isEnquiryModalOpen,
   } = useDisclosure()
   const googleAnalytics = useGoogleAnalytics()
+  const agencyName = agency?.shortname || 'AskGov'
 
   const sendOpenEnquiryEventToAnalytics = () => {
     googleAnalytics.sendUserEvent(
       googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY,
-      agency.shortname,
+      agencyName,
     )
     FullStory.event(googleAnalytics.GA_USER_EVENTS.OPEN_ENQUIRY, {
-      enquiry_str: agency.shortname,
+      enquiry_str: agencyName,
     })
   }
 
@@ -36,7 +37,7 @@ const CitizenRequest = ({ agency }: { agency: Agency }): JSX.Element => {
     captchaResponse: string,
   ): Promise<void> => {
     const mail: Mail = {
-      agencyId: agency.id ? [agency.id] : [],
+      agencyId: agency?.id ? [agency?.id] : [],
       enquiry: enquiry,
       captchaResponse: captchaResponse,
     }

--- a/client/src/components/EnquiryModal/EnquiryModal.component.tsx
+++ b/client/src/components/EnquiryModal/EnquiryModal.component.tsx
@@ -28,7 +28,7 @@ import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import * as FullStory from '@fullstory/browser'
 interface EnquiryModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
   onConfirm: (enquiry: Enquiry, captchaResponse: string) => Promise<void>
-  agency: Agency
+  agency?: Agency
 }
 
 export const EnquiryModal = ({
@@ -42,7 +42,7 @@ export const EnquiryModal = ({
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [captchaResponse, setCaptchaResponse] = useState<string | null>(null)
   const googleAnalytics = useGoogleAnalytics()
-  const agencyName = agency.shortname
+  const agencyName = agency?.shortname || 'AskGov'
 
   const sendSubmitEnquiryEventToAnalytics = (agencyName: string) => {
     googleAnalytics.sendUserEvent(
@@ -75,15 +75,16 @@ export const EnquiryModal = ({
         <ModalContent w="660px">
           <ModalHeader>
             <Text textStyle="h2" color="secondary.700">
-              {`${agency.shortname.toUpperCase()} Enquiry Form`}
+              {`${(agency?.shortname ?? '').toUpperCase()} Enquiry Form`}
             </Text>
           </ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <VStack align="left" spacing={0}>
               <Text>
-                {`This enquiry form will generate an email to be sent to 
-                ${agency.longname}. Please note that we would take within
+                {`This enquiry form will generate an email to be sent${
+                  agency?.longname ? ` to ${agency?.longname}` : ''
+                }. Please note that we would take within
                 3 - 14 working days to process your enquiry. Thank you.`}
               </Text>
               <Box h={4} />
@@ -100,6 +101,7 @@ export const EnquiryModal = ({
                 searchOnEnter={false}
                 isInvalid={formErrors.questionTitle}
                 inputRef={ref}
+                agencyShortName={agency?.shortname}
                 {...questionTitleProps}
               />
               {formErrors.questionTitle && errorLabel('This field is required')}

--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -20,6 +20,7 @@ const SearchBox = ({
   handleAbandon = (_inputValue) => {},
   searchOnEnter = true,
   showSearchIcon = true,
+  agencyShortName,
   ...inputProps
 }) => {
   /*
@@ -28,7 +29,6 @@ const SearchBox = ({
   Use a separate query here to return all unfiltered posts for
   client-side search 
   */
-  const { agency: agencyShortName } = useParams()
   const { data } = useQuery(
     [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agencyShortName],
     // TODO: refactor to better split between when agencyShortName is present

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -104,7 +104,9 @@ const HomePage = ({ match }) => {
             mx={agency ? 0 : 'auto'}
             maxW={{ base: '100%', xl: '80%' }}
           >
-            <SearchBoxComponent />
+            <SearchBoxComponent
+              agencyShortName={match.params.agency || agency?.shortname}
+            />
           </Box>
         </Flex>
       </Box>
@@ -225,19 +227,7 @@ const HomePage = ({ match }) => {
         </Box>
       </Flex>
       <Spacer />
-      <CitizenRequest
-        agency={
-          agency
-            ? agency
-            : {
-                id: '',
-                email: 'enquiries@ask.gov.sg',
-                shortname: 'AskGov',
-                longname: 'AskGov',
-                logo: '',
-              }
-        }
-      />
+      <CitizenRequest agency={agency} />
     </Flex>
   )
 }

--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -19,10 +19,10 @@ const SearchResults = () => {
   const { search } = useLocation()
   const searchParams = new URLSearchParams(search)
   const searchQuery = searchParams.get('search') ?? ''
-  const agency = searchParams.get('agency')
+  const agencyShortName = searchParams.get('agency')
   const { data, isLoading } = useQuery(
-    [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agency],
-    listPosts(undefined, agency),
+    [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agencyShortName],
+    listPosts(undefined, agencyShortName),
   )
 
   const foundPosts = new Fuse(data?.posts ?? [], {
@@ -53,7 +53,12 @@ const SearchResults = () => {
             <span style={{ color: '#acb2b8', fontSize: '12px' }}>
               Results for {searchQuery}
             </span>
-            <SearchBox placeholder={'Search...'} name={'search'} pt={'mt8'} />
+            <SearchBox
+              agencyShortName={agencyShortName}
+              placeholder={'Search...'}
+              name={'search'}
+              pt={'mt8'}
+            />
           </div>
         ) : (
           ''


### PR DESCRIPTION
## Problem

When creating an enquiry from a question, autocomplete suggestions are not confined to the agency
that created the question.

## Solution

The agency short name may not always be available in path params,
so accept it as an injected property instead.

- Change SearchBox to accept `agencyShortName`, not `useParams()`
- Get HomePage to inject agency into CitizenRequest as-is, instead of
  using AskGov default, since SearchBox can cope with an undefined
  agency
  - Move AskGov defaults to CitizenRequest and EnquiryModal

## Screenshots

Note all suggestions being specific to Parking
![image](https://user-images.githubusercontent.com/10572368/133364557-9421907f-346f-42a5-92f9-e373c22614e3.png)


## Tests

- Create (but don't submit) enquiry autosuggestions in:
  - AskGov landing page
  - Agency-specific page
  - Question
- For each scenario, verify that the suggestions are constrained to agency, or in the case of the AskGov landing page, span across agencies