### PR TITLE
fix(RichTextEditor): support telephone links

### DIFF
--- a/client/src/components/RichText/LinkDecorator.tsx
+++ b/client/src/components/RichText/LinkDecorator.tsx
@@ -1,0 +1,54 @@
+import { ContentBlock, ContentState, DraftDecorator } from 'draft-js'
+import type { ReactChildren } from 'react'
+import './RichTextEditor.styles.scss'
+import styles from './RichTextEditor.module.scss'
+
+const targetOptions: { [key: string]: string } = {
+  'http:': '_blank',
+  'https:': '_blank',
+  'mailto:': '',
+  'tel:': '',
+}
+
+const linkStrategy = (
+  contentBlock: ContentBlock,
+  callback: (start: number, end: number) => void,
+  contentState: ContentState,
+): void => {
+  contentBlock.findEntityRanges((character) => {
+    const entityKey = character.getEntity()
+    return (
+      entityKey !== null &&
+      contentState.getEntity(entityKey).getType() === 'LINK'
+    )
+  }, callback)
+}
+
+const PreviewLinkSpan = ({
+  children,
+  contentState,
+  entityKey,
+}: {
+  children: ReactChildren
+  contentState: ContentState
+  entityKey: string
+}): JSX.Element => {
+  const { url } = contentState.getEntity(entityKey).getData()
+  const protocol = new URL(url).protocol.toString()
+  if (protocol in targetOptions) {
+    return (
+      <span className="rdw-link-decorator-wrapper">
+        <a href={url} className={styles.title} target={targetOptions[protocol]}>
+          {children}
+        </a>
+      </span>
+    )
+  } else {
+    return <></>
+  }
+}
+
+export const PreviewLinkDecorator: DraftDecorator = {
+  strategy: linkStrategy,
+  component: PreviewLinkSpan,
+}

--- a/client/src/components/RichText/RichTextEditor.component.tsx
+++ b/client/src/components/RichText/RichTextEditor.component.tsx
@@ -14,6 +14,7 @@ import { RefCallBack } from 'react-hook-form'
 import { LinkControl } from './LinkControl'
 import { ApiClient, getApiErrorMessage } from '../../api'
 import { useStyledToast } from '../StyledToast/StyledToast'
+import { PreviewLinkDecorator } from './LinkDecorator'
 
 type UploadCallback = (
   file: File,
@@ -144,6 +145,7 @@ export const RichTextPreview: FC<{
       onEditorStateChange={setEditorState}
       placeholder={placeholder}
       editorClassName={editorClassName}
+      customDecorators={[PreviewLinkDecorator]}
       toolbar={{ link: { showOpenOptionOnHover: false } }}
       readOnly
       toolbarHidden


### PR DESCRIPTION
## Problem

`a href` using `tel` protocol was being replaced by `#`. This means that users are not able to click on links containing phone numbers, and being directed to their phone app. It seems like draft-js was being overly aggressive with the protocol and accepting only `http`, `https` and `mailto` during the conversion of draft-js `contentBlocks` back to `html` to be displayed on screen.

- Closes #422

## Solution

Use a custom decorator (credits: [Postman](https://github.com/opengovsg/postmangovsg)) that watches out for links and manually convert to html. As an added bonus, since we have manual control over `targetOptions`, weblinks will open in new pages but mail and phone numbers will not (should open in their default apps).


**AFTER**:

https://user-images.githubusercontent.com/20250559/135409541-705180d8-21e9-4c78-a154-e22e22bb2395.mov


https://user-images.githubusercontent.com/20250559/135409550-966c08d3-cb07-42e9-9445-985ebfded601.mov



