### PR TITLE
feat: show link to external agency website

### DIFF
--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -60,17 +60,21 @@ const Header = () => {
     </Flex>
   )
 
-  const websiteLinks = (
-    <Link href={agency?.website} isExternal>
-      <Button
-        rightIcon={<BiLinkExternal color="white" />}
-        variant="link"
-        color="white"
-      >
-        Go to {agency?.shortname.toUpperCase()}
-      </Button>
-    </Link>
-  )
+  const websiteLinks = () => {
+    // Extract hostname from URL
+    const hostname = new URL(agency?.website).hostname
+    return (
+      <Link href={agency?.website} isExternal>
+        <Button
+          rightIcon={<BiLinkExternal color="white" />}
+          variant="link"
+          color="white"
+        >
+          Go to {hostname}
+        </Button>
+      </Link>
+    )
+  }
 
   return (
     <Flex
@@ -115,7 +119,7 @@ const Header = () => {
         </Stack>
       </Link>
       <Spacer />
-      {agency?.website && websiteLinks}
+      {agency?.website && websiteLinks()}
       {user && authLinks}
     </Flex>
   )

--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -1,6 +1,15 @@
-import { Flex, Image, Stack, Text } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  Image,
+  Link,
+  Stack,
+  Spacer,
+  Text,
+} from '@chakra-ui/react'
+import { BiLinkExternal } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { Link, matchPath, useLocation } from 'react-router-dom'
+import { matchPath, useLocation } from 'react-router-dom'
 import { ReactComponent as Logo } from '../../assets/logo-white-alpha.svg'
 import { useAuth } from '../../contexts/AuthContext'
 import {
@@ -25,7 +34,7 @@ const Header = () => {
   )
 
   const authLinks = (
-    <Flex align="center">
+    <Flex align="center" mx={6}>
       {isLoading || user === null ? (
         <Spinner centerWidth="50px" centerHeight="50px" />
       ) : (
@@ -49,6 +58,18 @@ const Header = () => {
         handleClick={logout}
       />
     </Flex>
+  )
+
+  const websiteLinks = (
+    <Link href={agency?.website} isExternal>
+      <Button
+        rightIcon={<BiLinkExternal color="white" />}
+        variant="link"
+        color="white"
+      >
+        Go to {agency?.shortname.toUpperCase()}
+      </Button>
+    </Link>
   )
 
   return (
@@ -93,6 +114,8 @@ const Header = () => {
           ) : null}
         </Stack>
       </Link>
+      <Spacer />
+      {agency?.website && websiteLinks}
       {user && authLinks}
     </Flex>
   )

--- a/server/migrations/20210929043034-add-website-to-agency.js
+++ b/server/migrations/20210929043034-add-website-to-agency.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.addColumn('agencies', 'website', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface) => {
+    queryInterface.removeColumn('agencies', 'website')
+  },
+}

--- a/server/seeders/20210826064325-was.js
+++ b/server/seeders/20210826064325-was.js
@@ -67,6 +67,7 @@ module.exports = {
           longname: 'Work Allocation Singapore',
           logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
           email: 'enquiries@was.gov.sg',
+          website: 'https://www.was.gov.sg',
           createdAt: new Date(),
           updatedAt: new Date(),
         },

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -37,6 +37,10 @@ export const defineAgency = (
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    website: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
   })
   // Define associations for Agency
   Agency.hasMany(User)

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -27,6 +27,7 @@ describe('/agencies', () => {
       email: 'enquiries@was.gov.sg',
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
       noEnquiriesMessage: null,
+      website: null,
     })
     const agencyService = new AgencyService({ Agency })
     const controller = new AgencyController({ agencyService })

--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -20,6 +20,7 @@ describe('AgencyService', () => {
       email: 'enquiries@was.gov.sg',
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
       noEnquiriesMessage: null,
+      website: null,
     })
     service = new AgencyService({ Agency })
   })

--- a/shared/src/types/base/agency.ts
+++ b/shared/src/types/base/agency.ts
@@ -7,6 +7,7 @@ export const Agency = BaseModel.extend({
   email: z.string(),
   logo: z.string(),
   noEnquiriesMessage: z.string().nullable(),
+  website: z.string().nullable(),
 })
 
 export type Agency = z.infer<typeof Agency>


### PR DESCRIPTION
## Problem

- Closes #415

## Solution

Add new column `website` to `agency`. Websites should contain the full path of the url, including protocol (http), otherwise the link will still stay in askgov. The button will display only the hostname instead of the full url to maintain legitimacy (`.gov`) and brevity.

If the website is empty or at homepage, the link does not show up.

## Before & After Screenshots

**BEFORE**:
<img width="1904" alt="Screenshot 2021-09-29 at 2 31 30 PM" src="https://user-images.githubusercontent.com/20250559/135215136-a1104cf5-cee7-42f5-8647-c102bf1028d0.png">

**AFTER**:

https://user-images.githubusercontent.com/20250559/135215101-127181b1-7669-4d40-8445-ed924abde53a.mov

** Deploy notes **
Run the migration script to add new column

