### PR TITLE
build(shared): ensure a clean build for every invocation

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -5,7 +5,7 @@
   "main": "./build/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "tsc --build --clean && tsc",
     "lint": "eslint src --quiet --fix --ext '.ts'",
     "lint-ci": "eslint src --quiet --ext '.ts'",
     "lint-staged": "lint-staged"


### PR DESCRIPTION
## Problem

`npm run build-shared` invokes `tsc` as-is, which exits early if it discovers `tsconfig.tsbuildinfo`, even if files are missing. This interferes with running in dev

## Solution

Ensure a clean build for every invocation