### PR TITLE
perf(seo): preload googlefonts stylesheet

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -40,7 +40,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700&display=swap"
-      rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'"
+      rel="preload" as="style"
     />
   </head>
   <body>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -40,7 +40,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700&display=swap"
-      rel="preload"
+      rel="preload stylesheet"
       as="style"
       crossorigin="anonymous"
     />

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -40,7 +40,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700&display=swap"
-      rel="stylesheet"
+      rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'"
     />
   </head>
   <body>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -40,7 +40,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700&display=swap"
-      rel="preload" as="style"
+      rel="preload"
+      as="style"
+      crossorigin="anonymous"
     />
   </head>
   <body>


### PR DESCRIPTION
## Problem

The googlefonts stylesheet is being flagged as a render-blocking resource

Closes #397 

## Solution

Preload the stylesheet so that it loads asynchronously

## Before & After Screenshots

**AFTER**:
<img width="1767" alt="Screenshot 2021-09-30 at 4 01 10 PM" src="https://user-images.githubusercontent.com/56983748/135412219-1eb27cba-5e90-4215-a03b-9c919ab62fe6.png">

## Tests

Check that "Eliminate render-blocking resources" belongs to "Passed audits" after running Lighthouse in DevTools
