### PR TITLE
fix(datadog): avoid path tagging and arbitrary no. of values thereof

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -143,7 +143,7 @@ if (baseConfig.nodeEnv === Environment.Prod) {
     connectDatadog({
       response_code: true,
       tags: [`service:${datadogConfig.service}`, `env:${datadogConfig.env}`],
-      path: true,
+      path: false,
       dogstatsd: new StatsD({
         useDefaultRoute: true,
         errorHandler: (error) => {


### PR DESCRIPTION
## Problem and Solution

Datadog can only deal with so many possible values for tags. Avoid having too many of these
by not tagging by path, instead relying on tagging by the more coarse-grained route.

Derived from opengovsg/formsg#2824