### PR TITLE
feat: restrict number of attempts before deleting token

### DIFF
--- a/server/migrations/20210928070822-add-attempts-to-token.js
+++ b/server/migrations/20210928070822-add-attempts-to-token.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.addColumn('tokens', 'attempts', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    })
+  },
+
+  down: async (queryInterface) => {
+    queryInterface.removeColumn('tokens', 'attempts')
+  },
+}

--- a/server/src/models/token.model.ts
+++ b/server/src/models/token.model.ts
@@ -5,6 +5,7 @@ export const TOKEN_MODEL_NAME = 'token'
 export interface Token extends Model {
   contact: string
   hashedOtp: string
+  attempts: number
 }
 
 export const defineToken = (sequelize: Sequelize): ModelCtor<Token> =>
@@ -16,6 +17,10 @@ export const defineToken = (sequelize: Sequelize): ModelCtor<Token> =>
     },
     hashedOtp: {
       type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    attempts: {
+      type: DataTypes.INTEGER,
       allowNull: false,
     },
   })

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -130,7 +130,7 @@ export class AuthController {
 
     try {
       await this.Token.destroy({ where: { contact: email } })
-      await this.Token.create({ contact: email, hashedOtp })
+      await this.Token.create({ contact: email, hashedOtp, attempts: 0 })
       await this.mailService.sendLoginOtp(email, otp, ip)
     } catch (error) {
       logger.error({


### PR DESCRIPTION
## Problem and solution

Currently login allows unlimited tries with the same hashed token, which is susceptible to brute force. Restrict the number of tries to 3 before deleting token, forcing user to generate a new one.

- Take the opportunity to convert `AuthForm` to typescript, add form validation where possible
- Change text to make it clearer to user to grab OTP from email

**AFTER**:

https://user-images.githubusercontent.com/20250559/135200634-a3622a80-ac4f-40b4-a94d-03c11739f4d0.mov

## Deploy Notes

Run migration script to add new `attempts` column to `Token`
