### PR TITLE
fix(post): appease CodeQL by assigning tags.length to variable

### DIFF
--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -340,12 +340,13 @@ export class PostService {
     // with a question
 
     // get only the IDs we need via filtering
+    const tagsLength = tags?.length ?? 0
     const postsToMap =
-      tags && tags.length > 0
+      tagsLength > 0
         ? // filter posts further to contain ALL of the wanted tags from ANY of the tags
           // since posts are already filtered for ANY of the wanted tags
           // sufficient to filter posts that contain the same number of tags as wanted tags
-          posts.filter((posts) => posts.tags.length == tags.length)
+          posts.filter((posts) => posts.tags.length == tagsLength)
         : posts
     const filteredPostIds = postsToMap.map(({ id }) => id)
 


### PR DESCRIPTION
## Problem and Solution

CodeQL is somehow complaining that the `tags` query parameter can be confused to be a string, rather than an array. This is odd, given that RequestHandler already types it as a `string[]` (and even though CodeQL is unable to realise it, we have express-validator to sanitise the input).

To appease CodeQL, try to assign the length of the tags array to a variable.