### PR TITLE
refactor(agency): use shared types, dep injection for service

### DIFF
--- a/server/src/bootstrap/config/datadog.ts
+++ b/server/src/bootstrap/config/datadog.ts
@@ -1,5 +1,6 @@
 import convict, { Schema } from 'convict'
 import { readFileSync } from 'fs'
+import { baseConfig, Environment } from './base'
 
 function getInstanceId() {
   let instanceId = 'i-unknown'
@@ -8,8 +9,10 @@ function getInstanceId() {
     // found in cloud-init hosts, including EC2 instances
     instanceId = readFileSync('/var/lib/cloud/data/instance-id', 'utf-8')
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error)
+    if (baseConfig.nodeEnv === Environment.Prod) {
+      // eslint-disable-next-line no-console
+      console.error(error)
+    }
   } finally {
     // For safety, interpolate into another string and trim whitespace
     return `${instanceId}`.trim()

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -83,7 +83,7 @@ const mailOptions = {
 }
 const transport = createTransport(mailOptions)
 
-const agencyService = new AgencyService()
+const agencyService = new AgencyService({ Agency })
 const authService = new AuthService({ emailValidator, jwtSecret })
 const authMiddleware = new AuthMiddleware({ jwtSecret })
 const mailService = new MailService({

--- a/server/src/modules/agency/__tests__/agency.controller.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.controller.spec.ts
@@ -1,0 +1,105 @@
+import express from 'express'
+import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { AgencyController } from '../agency.controller'
+
+describe('AgencyController', () => {
+  const agency = {
+    id: 1,
+    shortname: 'was',
+    longname: 'Work Allocation Singapore',
+    email: 'enquiries@was.gov.sg',
+    logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+  }
+  const agencyService = {
+    findOneByName: jest.fn(),
+    findOneById: jest.fn(),
+  }
+  const agencyController = new AgencyController({ agencyService })
+
+  const app = express()
+  app.get('/', agencyController.getSingleAgency)
+  app.get('/:agencyId', agencyController.getSingleAgencyById)
+  const request = supertest(app)
+
+  beforeEach(() => {
+    agencyService.findOneByName.mockReset()
+    agencyService.findOneById.mockReset()
+    agencyService.findOneByName.mockReturnValue(agency)
+    agencyService.findOneById.mockReturnValue(agency)
+  })
+  describe('getSingleAgency', () => {
+    it('returns OK on valid query', async () => {
+      const { shortname, longname } = agency
+
+      const response = await request.get('/').query({ shortname, longname })
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(agency)
+      expect(agencyService.findOneByName).toHaveBeenCalledWith({
+        shortname,
+        longname,
+      })
+    })
+
+    it('returns NOT_FOUND on invalid query', async () => {
+      const { shortname, longname } = agency
+      agencyService.findOneByName.mockReturnValue(null)
+
+      const response = await request.get('/').query({ shortname, longname })
+
+      expect(response.status).toEqual(StatusCodes.NOT_FOUND)
+      expect(response.body).toStrictEqual({ message: 'Agency not found' })
+      expect(agencyService.findOneByName).toHaveBeenCalledWith({
+        shortname,
+        longname,
+      })
+    })
+
+    it('returns INTERNAL_SERVER_ERROR on bad service', async () => {
+      const { shortname, longname } = agency
+      agencyService.findOneByName.mockRejectedValue(new Error())
+
+      const response = await request.get('/').query({ shortname, longname })
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(agencyService.findOneByName).toHaveBeenCalledWith({
+        shortname,
+        longname,
+      })
+    })
+  })
+
+  describe('getSingleAgencyById', () => {
+    it('returns OK on valid query', async () => {
+      const id = `${agency.id}`
+
+      const response = await request.get(`/${id}`)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(agency)
+      expect(agencyService.findOneById).toHaveBeenCalledWith(id)
+    })
+
+    it('returns NOT_FOUND on invalid query', async () => {
+      const id = `${agency.id}`
+      agencyService.findOneById.mockReturnValue(null)
+
+      const response = await request.get(`/${id}`)
+
+      expect(response.status).toEqual(StatusCodes.NOT_FOUND)
+      expect(response.body).toStrictEqual({ message: 'Agency not found' })
+      expect(agencyService.findOneById).toHaveBeenCalledWith(id)
+    })
+
+    it('returns INTERNAL_SERVER_ERROR on bad service', async () => {
+      const id = `${agency.id}`
+      agencyService.findOneById.mockRejectedValue(new Error())
+
+      const response = await request.get(`/${id}`)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(agencyService.findOneById).toHaveBeenCalledWith(id)
+    })
+  })
+})

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -1,0 +1,69 @@
+import { routeAgencies } from '../agency.routes'
+import { AgencyService } from '../agency.service'
+import { AgencyController } from '../agency.controller'
+import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import { Sequelize, Model } from 'sequelize'
+import { Agency } from '~shared/types/base'
+import { ModelDef } from '../../../types/sequelize'
+import express from 'express'
+import supertest, { SuperTest, Test } from 'supertest'
+import { StatusCodes } from 'http-status-codes'
+
+describe('/agencies', () => {
+  const path = '/agencies'
+  let agency: Agency &
+    Model<Agency, Omit<Agency, 'updatedAt' | 'createdAt' | 'id'>>
+  let db: Sequelize
+  let Agency: ModelDef<Agency>
+
+  let request: SuperTest<Test>
+
+  beforeAll(async () => {
+    db = await createTestDatabase()
+    Agency = getModel<Agency & Model>(db, ModelName.Agency)
+    agency = await Agency.create({
+      shortname: 'was',
+      longname: 'Work Allocation Singapore',
+      email: 'enquiries@was.gov.sg',
+      logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+    })
+    const agencyService = new AgencyService({ Agency })
+    const controller = new AgencyController({ agencyService })
+    const router = routeAgencies({ controller })
+    const app = express()
+    app.use(path, router)
+    request = supertest(app)
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  describe('?shortname=<shortname>&longname=<longname>', () => {
+    it('returns agency by name', async () => {
+      const { shortname, longname } = agency
+      const response = await request.get(path).query({ shortname, longname })
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        ...agency.get(),
+        createdAt: `${(agency.createdAt as Date).toISOString()}`,
+        updatedAt: `${(agency.updatedAt as Date).toISOString()}`,
+      })
+    })
+  })
+
+  describe(`/:agencyId`, () => {
+    it('returns agency by id', async () => {
+      const { id } = agency
+      const response = await request.get(`${path}/${id}`)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        ...agency.get(),
+        createdAt: `${(agency.createdAt as Date).toISOString()}`,
+        updatedAt: `${(agency.updatedAt as Date).toISOString()}`,
+      })
+    })
+  })
+})

--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -1,0 +1,67 @@
+import { AgencyService } from '../agency.service'
+import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import { Sequelize, Model } from 'sequelize'
+import { Agency } from '~shared/types/base'
+import { ModelDef } from '../../../types/sequelize'
+
+describe('AgencyService', () => {
+  let agency: Agency
+
+  let db: Sequelize
+  let Agency: ModelDef<Agency>
+  let service: AgencyService
+  beforeAll(async () => {
+    db = await createTestDatabase()
+    Agency = getModel<Agency & Model>(db, ModelName.Agency)
+    agency = await Agency.create({
+      shortname: 'was',
+      longname: 'Work Allocation Singapore',
+      email: 'enquiries@was.gov.sg',
+      logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+    })
+    service = new AgencyService({ Agency })
+  })
+
+  afterAll(async () => {
+    await db.close()
+  })
+
+  const expectAgencyMatch = (actualAgency: Agency | null, agency: Agency) => {
+    expect(actualAgency?.id).toEqual(agency.id)
+    expect(actualAgency?.shortname).toEqual(agency.shortname)
+    expect(actualAgency?.longname).toEqual(agency.longname)
+    expect(actualAgency?.email).toEqual(agency.email)
+    expect(actualAgency?.logo).toEqual(agency.logo)
+  }
+
+  describe('findOneByName', () => {
+    it('returns agency on existing shortname', async () => {
+      const { shortname } = agency
+      const actualAgency = await service.findOneByName({ shortname })
+      expectAgencyMatch(actualAgency, agency)
+    })
+    it('returns agency on existing longname', async () => {
+      const { longname } = agency
+      const actualAgency = await service.findOneByName({ longname })
+      expectAgencyMatch(actualAgency, agency)
+    })
+    it('returns null on non-existing shortname', async () => {
+      const shortname = 'non-existing'
+      const actualAgency = await service.findOneByName({ shortname })
+      expect(actualAgency).toBeNull()
+    })
+  })
+
+  describe('findOneById', () => {
+    it('returns agency on existing id', async () => {
+      const { id } = agency
+      const actualAgency = await service.findOneById(id)
+      expectAgencyMatch(actualAgency, agency)
+    })
+    it('returns null on non-existing shortname', async () => {
+      const id = agency.id + 20
+      const actualAgency = await service.findOneById(id)
+      expect(actualAgency).toBeNull()
+    })
+  })
+})

--- a/server/src/modules/agency/agency.controller.ts
+++ b/server/src/modules/agency/agency.controller.ts
@@ -1,5 +1,5 @@
 import { AgencyService } from './agency.service'
-import { Agency } from '../../models/agencies.model'
+import { Agency } from '~shared/types/base'
 import { Message } from '../../types/message-type'
 import { AgencyQuery } from '../../types/agency-type'
 import { createLogger } from '../../bootstrap/logging'
@@ -29,7 +29,7 @@ export class AgencyController {
     AgencyQuery
   > = async (req, res) => {
     try {
-      const data = await this.agencyService.findOneByShortName(req.query)
+      const data = await this.agencyService.findOneByName(req.query)
       if (!data) {
         return res
           .status(StatusCodes.NOT_FOUND)

--- a/server/src/modules/agency/agency.service.ts
+++ b/server/src/modules/agency/agency.service.ts
@@ -1,24 +1,23 @@
-import { Agency } from '../../bootstrap/sequelize'
-import { Agency as AgencyType } from '../../models/agencies.model'
+import { ModelDef } from '../../types/sequelize'
+import { Agency } from '~shared/types/base'
 import { AgencyQuery } from '../../types/agency-type'
-
 export class AgencyService {
+  private Agency: ModelDef<Agency>
+
+  constructor({ Agency }: { Agency: ModelDef<Agency> }) {
+    this.Agency = Agency
+  }
+
   /**
    * Find an agency by their shortname or longname
    * @param query agency's shortname or longname
    * @returns agency if found, else null
    */
-  findOneByShortName = async (
-    query: AgencyQuery,
-  ): Promise<AgencyType | null> => {
-    const agency = await Agency.findOne({
+  findOneByName = async (query: AgencyQuery): Promise<Agency | null> => {
+    const agency = await this.Agency.findOne({
       where: query,
     })
-    if (!agency) {
-      return null
-    } else {
-      return agency
-    }
+    return agency ?? null
   }
 
   /**
@@ -28,14 +27,10 @@ export class AgencyService {
    * @param agencyId Agency's id
    * @returns agency if found, else null
    */
-  findOneById = async (agencyId: number): Promise<AgencyType | null> => {
-    const agency = await Agency.findOne({
+  findOneById = async (agencyId: number): Promise<Agency | null> => {
+    const agency = await this.Agency.findOne({
       where: { id: agencyId },
     })
-    if (!agency) {
-      return null
-    } else {
-      return agency
-    }
+    return agency ?? null
   }
 }

--- a/server/src/types/sequelize.ts
+++ b/server/src/types/sequelize.ts
@@ -1,0 +1,3 @@
+import { Model, ModelCtor } from 'sequelize'
+
+export type ModelDef<M, C = M> = ModelCtor<Model<M, C> & M>

--- a/server/src/types/sequelize.ts
+++ b/server/src/types/sequelize.ts
@@ -1,3 +1,6 @@
 import { Model, ModelCtor } from 'sequelize'
 
-export type ModelDef<M, C = M> = ModelCtor<Model<M, C> & M>
+export type ModelDef<
+  M,
+  C = Omit<M, 'createdAt' | 'updatedAt' | 'id'>,
+> = ModelCtor<Model<M, C> & M>


### PR DESCRIPTION
## Problem

The agency module currently does not have test coverage and does not use 
shared types. Its service also does not use dep injection for its models.

## Solution

- Create a custom definition for sequelize models since standard ones
  are not quite accurate. More precisely, a Model<M> will have
  properties of M as well as Model, but this is not declared so.
- Rework AgencyService so that the Sequelize model is injected rather
  than imported. Take care to use the new imported types to avoid
  returning Sequelize objects to callers
- Adjust AgencyController and bootstrap to account for changes
- Provide test coverage for the module
- Take the opportunity to only log failure to get instance-id in prod