### PR TITLE
fix(bootstrap): send index.html with express.static

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -168,11 +168,12 @@ if (baseConfig.nodeEnv === Environment.Prod) {
     express.static(path.resolve(__dirname, '../../..', 'client', 'build')),
   )
 
-  app.get('*', (_req, res) => {
-    res.sendFile(
+  app.get(
+    '*',
+    express.static(
       path.resolve(__dirname, '../../..', 'client', 'build', 'index.html'),
-    )
-  })
+    ),
+  )
 }
 
 export default app


### PR DESCRIPTION
## Problem

The backend currently serves index.html using `Response.sendFile()`, 
which incurs a file read with each request. Due to lack of rate-limiting,
this exposes us to a possible DoS by sending multiple requests to 
overwhelm the filesystem.

## Solution

Avoid reading the file repeatedly by using express.static to read the
file just once at runtime, and serve it from in-memory
