### PR TITLE
feat(rte): enforce alt text for images

### DIFF
--- a/client/src/components/RichText/RichTextEditor.component.tsx
+++ b/client/src/components/RichText/RichTextEditor.component.tsx
@@ -42,6 +42,7 @@ const toolbarWithImageUpload = (uploadCallback: UploadCallback) => {
       uploadEnabled: true,
       uploadCallback,
       previewImage: true,
+      alt: { present: true, mandatory: true },
     },
   }
 }


### PR DESCRIPTION
## Problem

To ensure agencies maintain good SEO practices, images should have alt text annotations in questions and answers

## Solution

Enforce alt text for images in RichTextEditor

![image](https://user-images.githubusercontent.com/10572368/135566745-e560f00a-f8f7-46e5-b096-8db7ddeba3d3.png)


