### PR TITLE
feat(breakpoints): add breakpoints for devices

### DIFF
--- a/client/src/theme/breakpoints.ts
+++ b/client/src/theme/breakpoints.ts
@@ -1,7 +1,13 @@
+// Note the following breakpoints for different devices:
+// - mobile: 479px and below
+// - tablet: 480-1439px
+// - desktop: 1440px and above
 export const breakpoints = {
   xs: '360px',
   sm: '480px',
   md: '768px',
   lg: '1024px',
   xl: '1440px',
+  tablet: '480px', // should be same as sm
+  desktop: '1440px', // should be same as xl
 }


### PR DESCRIPTION
Added breakpoints for devices so specifications for mobile, table and desktop can be simply added
with: `{ base: <specs for mobile>, tablet: <specs for tablet>, desktop: <specs for desktop> }`

## Problem

The granular breakpoints for `xs`, `sm`, `md`, `lg` and `xl` are not very meaningful when development is centred around devices instead of those specific sizes.

## Solution

Add breakpoint specifications for `tablet` and `desktop` so development centred around devices will be easier and more readable.

To use code for specifications for different devices, simply use the following: `{ base: <specs for mobile>, tablet: <specs for tablet>, desktop: <specs for desktop> }`. For usage examples: https://chakra-ui.com/docs/features/responsive-styles

## Tests

Change display size and check if content on display is expected.
