### PR TITLE
feat(breakpoints): add custom breakpoints based on design system

### DIFF
--- a/client/src/theme/breakpoints.ts
+++ b/client/src/theme/breakpoints.ts
@@ -1,0 +1,7 @@
+export const breakpoints = {
+  xs: '360px',
+  sm: '480px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1440px',
+}

--- a/client/src/theme/index.ts
+++ b/client/src/theme/index.ts
@@ -3,9 +3,11 @@ import { extendTheme } from '@chakra-ui/react'
 import { components } from './components'
 import { colors } from './colors'
 import { textStyles } from './textStyles'
+import { breakpoints } from './breakpoints'
 
 export const theme = extendTheme({
   components,
   colors,
   textStyles,
+  breakpoints,
 })


### PR DESCRIPTION
## Problem

Breakpoints were not specified according to the specifications in the [AskGov Design System document](https://www.figma.com/file/yATTXTZ5Goy9XDy5qooSO3/AskGov-Design-System?node-id=3527%3A8037).

## Solution

Add respective custom breakpoints specifications and extend the theme. Note that mobile view is size `xs` and below (so 479px and below). For more information on breakpoints customisation, refer to: https://chakra-ui.com/docs/features/responsive-styles.

## Tests

Change display size and check if content on display is expected.