### PR TITLE
feat(seo): update page titles according to agency

### DIFF
--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -11,12 +11,13 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
-import { BiChevronUp, BiChevronDown } from 'react-icons/bi'
+import { BiChevronDown, BiChevronUp } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { useLocation, useParams } from 'react-router-dom'
 import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import OfficerDashboardComponent from '../../components/OfficerDashboard/OfficerDashboard.component'
+import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostQuestionButton from '../../components/PostQuestionButton/PostQuestionButton.component'
 import QuestionsListComponent from '../../components/QuestionsList/QuestionsList.component'
 import SearchBoxComponent from '../../components/SearchBox/SearchBox.component'
@@ -58,8 +59,10 @@ const HomePage = ({ match }) => {
 
   const agencyAndTags = mergeTags(match.params.agency, queryState)
   const isAuthenticatedOfficer = isUserPublicOfficer(user)
+
   return (
     <Flex direction="column" height="100%" className="home-page">
+      <PageTitle title={`${agency?.shortname.toUpperCase()} FAQ - AskGov`} />
       <Box
         bg="primary.500"
         h={

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -66,7 +66,9 @@ const Post = () => {
     <Spinner centerHeight="200px" />
   ) : (
     <Flex direction="column" height="100%">
-      <PageTitle title={`${post.title} - AskGov`} />
+      <PageTitle
+        title={`${post.title} - ${agencyShortName?.toUpperCase()} FAQ - AskGov`}
+      />
       <Center>
         <Stack
           maxW="1188px"

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -17,7 +17,6 @@ import withPageTitle from './services/withPageTitle'
 
 const HomePageComponent = withPageTitle({
   component: HomePage,
-  title: 'AskGov',
 })
 
 const SearchResultsComponent = withPageTitle({


### PR DESCRIPTION
- dynamically set HomePage and Post page's title when viewing agency

re #401

## Problem

Page title not being reflective of the agency which the page is serving.

Closes #401

## Solution

Dynamically render page title in home and post page components depending on agency.

## Before & After Screenshots

**BEFORE**:

Page title on agency (WAS) home page:

<img width="244" alt="Screenshot 2021-09-29 at 8 38 18 AM" src="https://user-images.githubusercontent.com/37061143/135183824-5fe34c2b-446e-468e-be0e-0902e5e3f0bf.png">

Page title on agency (WAS) post page:

<img width="252" alt="Screenshot 2021-09-29 at 8 38 05 AM" src="https://user-images.githubusercontent.com/37061143/135183827-833a2c21-99ed-41dc-8130-8ec16bd1cd93.png">

**AFTER**:

Page title on agency (WAS) home page:

<img width="246" alt="Screenshot 2021-09-29 at 8 34 43 AM" src="https://user-images.githubusercontent.com/37061143/135183706-e9cfc3a4-ca1c-4a3c-8a4b-143dda854d3c.png">

Page title on agency (WAS) post page:

<img width="251" alt="Screenshot 2021-09-29 at 8 35 57 AM" src="https://user-images.githubusercontent.com/37061143/135183716-ff8a76d2-7383-49d4-9520-36b512fba937.png">

## Tests

1. Navigate to an agency home page and check if the page title includes the agency name.
2. Navigate to an agency post page and check if the page title includes the agency name.
