### PR TITLE
fix(test): ensure Jest types are imported

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "./build/index.js",
   "scripts": {
     "start": "node -r tsconfig-paths/register ./build/index.js",
-    "build": "tsc -b",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "ts-node-dev -r tsconfig-paths/register --respawn --transpile-only --inspect --watch ../shared/src -- ./src/index.ts",
     "test": "jest",
     "lint": "eslint . --quiet --fix --ext '.ts'",

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/__tests__/",
+    "**/__mocks__/"
+  ]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,7 +19,6 @@
   "include": [
     "src"
   ],
-  "exclude": ["**/__tests__/"],
   "references": [
     { "path": "../shared" }
   ],


### PR DESCRIPTION
## Problem

Closes #313

## Solution

Extract a separate `tsconfig.build.json` for building the backend. `tsconfig` applies to the whole project (including tests), whereas `tsconfig.build.json` applies only to build files.