### PR TITLE
refactor(shared): create remaining shared model types

### DIFF
--- a/client/src/api/types/tag.ts
+++ b/client/src/api/types/tag.ts
@@ -1,4 +1,4 @@
-import { TagType } from '../../types/tag-type'
+import { TagType } from '~shared/types/base'
 import { BaseModelParams } from './common'
 
 export type BaseTagDto = BaseModelParams & {

--- a/client/src/components/PostItem/PostItem.component.jsx
+++ b/client/src/components/PostItem/PostItem.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
-import { TagType } from '../../types/tag-type'
+import { TagType } from '~shared/types/base'
 import EditButton from '../EditButton/EditButton.component'
 import { RichTextFrontPreview } from '../RichText/RichTextEditor.component'
 import TagBadge from '../TagBadge/TagBadge.component'

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -25,7 +25,7 @@ import {
   GET_TAGS_USED_BY_AGENCY_QUERY_KEY,
 } from '../../services/tag.service'
 import { getRedirectURL } from '../../util/urlparser'
-import { TagType } from '../../types/tag-type'
+import { TagType } from '~shared/types/base'
 
 const TagPanel = (): ReactElement => {
   const { agency: agencyShortName } = useParams<{ agency: string }>()

--- a/client/src/pages/Login/Login.component.jsx
+++ b/client/src/pages/Login/Login.component.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Redirect } from 'react-router-dom'
 import AuthForm from '../../components/AuthForm/AuthForm.component'
 import { useAuth } from '../../contexts/AuthContext'
-import { TagType } from '../../types/tag-type'
+import { TagType } from '~shared/types/base'
 import './Login.styles.scss'
 
 const Login = () => {

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -15,8 +15,7 @@ import {
   getPostById,
   GET_POST_BY_ID_QUERY_KEY,
 } from '../../services/PostService'
-import { PostStatus } from '~shared/types/base'
-import { TagType } from '../../types/tag-type'
+import { PostStatus, TagType } from '~shared/types/base'
 import AnswerSection from './AnswerSection/AnswerSection.component'
 import './Post.styles.scss'
 import QuestionSection from './QuestionSection/QuestionSection.component'

--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom'
 import Select from 'react-select'
 import { RichTextEditor } from '../../../components/RichText/RichTextEditor.component'
 import { Tag } from '../../../services/tag.service'
-import { TagType } from '../../../types/tag-type'
+import { TagType } from '~shared/types/base'
 import './AskForm.styles.scss'
 
 export type AskFormSubmission = {

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -1,3 +1,5 @@
+import { PermissionType } from '~shared/types/base'
+
 export const isUserPublicOfficer = (user) =>
   !!user?.username?.endsWith('.gov.sg')
 
@@ -5,7 +7,9 @@ export const hasAnswerPermissions = (user, post) => {
   const hasAnswerPermissions = post.tags.every((postTag) => {
     const userTag = user.tags.find((userTag) => userTag.id === postTag.id)
     return (
-      userTag && userTag.permission && userTag.permission.role === 'answerer'
+      userTag &&
+      userTag.permission &&
+      userTag.permission.role === PermissionType.Answerer
     )
   })
   return hasAnswerPermissions

--- a/client/src/types/tag-type.ts
+++ b/client/src/types/tag-type.ts
@@ -1,4 +1,0 @@
-export enum TagType {
-  Agency = 'AGENCY',
-  Topic = 'TOPIC',
-}

--- a/client/src/util/urlparser.ts
+++ b/client/src/util/urlparser.ts
@@ -1,4 +1,4 @@
-import { TagType } from '../types/tag-type'
+import { TagType } from '~shared/types/base'
 import queryString from 'query-string'
 import { Agency } from '../services/AgencyService'
 

--- a/server/src/middleware/checkOwnership.ts
+++ b/server/src/middleware/checkOwnership.ts
@@ -6,7 +6,7 @@ import {
 } from '../bootstrap/sequelize'
 import { Request, Response, NextFunction } from 'express'
 import { Answer, Post, Tag } from '../models'
-import { TagType } from '../types/tag-type'
+import { TagType } from '../../../shared/types/base'
 import { StatusCodes } from 'http-status-codes'
 
 type AnswerWithRelations = Answer & {
@@ -27,7 +27,7 @@ const checkOwnership = async (
     include: [
       {
         model: PostModel,
-        include: [{ model: TagModel, where: { tagType: TagType.AGENCY } }],
+        include: [{ model: TagModel, where: { tagType: TagType.Agency } }],
       },
     ],
   })) as AnswerWithRelations
@@ -43,7 +43,7 @@ const checkOwnership = async (
   }
 
   const user = (await UserModel.findByPk(req.user.id, {
-    include: [{ model: TagModel, where: { tagType: TagType.AGENCY } }],
+    include: [{ model: TagModel, where: { tagType: TagType.Agency } }],
   })) as { tags: Tag[] } | null
 
   if (!user) {

--- a/server/src/models/answers.model.ts
+++ b/server/src/models/answers.model.ts
@@ -1,12 +1,10 @@
 import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
-
+import { Answer as AnswerBaseDto } from '../../../shared/types/base'
 import { User } from './users.model'
 import { Post } from './posts.model'
 
-export interface Answer extends Model {
-  id: number
-  body: string
-}
+// TODO (#225): Remove this and replace ModelCtor below with ModelDefined
+export interface Answer extends Model, AnswerBaseDto {}
 
 // constructor
 export const defineAnswer = (

--- a/server/src/models/tags.model.ts
+++ b/server/src/models/tags.model.ts
@@ -1,15 +1,7 @@
 import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
+import { Tag as TagBaseDto, TagType } from '../../../shared/types/base'
 
-import { TagType } from '../types/tag-type'
-
-export interface Tag extends Model {
-  id: number
-  tagname: string
-  description: string
-  link: string
-  hasPilot: boolean
-  tagType: string
-}
+export interface Tag extends Model, TagBaseDto {}
 
 // constructor
 export const defineTag = (sequelize: Sequelize): ModelCtor<Tag> =>
@@ -32,7 +24,7 @@ export const defineTag = (sequelize: Sequelize): ModelCtor<Tag> =>
       allowNull: false,
     },
     tagType: {
-      type: DataTypes.ENUM(TagType.AGENCY, TagType.TOPIC),
+      type: DataTypes.ENUM(...Object.values(TagType)),
       allowNull: false,
     },
   })

--- a/server/src/models/users.model.ts
+++ b/server/src/models/users.model.ts
@@ -2,7 +2,7 @@ import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
 
 import { Tag } from './tags.model'
 import { IMinimatch } from 'minimatch'
-import { User as UserBaseDto } from '../../../shared/types/base'
+import { PermissionType, User as UserBaseDto } from '../../../shared/types/base'
 
 const USER_MODEL_NAME = 'user'
 
@@ -49,7 +49,7 @@ export const defineUserAndPermission = (
   })
   const Permission: ModelCtor<Permission> = sequelize.define('permission', {
     role: {
-      type: DataTypes.ENUM('answerer', 'admin'),
+      type: DataTypes.ENUM(...Object.values(PermissionType)),
       allowNull: false,
     },
   })

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import minimatch from 'minimatch'
 
-import { PostStatus } from '../../../../shared/types/base'
+import { PermissionType, PostStatus } from '../../../../shared/types/base'
 import {
   User as UserModel,
   Permission as PermissionModel,
@@ -151,7 +151,7 @@ export class AuthService {
       const permission = userTags.find(
         (userTag) => userTag.tagId === postTag.tagId,
       )
-      return permission && permission.role === 'answerer'
+      return permission && permission.role === PermissionType.Answerer
     })
   }
 
