### PR TITLE
Feat/neverthrow agency

### DIFF
--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -3,6 +3,7 @@ import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
 import { Sequelize, Model } from 'sequelize'
 import { Agency } from '~shared/types/base'
 import { ModelDef } from '../../../types/sequelize'
+import { MissingAgencyError } from '../agency.errors'
 
 describe('AgencyService', () => {
   let agency: Agency
@@ -38,17 +39,17 @@ describe('AgencyService', () => {
     it('returns agency on existing shortname', async () => {
       const { shortname } = agency
       const actualAgency = await service.findOneByName({ shortname })
-      expectAgencyMatch(actualAgency, agency)
+      expectAgencyMatch(actualAgency._unsafeUnwrap(), agency)
     })
     it('returns agency on existing longname', async () => {
       const { longname } = agency
       const actualAgency = await service.findOneByName({ longname })
-      expectAgencyMatch(actualAgency, agency)
+      expectAgencyMatch(actualAgency._unsafeUnwrap(), agency)
     })
-    it('returns null on non-existing shortname', async () => {
+    it('returns MissingAgencyError on non-existing shortname', async () => {
       const shortname = 'non-existing'
       const actualAgency = await service.findOneByName({ shortname })
-      expect(actualAgency).toBeNull()
+      expect(actualAgency._unsafeUnwrapErr()).toEqual(new MissingAgencyError())
     })
   })
 
@@ -56,12 +57,12 @@ describe('AgencyService', () => {
     it('returns agency on existing id', async () => {
       const { id } = agency
       const actualAgency = await service.findOneById(id)
-      expectAgencyMatch(actualAgency, agency)
+      expectAgencyMatch(actualAgency._unsafeUnwrap(), agency)
     })
-    it('returns null on non-existing shortname', async () => {
+    it('returns MissingAgencyError on non-existing shortname', async () => {
       const id = agency.id + 20
       const actualAgency = await service.findOneById(id)
-      expect(actualAgency).toBeNull()
+      expect(actualAgency._unsafeUnwrapErr()).toEqual(new MissingAgencyError())
     })
   })
 })

--- a/server/src/modules/agency/agency.controller.ts
+++ b/server/src/modules/agency/agency.controller.ts
@@ -29,24 +29,20 @@ export class AgencyController {
     undefined,
     AgencyQuery
   > = async (req, res) => {
-    try {
-      const data = await this.agencyService.findOneByName(req.query)
-      if (!data) {
-        return res
-          .status(StatusCodes.NOT_FOUND)
-          .json({ message: 'Agency not found' })
-      }
-      return res.status(StatusCodes.OK).json(data)
-    } catch (error) {
-      logger.error({
-        message: 'Error while retrieving single agency by name',
-        meta: {
-          function: 'getSingleAgency',
-        },
-        error,
+    return this.agencyService
+      .findOneByName(req.query)
+      .map((data) => res.status(StatusCodes.OK).json(data))
+      .mapErr((error) => {
+        if (error.constructor === MissingAgencyError) {
+          return res
+            .status(StatusCodes.NOT_FOUND)
+            .json({ message: error.message })
+        } else {
+          return res
+            .status(StatusCodes.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Something went wrong. Please try again.' })
+        }
       })
-      return res.sendStatus(StatusCodes.INTERNAL_SERVER_ERROR)
-    }
   }
 
   /**

--- a/server/src/modules/agency/agency.controller.ts
+++ b/server/src/modules/agency/agency.controller.ts
@@ -4,8 +4,6 @@ import { Message } from '../../types/message-type'
 import { AgencyQuery } from '../../types/agency-type'
 import { StatusCodes } from 'http-status-codes'
 import { ControllerHandler } from '../../types/response-handler'
-import { MissingAgencyError } from './agency.errors'
-
 export class AgencyController {
   private agencyService: Public<AgencyService>
 
@@ -30,15 +28,7 @@ export class AgencyController {
       .findOneByName(req.query)
       .map((data) => res.status(StatusCodes.OK).json(data))
       .mapErr((error) => {
-        if (error.constructor === MissingAgencyError) {
-          return res
-            .status(StatusCodes.NOT_FOUND)
-            .json({ message: error.message })
-        } else {
-          return res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Something went wrong. Please try again.' })
-        }
+        return res.status(error.statusCode).json({ message: error.message })
       })
   }
 
@@ -58,15 +48,7 @@ export class AgencyController {
       .findOneById(agencyId)
       .map((data) => res.status(StatusCodes.OK).json(data))
       .mapErr((error) => {
-        if (error.constructor === MissingAgencyError) {
-          return res
-            .status(StatusCodes.NOT_FOUND)
-            .json({ message: error.message })
-        } else {
-          return res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Something went wrong. Please try again.' })
-        }
+        return res.status(error.statusCode).json({ message: error.message })
       })
   }
 }

--- a/server/src/modules/agency/agency.controller.ts
+++ b/server/src/modules/agency/agency.controller.ts
@@ -2,12 +2,9 @@ import { AgencyService } from './agency.service'
 import { Agency } from '~shared/types/base'
 import { Message } from '../../types/message-type'
 import { AgencyQuery } from '../../types/agency-type'
-import { createLogger } from '../../bootstrap/logging'
 import { StatusCodes } from 'http-status-codes'
 import { ControllerHandler } from '../../types/response-handler'
 import { MissingAgencyError } from './agency.errors'
-
-const logger = createLogger(module)
 
 export class AgencyController {
   private agencyService: Public<AgencyService>

--- a/server/src/modules/agency/agency.errors.ts
+++ b/server/src/modules/agency/agency.errors.ts
@@ -1,7 +1,11 @@
 import { ApplicationError } from '../core/core.errors'
+import { StatusCodes } from 'http-status-codes'
 
 export class MissingAgencyError extends ApplicationError {
-  constructor(message = 'Agency not found') {
-    super(message)
+  constructor(
+    message = 'Agency not found',
+    statusCode = StatusCodes.NOT_FOUND,
+  ) {
+    super(message, statusCode)
   }
 }

--- a/server/src/modules/agency/agency.errors.ts
+++ b/server/src/modules/agency/agency.errors.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from '../core/core.errors'
+
+export class MissingAgencyError extends ApplicationError {
+  constructor(message = 'Agency not found') {
+    super(message)
+  }
+}

--- a/server/src/modules/agency/agency.service.ts
+++ b/server/src/modules/agency/agency.service.ts
@@ -65,7 +65,7 @@ export class AgencyService {
       }),
       (error) => {
         logger.error({
-          message: 'Database find agency error',
+          message: 'Database error while retrieving single agency by id',
           meta: {
             function: 'findOneById',
             agencyId,

--- a/server/src/modules/agency/agency.service.ts
+++ b/server/src/modules/agency/agency.service.ts
@@ -1,6 +1,12 @@
 import { ModelDef } from '../../types/sequelize'
 import { Agency } from '~shared/types/base'
 import { AgencyQuery } from '../../types/agency-type'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { createLogger } from '../../bootstrap/logging'
+import { MissingAgencyError } from './agency.errors'
+import { DatabaseError } from '../core/core.errors'
+
+const logger = createLogger(module)
 export class AgencyService {
   private Agency: ModelDef<Agency>
 
@@ -25,12 +31,33 @@ export class AgencyService {
    * tried integrating into one function but params can't tell
    * the diff between string or number
    * @param agencyId Agency's id
-   * @returns agency if found, else null
+   * @returns ok(agency) if retrieval is successful
+   * @returns err(DatabaseError) if database errors occurs whilst retrieving agency
+   * @returns err(MissingAgencyError) if agency does not exist in the database
    */
-  findOneById = async (agencyId: number): Promise<Agency | null> => {
-    const agency = await this.Agency.findOne({
-      where: { id: agencyId },
+  findOneById = (
+    agencyId: number,
+  ): ResultAsync<Agency, DatabaseError | MissingAgencyError> => {
+    return ResultAsync.fromPromise(
+      this.Agency.findOne({
+        where: { id: agencyId },
+      }),
+      (error) => {
+        logger.error({
+          message: 'Database find agency error',
+          meta: {
+            function: 'findOneById',
+            agencyId,
+          },
+          error,
+        })
+        return new DatabaseError()
+      },
+    ).andThen((agency) => {
+      if (!agency) {
+        return errAsync(new MissingAgencyError())
+      }
+      return okAsync(agency)
     })
-    return agency ?? null
   }
 }

--- a/server/src/modules/core/core.errors.ts
+++ b/server/src/modules/core/core.errors.ts
@@ -1,14 +1,12 @@
+import { StatusCodes } from 'http-status-codes'
+
 /**
- * A custom base error class that encapsulates the name, message, status code,
- * and logging meta string (if any) for the error.
+ * A custom base error class that encapsulates the name, message and status code
  */
 export class ApplicationError extends Error {
-  /**
-   * Meta object to be logged by the application logger, if any.
-   */
-  meta?: unknown
+  statusCode: StatusCodes
 
-  constructor(message?: string, meta?: unknown) {
+  constructor(message?: string, statusCode?: StatusCodes) {
     super()
 
     Error.captureStackTrace(this, this.constructor)
@@ -17,7 +15,7 @@ export class ApplicationError extends Error {
 
     this.message = message || 'Something went wrong. Please try again.'
 
-    this.meta = meta
+    this.statusCode = statusCode || StatusCodes.INTERNAL_SERVER_ERROR
   }
 }
 
@@ -25,7 +23,10 @@ export class ApplicationError extends Error {
  * Error thrown when database query fails
  */
 export class DatabaseError extends ApplicationError {
-  constructor(message?: string) {
-    super(message)
+  constructor(
+    message?: string,
+    statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
+  ) {
+    super(message, statusCode)
   }
 }

--- a/server/src/modules/core/core.errors.ts
+++ b/server/src/modules/core/core.errors.ts
@@ -1,0 +1,31 @@
+/**
+ * A custom base error class that encapsulates the name, message, status code,
+ * and logging meta string (if any) for the error.
+ */
+export class ApplicationError extends Error {
+  /**
+   * Meta object to be logged by the application logger, if any.
+   */
+  meta?: unknown
+
+  constructor(message?: string, meta?: unknown) {
+    super()
+
+    Error.captureStackTrace(this, this.constructor)
+
+    this.name = this.constructor.name
+
+    this.message = message || 'Something went wrong. Please try again.'
+
+    this.meta = meta
+  }
+}
+
+/**
+ * Error thrown when database query fails
+ */
+export class DatabaseError extends ApplicationError {
+  constructor(message?: string) {
+    super(message)
+  }
+}


### PR DESCRIPTION
## Problem

Use of `try...catch` for error handling is [not type-safe](https://www.codementor.io/@supermacro/type-safe-error-handling-in-typescript-1bp40rs502). Hence we need to gradually migrate to [neverthrow](https://github.com/supermacro/neverthrow#top-level-api).

## Solution

- Introduce `neverthrow` to the agency module
- Introduce `ApplicationError` class and extend it to create appropriate error classes
- Fix tests with the use of `_unsafeUnwrap` and `_unsafeUnwrapErr`

## Tests

Current test suite should pass

## Deploy Notes

None