### PR TITLE
refactor: create shared API types for auth endpoints

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { useMutation, UseMutationResult } from 'react-query'
 import { ApiClient } from '../api'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import * as AuthService from '../services/AuthService'
+import { LoadUserDto } from '~shared/types/api'
 
 interface AuthContextProps {
   user: unknown
@@ -28,12 +29,11 @@ export const AuthProvider = ({
 }: {
   children: JSX.Element
 }): JSX.Element => {
-  const [user, setUser] = useState<Record<string, unknown> | null>(null)
+  const [user, setUser] = useState<LoadUserDto>(null)
   const [token, setToken] = useLocalStorage<string>('token')
 
   const whoami = () => {
-    // TODO: type the response/user
-    ApiClient.get<{ data: Record<string, unknown> } | null>('/auth')
+    ApiClient.get<LoadUserDto>('/auth')
       .then(({ data }) => {
         if (data) {
           setUser(data)

--- a/client/src/services/AuthService.ts
+++ b/client/src/services/AuthService.ts
@@ -1,3 +1,4 @@
+import { VerifyLoginOtpDto } from '~shared/types/api'
 import { ApiClient } from '../api'
 
 export const sendOtp = (email: string): Promise<void> => {
@@ -7,14 +8,13 @@ export const sendOtp = (email: string): Promise<void> => {
 export const verifyOtp = async (data: {
   email: string
   otp: string
-}): Promise<{
-  displayName: string
-  newParticipant: boolean
-  token: string
-}> => {
+}): Promise<
+  // capitalise N in displayname key
+  Omit<VerifyLoginOtpDto, 'displayname'> & { displayName: string }
+> => {
   const {
     data: { displayname, newParticipant, token },
-  } = await ApiClient.post('/auth/verifyotp', data)
+  } = await ApiClient.post<VerifyLoginOtpDto>('/auth/verifyotp', data)
   return {
     displayName: displayname,
     newParticipant,

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -1,17 +1,14 @@
 import { validationResult } from 'express-validator'
+import { StatusCodes } from 'http-status-codes'
+import { ErrorDto, LoadUserDto, VerifyLoginOtpDto } from '~shared/types/api'
+import { createLogger } from '../../bootstrap/logging'
+import { Token, User } from '../../bootstrap/sequelize'
+import { UserService } from '../../modules/user/user.service'
+import { ControllerHandler } from '../../types/response-handler'
 import { generateRandomDigits, hashData, verifyHash } from '../../util/hash'
-import { User, Token } from '../../bootstrap/sequelize'
-import { User as UserType } from '../../models'
 import { createValidationErrMessage } from '../../util/validation-error'
-
 import { MailService } from '../mail/mail.service'
 import { AuthService } from './auth.service'
-import { UserService } from '../../modules/user/user.service'
-import { Request, Response } from 'express'
-import { createLogger } from '../../bootstrap/logging'
-import { ControllerHandler } from '../../types/response-handler'
-import { Message } from '../../types/message-type'
-import { StatusCodes } from 'http-status-codes'
 
 const OTP_LENGTH = 6
 
@@ -42,7 +39,7 @@ export class AuthController {
    * @returns 401 if user not signed in
    * @returns 500 if database error
    */
-  loadUser: ControllerHandler<undefined, UserType | null | Message> = async (
+  loadUser: ControllerHandler<unknown, LoadUserDto | ErrorDto> = async (
     req,
     res,
   ) => {
@@ -80,7 +77,7 @@ export class AuthController {
    */
   handleSendLoginOtp: ControllerHandler<
     undefined,
-    Message,
+    ErrorDto, // success case has no return data
     { email: string },
     undefined
   > = async (req, res) => {
@@ -151,7 +148,7 @@ export class AuthController {
    */
   handleVerifyLoginOtp: ControllerHandler<
     undefined,
-    { token: string; newParticipant: boolean; displayname: string } | Message,
+    VerifyLoginOtpDto | ErrorDto,
     { email: string; otp: string },
     undefined
   > = async (req, res) => {

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -1,6 +1,7 @@
 import { getOfficerDisplayName } from './user.util'
 import { User as UserModel, Tag as TagModel } from '../../bootstrap/sequelize'
 import { User } from '../../models'
+import { LoadUserDto } from '~shared/types/api'
 
 export class UserService {
   createOfficer = async (username: string): Promise<User> => {
@@ -10,7 +11,9 @@ export class UserService {
     })
   }
 
-  loadUser = async (userId: number): Promise<User | null> => {
-    return UserModel.findByPk(userId, { include: TagModel })
+  loadUser = async (userId: number): Promise<LoadUserDto> => {
+    return UserModel.findByPk(userId, {
+      include: TagModel,
+    }) as Promise<LoadUserDto>
   }
 }

--- a/shared/src/types/api/auth.ts
+++ b/shared/src/types/api/auth.ts
@@ -1,0 +1,15 @@
+import { Permission, Tag, User } from '../base'
+
+export type LoadUserDto =
+  | (User & {
+      tags: (Tag & {
+        permission: Permission
+      })[]
+    })
+  | null
+
+export type VerifyLoginOtpDto = {
+  token: string
+  newParticipant: boolean
+  displayname: string
+}

--- a/shared/src/types/api/common.ts
+++ b/shared/src/types/api/common.ts
@@ -1,0 +1,3 @@
+export type ErrorDto = {
+  message: string
+}

--- a/shared/src/types/api/index.ts
+++ b/shared/src/types/api/index.ts
@@ -1,0 +1,2 @@
+export * from './auth'
+export * from './common'

--- a/shared/src/types/base/common.ts
+++ b/shared/src/types/base/common.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 
-export const BaseModel = z.object({
-  id: z.number(),
+export const SequelizeTimestamps = z.object({
   // createdAt and updatedAt are of type Date
   // in the backend, but are received by the frontend
   // as strings because
@@ -10,4 +9,8 @@ export const BaseModel = z.object({
   // on the string/Date
   createdAt: z.date().or(z.string()),
   updatedAt: z.date().or(z.string()),
+})
+
+export const BaseModel = SequelizeTimestamps.extend({
+  id: z.number(),
 })

--- a/shared/src/types/base/common.ts
+++ b/shared/src/types/base/common.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const SequelizeTimestamps = z.object({
+export const HasSequelizeTimestamps = z.object({
   // createdAt and updatedAt are of type Date
   // in the backend, but are received by the frontend
   // as strings because
@@ -11,6 +11,6 @@ export const SequelizeTimestamps = z.object({
   updatedAt: z.date().or(z.string()),
 })
 
-export const BaseModel = SequelizeTimestamps.extend({
+export const BaseModel = HasSequelizeTimestamps.extend({
   id: z.number(),
 })

--- a/shared/src/types/base/common.ts
+++ b/shared/src/types/base/common.ts
@@ -2,4 +2,12 @@ import { z } from 'zod'
 
 export const BaseModel = z.object({
   id: z.number(),
+  // createdAt and updatedAt are of type Date
+  // in the backend, but are received by the frontend
+  // as strings because
+  // typeof JSON.parse(JSON.stringify(new Date())) === 'string'
+  // To convert (string | Date) to Date, simply call new Date()
+  // on the string/Date
+  createdAt: z.date().or(z.string()),
+  updatedAt: z.date().or(z.string()),
 })

--- a/shared/src/types/base/permission.ts
+++ b/shared/src/types/base/permission.ts
@@ -1,16 +1,17 @@
 import { z } from 'zod'
-import { BaseModel } from './common'
+import { SequelizeTimestamps } from './common'
 
 export enum PermissionType {
   Answerer = 'answerer',
   Admin = 'admin',
 }
 
-// Permission table has no id
-export const Permission = BaseModel.extend({
+// Permission table has no id, so extend from
+// Timestamps instead of BaseModel
+export const Permission = SequelizeTimestamps.extend({
   role: z.nativeEnum(PermissionType),
   tagId: z.number(),
   userId: z.number(),
-}).omit({ id: true })
+})
 
 export type Permission = z.infer<typeof Permission>

--- a/shared/src/types/base/permission.ts
+++ b/shared/src/types/base/permission.ts
@@ -1,15 +1,16 @@
 import { z } from 'zod'
+import { BaseModel } from './common'
 
 export enum PermissionType {
   Answerer = 'answerer',
   Admin = 'admin',
 }
 
-// no BaseModel as Permission table has no id
-export const Permission = z.object({
+// Permission table has no id
+export const Permission = BaseModel.extend({
   role: z.nativeEnum(PermissionType),
   tagId: z.number(),
   userId: z.number(),
-})
+}).omit({ id: true })
 
 export type Permission = z.infer<typeof Permission>

--- a/shared/src/types/base/permission.ts
+++ b/shared/src/types/base/permission.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { SequelizeTimestamps } from './common'
+import { HasSequelizeTimestamps } from './common'
 
 export enum PermissionType {
   Answerer = 'answerer',
@@ -8,7 +8,7 @@ export enum PermissionType {
 
 // Permission table has no id, so extend from
 // Timestamps instead of BaseModel
-export const Permission = SequelizeTimestamps.extend({
+export const Permission = HasSequelizeTimestamps.extend({
   role: z.nativeEnum(PermissionType),
   tagId: z.number(),
   userId: z.number(),

--- a/shared/src/types/base/user.ts
+++ b/shared/src/types/base/user.ts
@@ -5,6 +5,7 @@ export const User = BaseModel.extend({
   username: z.string(),
   displayname: z.string(),
   views: z.number().nonnegative(),
+  agencyId: z.number(),
 })
 
 export type User = z.infer<typeof User>


### PR DESCRIPTION
Creates shared types between frontend and backend for authentication endpoints.

Part of #218 
Depends on #297 