### PR TITLE
fix(breakpoints): specify in em, not px

### DIFF
--- a/client/src/theme/breakpoints.ts
+++ b/client/src/theme/breakpoints.ts
@@ -1,7 +1,9 @@
-export const breakpoints = {
+import { createBreakpoints } from '@chakra-ui/theme-tools'
+
+export const breakpoints = createBreakpoints({
   xs: '22.5em',
   sm: '30em',
   md: '48em',
   lg: '64em',
   xl: '90em',
-}
+})

--- a/client/src/theme/breakpoints.ts
+++ b/client/src/theme/breakpoints.ts
@@ -1,7 +1,7 @@
 export const breakpoints = {
-  xs: '360px',
-  sm: '480px',
-  md: '768px',
-  lg: '1024px',
-  xl: '1440px',
+  xs: '22.5em',
+  sm: '30em',
+  md: '48em',
+  lg: '64em',
+  xl: '90em',
 }


### PR DESCRIPTION
## Problem

Breakpoints specified in px are poorly handled by Chakra, which is unable to reconcile them against its own default breakpoints, specified in em. This triggers chakra-ui/chakra-ui#3042, and causes dependents (notably the boolean flag that chooses which pagination widget to use) to oscillate.

## Solution

Port opengovsg/formsg@54b9175 to avoid the abovementioned bug

### Screen Recordings

#### Before

https://user-images.githubusercontent.com/10572368/134842304-3c409cfb-3756-4953-a043-86284bfed76b.mov

#### After

https://user-images.githubusercontent.com/10572368/134842273-f8e13101-d221-4d8e-b8fa-405a7a9f2014.mov


