### PR TITLE
fix(header): set header logo link as routerlink

### DIFF
--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react'
 import { BiLinkExternal } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { matchPath, useLocation } from 'react-router-dom'
+import { matchPath, useLocation, Link as RouterLink } from 'react-router-dom'
 import { ReactComponent as Logo } from '../../assets/logo-white-alpha.svg'
 import { useAuth } from '../../contexts/AuthContext'
 import {
@@ -87,7 +87,7 @@ const Header = () => {
       py={4}
       shrink={0}
     >
-      <Link to={agency ? `/agency/${agency.shortname}` : '/'}>
+      <Link as={RouterLink} to={agency ? `/agency/${agency.shortname}` : '/'}>
         <Stack
           direction={{ base: 'column', md: 'row' }}
           textDecor="none"


### PR DESCRIPTION
- set chakra Link component as Link from react-router-dom
- fixes link and makes it crawlable

fix #444

## Problem

Fix header's left link so that it is crawlable.

Closes #444

## Solution

Set `Link` component used as `Link` from `react-router-dom`.

**Bug Fixes**:

- Uncrawlable link in header.

## Before & After Screenshots

**BEFORE**:

Uncrawlable link flagged as SEO issue by Lighthouse:

<img width="896" alt="Screenshot 2021-10-01 at 3 13 04 PM" src="https://user-images.githubusercontent.com/37061143/135582292-65eacbe4-d665-48f3-8f60-cf41a08870f5.png">

(No link when hovered or clicked, but this can't be captured through a screenshot or video.)

**AFTER**:

URL which user will be directed to after clicking is correct:

<img width="640" alt="Screenshot 2021-10-01 at 3 10 06 PM" src="https://user-images.githubusercontent.com/37061143/135582052-675e8532-e501-4044-9986-9242dad670e2.png">

Uncrawlable link no longer flagged as SEO issue by Lighthouse:

<img width="896" alt="Screenshot 2021-10-01 at 3 09 32 PM" src="https://user-images.githubusercontent.com/37061143/135582061-7c451272-f754-448c-9d8b-b6790a1fd4e0.png">

## Tests

1. Navigate to different pages and click the logo on the left of the header. If the logo does not include any agency name, user should be directed to "/", otherwise, user should be directed to "agency/:agency_name".
