### PR TITLE
fix(seo): fix title in the case of an undefined agency

### DIFF
--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -62,7 +62,11 @@ const HomePage = ({ match }) => {
 
   return (
     <Flex direction="column" height="100%" className="home-page">
-      <PageTitle title={`${agency?.shortname.toUpperCase()} FAQ - AskGov`} />
+      <PageTitle
+        title={
+          agency ? `${agency?.shortname.toUpperCase()} FAQ - AskGov` : undefined
+        }
+      />
       <Box
         bg="primary.500"
         h={


### PR DESCRIPTION
## Problem

"undefined" was shown as agency name on the page title when the main AskGov page is viewed.

## Solution

Check if agency is defined. If so, update page title to include agency name. If not, use default title by setting `title` property of `PageTitle` as `undefined`.

## Before & After Screenshots

**BEFORE**:

![image](https://user-images.githubusercontent.com/37061143/135188545-5dec4779-1760-491a-9247-f2a9e6bb4075.png)

**AFTER**:

![image](https://user-images.githubusercontent.com/37061143/135189279-77ae1556-9936-4e5d-8859-1400c13c83b3.png)

## Tests

1. Navigate to the main AskGov page and check the page title. It should be the default page title.
2. Navigate to the agency main pages and check the page title. It should be in the format of "<agency name> FAQ - AskGov".
