### PR TITLE
feat(search-results): add CitizenRequest at footer

### DIFF
--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -1,19 +1,24 @@
+import { Spacer } from '@chakra-ui/react'
 import Fuse from 'fuse.js'
 import { Fragment } from 'react'
 import { useQuery } from 'react-query'
 import { useLocation } from 'react-router-dom'
-import PageTitle from '../../components/PageTitle/PageTitle.component'
 import { BackToHome } from '../../components/BackToHome/BackToHome'
+import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
+import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostItem from '../../components/PostItem/PostItem.component'
 import SearchBox from '../../components/SearchBox/SearchBox.component'
-import { Spacer } from '@chakra-ui/react'
 import Spinner from '../../components/Spinner/Spinner.component'
+import {
+  getAgencyByShortName,
+  GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
+} from '../../services/AgencyService'
 import {
   listPosts,
   LIST_POSTS_FOR_SEARCH_QUERY_KEY,
 } from '../../services/PostService'
-import './SearchResults.styles.scss'
 import { sortByCreatedAt } from '../../util/date'
+import './SearchResults.styles.scss'
 
 const SearchResults = () => {
   const { search } = useLocation()
@@ -23,6 +28,11 @@ const SearchResults = () => {
   const { data, isLoading } = useQuery(
     [LIST_POSTS_FOR_SEARCH_QUERY_KEY, agencyShortName],
     listPosts(undefined, agencyShortName),
+  )
+  const { data: agency } = useQuery(
+    [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
+    () => getAgencyByShortName({ shortname: agencyShortName }),
+    { enabled: !!agencyShortName },
   )
 
   const foundPosts = new Fuse(data?.posts ?? [], {
@@ -71,7 +81,20 @@ const SearchResults = () => {
           )}
         </div>
       </div>
-      <Spacer minH={20} />
+      <Spacer />
+      <CitizenRequest
+        agency={
+          agency
+            ? agency
+            : {
+                id: '',
+                email: 'enquiries@ask.gov.sg',
+                shortname: 'AskGov',
+                longname: 'AskGov',
+                logo: '',
+              }
+        }
+      />
     </Fragment>
   )
 }


### PR DESCRIPTION
## Problem
If the user searches and finds nothing of interest, he or she has no
recourse to follow up to get an answer

## Solution
Provide CitizenRequest in SearchResults to prompt user to make an enquiry

- Organise imports, bring in AgencyService, CitizenRequest
- Remove min height in spacer since CitizenRequest has height
- Add CitizenRequest to SearchResults

![image](https://user-images.githubusercontent.com/10572368/135710229-32d51d88-ae35-4908-8884-2cd471846ad0.png)

