### PR TITLE
feat(post): reinstate last updated date

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6785,6 +6785,16 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
+    },
+    "date-fns-tz": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.6.tgz",
+      "integrity": "sha512-nyy+URfFI3KUY7udEJozcoftju+KduaqkVfwyTIE0traBiVye09QnyWKLZK7drRr5h9B7sPJITmQnS3U6YOdQg=="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14384,19 +14384,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
-    "moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3853,15 +3853,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-draft-wysiwyg": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/react-draft-wysiwyg/-/react-draft-wysiwyg-1.13.3.tgz",
@@ -3900,18 +3891,6 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
-      }
-    },
-    "@types/react-select": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.18.tgz",
-      "integrity": "sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==",
-      "dev": true,
-      "requires": {
-        "@emotion/serialize": "^1.0.0",
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "@types/react-transition-group": "*"
       }
     },
     "@types/react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,8 @@
     "@testing-library/react": "^12.1.1",
     "@testing-library/user-event": "^13.2.1",
     "axios": "^0.21.4",
+    "date-fns": "^2.24.0",
+    "date-fns-tz": "^1.1.6",
     "downshift": "^6.1.7",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,8 +16,6 @@
     "draftjs-to-html": "^0.9.1",
     "framer-motion": "^4.1.17",
     "fuse.js": "^6.4.6",
-    "moment": "2.29.1",
-    "moment-timezone": "^0.5.33",
     "prop-types": "^15.7.2",
     "query-string": "^7.0.1",
     "react": "^17.0.2",

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -2,6 +2,8 @@ import { Center, Flex, Stack, Spacer, Text, VStack } from '@chakra-ui/layout'
 import { BiArrowBack, BiXCircle } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { Link, useParams, useHistory } from 'react-router-dom'
+import { format, utcToZonedTime } from 'date-fns-tz'
+
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import Spinner from '../../components/Spinner/Spinner.component'
@@ -62,6 +64,11 @@ const Post = () => {
   const isAgencyMember =
     user && post?.tags && hasCommonAgencyTags(user, post?.tags)
 
+  const formattedTimeString = format(
+    utcToZonedTime(post?.updatedAt ?? Date.now()),
+    'dd MMM yyyy HH:mm, zzzz',
+  )
+
   return isLoading ? (
     <Spinner centerHeight="200px" />
   ) : (
@@ -107,9 +114,6 @@ const Post = () => {
                     )
                   })}
                 </div>
-                {/* <div className="post-time">
-                  <time dateTime={post.createdAt}>{post.createdAt} ago</time>
-                </div> */}
                 <ViewCount views={post.views} className="views-info center" />
               </div>
               {post.status === PostStatus.Private ? (
@@ -128,6 +132,11 @@ const Post = () => {
             <div className="question-main">
               <QuestionSection post={post} />
               <AnswerSection post={post} />
+              <div className="post-time">
+                <time dateTime={formattedTimeString}>
+                  Last updated {formattedTimeString}
+                </time>
+              </div>
             </div>
           </div>
           <VStack

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -108,10 +108,8 @@ const Post = () => {
                   })}
                 </div>
                 {/* <div className="post-time">
-              <time dateTime={moment(post.createdAt).fromNow(true)}>
-                {moment(post.createdAt).fromNow(true)} ago
-              </time>
-            </div> */}
+                  <time dateTime={post.createdAt}>{post.createdAt} ago</time>
+                </div> */}
                 <ViewCount views={post.views} className="views-info center" />
               </div>
               {post.status === PostStatus.Private ? (

--- a/client/src/pages/Post/Post.styles.scss
+++ b/client/src/pages/Post/Post.styles.scss
@@ -21,11 +21,6 @@
     .tags-name-time {
       display: flex;
       align-items: flex-start;
-
-      .post-time {
-        padding-left: 10px;
-        padding-right: 20px;
-      }
     }
 
     .private-subtitle {
@@ -43,6 +38,13 @@
 
   .subtitle-bar + .question-main {
     margin-top: 16px;
+
+    .post-time {
+      @include body-2;
+      color: $sec-400;
+      padding-left: 10px;
+      padding-right: 20px;
+    }
   }
 
 }

--- a/client/src/util/date.ts
+++ b/client/src/util/date.ts
@@ -1,21 +1,3 @@
-import moment, { MomentInput } from 'moment-timezone'
-
-export const dateToDaysAgo = (date: MomentInput): number =>
-  moment().diff(date, 'days')
-
-export const dateToDaysAgoString = (date: MomentInput): string => {
-  const daysAgo = dateToDaysAgo(date)
-  if (daysAgo < 0) {
-    return 'In the future'
-  } else if (daysAgo <= 1) {
-    return 'Less than 1 day ago'
-  } else if (daysAgo < 30) {
-    return `${daysAgo} days ago`
-  } else {
-    return moment(date).format('D MMM, YYYY')
-  }
-}
-
 type HasCreatedAt = {
   createdAt: Date | string | number
 }

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -417,6 +417,7 @@ export class PostService {
         'title',
         'description',
         'createdAt',
+        'updatedAt',
         'views',
         'status',
         [

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -402,6 +402,7 @@ export class PostService {
         where: {
           id: postId,
         },
+        silent: true,
       },
     )
 


### PR DESCRIPTION
## Problem

The last updated date in Post does not reflect the last time content
was updated, as Post.views is updated whenever someone views the post.
It was thus not returned by the backend, with the created timestamp being
not as useful and thus hidden

## Solution
- replace moment with date-fns-tz in /client
- avoid updatedAt changes on post view
- expose updatedAt to frontend
- use date-fns-tz to display the date after the answer section

## Screenshot
![image](https://user-images.githubusercontent.com/10572368/135206075-b25e2ce7-fe58-42c2-ab96-99df082a8bc5.png)