@@ -172,7 +172,7 @@ export class AuthService {
       const permission = userTags.find(
         (userTag) => userTag.tagId === postTag.id,
       )
-      return !(permission && permission.role === 'answerer')
+      return !(permission && permission.role === PermissionType.Answerer)
     })
   }
 

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -12,7 +12,7 @@ import {
   Tag as TagModel,
   User as UserModel,
 } from '../../../models'
-import { PostStatus } from '../../../../../shared/types/base'
+import { PermissionType, PostStatus } from '../../../../../shared/types/base'
 import { SortType } from '../../../types/sort-type'
 import { TagType } from '../../../../../shared/types/base'
 import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
@@ -87,7 +87,7 @@ describe('/posts', () => {
     await Permission.create({
       userId: mockUser.id,
       tagId: mockTag.id,
-      role: 'Answerer',
+      role: PermissionType.Answerer,
     })
     controller = new PostController({ authService, postService })
     app.use(path, routePosts({ controller, authMiddleware }))

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../models'
 import { PostStatus } from '../../../../../shared/types/base'
 import { SortType } from '../../../types/sort-type'
-import { TagType } from '../../../types/tag-type'
+import { TagType } from '../../../../../shared/types/base'
 import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
 import { PostController } from '../post.controller'
 import { routePosts } from '../post.routes'
@@ -73,7 +73,7 @@ describe('/posts', () => {
       description: '',
       link: '',
       hasPilot: true,
-      tagType: TagType.TOPIC,
+      tagType: TagType.Topic,
     })
     for (let title = 1; title <= 20; title++) {
       const mockPost = await Post.create({

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -7,9 +7,8 @@ import {
   User as UserModel,
   Permission as PermissionModel,
 } from '../../../models'
-import { PostStatus } from '../../../../../shared/types/base'
+import { PostStatus, TagType } from '../../../../../shared/types/base'
 import { SortType } from '../../../types/sort-type'
-import { TagType } from '../../../types/tag-type'
 import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
 import { PostService } from '../post.service'
 
@@ -44,7 +43,7 @@ describe('PostService', () => {
       description: '',
       link: '',
       hasPilot: true,
-      tagType: TagType.TOPIC,
+      tagType: TagType.Topic,
     })
     for (let title = 1; title <= 20; title++) {
       const mockPost = await Post.create({

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -7,7 +7,11 @@ import {
   User as UserModel,
   Permission as PermissionModel,
 } from '../../../models'
-import { PostStatus, TagType } from '../../../../../shared/types/base'
+import {
+  PermissionType,
+  PostStatus,
+  TagType,
+} from '../../../../../shared/types/base'
 import { SortType } from '../../../types/sort-type'
 import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
 import { PostService } from '../post.service'
@@ -57,7 +61,7 @@ describe('PostService', () => {
     await Permission.create({
       userId: mockUser.id,
       tagId: mockTag.id,
-      role: 'Answerer',
+      role: PermissionType.Answerer,
     })
   })
 

--- a/server/src/modules/tags/tags.service.ts
+++ b/server/src/modules/tags/tags.service.ts
@@ -5,11 +5,10 @@ import {
   Tag as TagModel,
   User as UserModel,
 } from '../../bootstrap/sequelize'
-import { PostStatus } from '../../../../shared/types/base'
+import { PostStatus, TagType } from '../../../../shared/types/base'
 import { countBy, uniqBy } from 'lodash'
 import { Tag } from '../../models'
 import { PostWithUserTagRelations } from '../post/post.service'
-import { TagType } from '../../types/tag-type'
 
 export class TagsService {
   private postsCountLiteral: ProjectionAlias = [
@@ -58,7 +57,7 @@ export class TagsService {
   listTagsUsedByUser = async (userId: number): Promise<Tag[]> => {
     const userAgencyTags = await TagModel.findAll({
       where: {
-        tagType: TagType.AGENCY,
+        tagType: TagType.Agency,
       },
       include: {
         model: UserModel,
@@ -96,7 +95,7 @@ export class TagsService {
 
     const allowedTopicTags = await TagModel.findAll({
       where: {
-        tagType: TagType.TOPIC,
+        tagType: TagType.Topic,
       },
       include: {
         model: UserModel,

--- a/server/src/types/tag-type.ts
+++ b/server/src/types/tag-type.ts
@@ -1,4 +1,0 @@
-export const TagType = {
-  AGENCY: 'AGENCY',
-  TOPIC: 'TOPIC',
-}

--- a/shared/types/base/answer.ts
+++ b/shared/types/base/answer.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import { BaseModel } from './common'
+
+export const Answer = BaseModel.extend({
+  body: z.string(),
+})
+
+export type Answer = z.infer<typeof Answer>

--- a/shared/types/base/index.ts
+++ b/shared/types/base/index.ts
@@ -1,5 +1,6 @@
 export * from './agency'
 export * from './answer'
+export * from './permission'
 export * from './post'
 export * from './tag'
 export * from './user'

--- a/shared/types/base/index.ts
+++ b/shared/types/base/index.ts
@@ -1,4 +1,5 @@
 export * from './agency'
 export * from './answer'
 export * from './post'
+export * from './tag'
 export * from './user'

--- a/shared/types/base/index.ts
+++ b/shared/types/base/index.ts
@@ -1,3 +1,4 @@
 export * from './agency'
+export * from './answer'
 export * from './post'
 export * from './user'

--- a/shared/types/base/permission.ts
+++ b/shared/types/base/permission.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export enum PermissionType {
+  Answerer = 'answerer',
+  Admin = 'admin',
+}
+
+// no BaseModel as Permission table has no id
+export const Permission = z.object({
+  role: z.nativeEnum(PermissionType),
+  tagId: z.number(),
+  userId: z.number(),
+})
+
+export type Permission = z.infer<typeof Permission>

--- a/shared/types/base/tag.ts
+++ b/shared/types/base/tag.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { BaseModel } from './common'
+
+export enum TagType {
+  Agency = 'AGENCY',
+  Topic = 'TOPIC',
+}
+
+export const Tag = BaseModel.extend({
+  tagname: z.string(),
+  description: z.string(),
+  link: z.string(),
+  hasPilot: z.boolean(),
+  tagType: z.nativeEnum(TagType),
+})
+
+export type Tag = z.infer<typeof Tag>


### PR DESCRIPTION
- Creates shared model types for `Answer`, `Tag` and `Permission`
- Creates shared enums for `TagType` (previously separate enums in frontend and backend) and `PermissionType` (previously hardcoded strings)