### PR TITLE
feat(enquiries): allow agencies to refuse, providing message instead

### DIFF
--- a/client/src/components/CitizenRequest/CitizenRequest.component.tsx
+++ b/client/src/components/CitizenRequest/CitizenRequest.component.tsx
@@ -1,11 +1,24 @@
-import { Button, Flex, Text, useDisclosure } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
+import * as FullStory from '@fullstory/browser'
 import { getApiErrorMessage } from '../../api'
+import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import { Agency } from '../../services/AgencyService'
 import { Enquiry, Mail, postMail } from '../../services/MailService'
 import { EnquiryModal } from '../EnquiryModal/EnquiryModal.component'
+import { RichTextPreview } from '../RichText/RichTextEditor.component'
 import { useStyledToast } from '../StyledToast/StyledToast'
-import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
-import * as FullStory from '@fullstory/browser'
 
 const CitizenRequest = ({ agency }: { agency?: Agency }): JSX.Element => {
   const toast = useStyledToast()
@@ -77,14 +90,36 @@ const CitizenRequest = ({ agency }: { agency?: Agency }): JSX.Element => {
         color="white"
         onClick={onClick}
       >
-        Submit an enquiry
+        {agency?.noEnquiriesMessage ? 'More information' : 'Submit an enquiry'}
       </Button>
       <EnquiryModal
-        isOpen={isEnquiryModalOpen}
+        isOpen={!Boolean(agency?.noEnquiriesMessage) && isEnquiryModalOpen}
         onClose={onEnquiryModalClose}
         onConfirm={onPostConfirm}
         agency={agency}
       />
+      <Modal
+        isOpen={Boolean(agency?.noEnquiriesMessage) && isEnquiryModalOpen}
+        onClose={onEnquiryModalClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>More information</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <RichTextPreview
+              value={
+                agency?.noEnquiriesMessage ||
+                `${agency?.longname} does not accept enquiries via AskGov`
+              }
+            />
+          </ModalBody>
+
+          <ModalFooter>
+            <Button onClick={onEnquiryModalClose}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </Flex>
   )
 }

--- a/client/src/services/AgencyService.ts
+++ b/client/src/services/AgencyService.ts
@@ -1,12 +1,7 @@
+import { Agency } from '~shared/types/base'
 import { ApiClient } from '../api'
 
-export type Agency = {
-  id: number
-  email: string
-  shortname: string
-  longname: string
-  logo: string
-}
+export { Agency } from '~shared/types/base'
 
 export type AgencyQuery = {
   shortname: string

--- a/server/migrations/20210928050658-add-no-enquiries-to-agency.js
+++ b/server/migrations/20210928050658-add-no-enquiries-to-agency.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.addColumn('agencies', 'noEnquiriesMessage', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface) => {
+    queryInterface.removeColumn('agencies', 'noEnquiriesMessage')
+  },
+}

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -33,6 +33,10 @@ export const defineAgency = (
         isUrl: true,
       },
     },
+    noEnquiriesMessage: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
   })
   // Define associations for Agency
   Agency.hasMany(User)

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -26,6 +26,7 @@ describe('/agencies', () => {
       longname: 'Work Allocation Singapore',
       email: 'enquiries@was.gov.sg',
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+      noEnquiriesMessage: null,
     })
     const agencyService = new AgencyService({ Agency })
     const controller = new AgencyController({ agencyService })

--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -18,6 +18,7 @@ describe('AgencyService', () => {
       longname: 'Work Allocation Singapore',
       email: 'enquiries@was.gov.sg',
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+      noEnquiriesMessage: null,
     })
     service = new AgencyService({ Agency })
   })

--- a/shared/src/types/base/agency.ts
+++ b/shared/src/types/base/agency.ts
@@ -6,6 +6,7 @@ export const Agency = BaseModel.extend({
   longname: z.string(),
   email: z.string(),
   logo: z.string(),
+  noEnquiriesMessage: z.string().nullable(),
 })
 
 export type Agency = z.infer<typeof Agency>


### PR DESCRIPTION
## Problem and Solution
Some agencies are unable to handle enquiries coming in from AskGov, so provide them with the means to direct them elsewhere

- add `noEnquiriesMessage` to agencies shared type
  - define corresponding column in sequelize, migration script
- have AgencyService use shared type instead of defining its own
- if `noEnquiriesMessage` defined, present a simple text modal bearing
  the message instead of the EnquiryModal
