### PR TITLE
refactor(seo): add width and height to masthead image element

### DIFF
--- a/client/src/components/Masthead/Masthead.component.tsx
+++ b/client/src/components/Masthead/Masthead.component.tsx
@@ -43,7 +43,7 @@ const Masthead: FC = () => {
     <Box bg="secondary.200" px={{ base: '24px', sm: '29px', xl: '33px' }}>
       <Flex direction="row">
         <Center my={mastheadTopMarginY}>
-          <Image src={LionHeadSymbol} />
+          <Image src={LionHeadSymbol} htmlHeight="15.2px" htmlWidth="15.2px" />
           <Text textStyle={mastheadTopTextStyle} color="neutral.900" mx={1}>
             A Singapore Government Agency Website.
           </Text>


### PR DESCRIPTION
## Problem

The masthead logo image element was failing Google PageSpeed Insights diagnostics test as it did not have explicit width and height properties

Closes #392 

## Solution

Set width and height to the masthead logo image element according to [specifications on Figma](https://www.figma.com/file/yATTXTZ5Goy9XDy5qooSO3/AskGov-Design-System?node-id=2142%3A24)


## Before & After Screenshots

**AFTER**:

Web:
![Screenshot 2021-09-29 at 12 36 00 PM](https://user-images.githubusercontent.com/56983748/135204234-32b62719-0e02-4c04-a702-ab06de39bc88.png)

Mobile:
![IMG_0293](https://user-images.githubusercontent.com/56983748/135204555-75fffb60-05ff-4f4d-b0f3-c8a4b38fb7a8.jpg)


## Tests

Run [Google's PageSpeed Insights diagnostics on our site](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fask.gov.sg%2F&tab=mobile). 
For localhost, this can be done through Chrome DevTools > Lighthouse > Generate Report