### PR TITLE
feat(seo): add alt to lion head, ogp logo

### DIFF
--- a/client/src/components/Footer/Footer.component.tsx
+++ b/client/src/components/Footer/Footer.component.tsx
@@ -93,6 +93,7 @@ const Footer = (): JSX.Element => {
               htmlWidth="160px"
               htmlHeight="47px"
               src={OGPLogo}
+              alt="Open Government Products Logo"
               loading="lazy"
             />
           </Link>

--- a/client/src/components/Masthead/Masthead.component.tsx
+++ b/client/src/components/Masthead/Masthead.component.tsx
@@ -45,6 +45,7 @@ const Masthead: FC = () => {
         <Center my={mastheadTopMarginY}>
           <Image
             src={LionHeadSymbol}
+            alt="Lion Head Symbol"
             htmlHeight="15.2px"
             htmlWidth="12.8px"
             loading="lazy"


### PR DESCRIPTION
## Problem

Lighthouse Audits indicate image alt text as the sole remaining problem for SEO

![image](https://user-images.githubusercontent.com/10572368/135467184-c953e36a-66a3-4fe8-8611-ce6844b55db8.png)


## Solution
Add alt text to Lion Head Symbol and OGP logo

![image](https://user-images.githubusercontent.com/10572368/135468081-a88965a7-1d04-48e9-83be-1250564b61a5.png)

