### PR TITLE
feat(logo-link): add agency main page link to agency logo

### DIFF
--- a/client/src/components/AgencyLogo/AgencyLogo.component.jsx
+++ b/client/src/components/AgencyLogo/AgencyLogo.component.jsx
@@ -1,10 +1,10 @@
-import { Image, Box } from '@chakra-ui/react'
+import { Box, Image, Link } from '@chakra-ui/react'
 import { useQuery } from 'react-query'
+import { Link as RouterLink, useParams } from 'react-router-dom'
 import {
   getAgencyByShortName,
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
 } from '../../services/AgencyService'
-import { useParams } from 'react-router-dom'
 
 const AgencyLogo = () => {
   const { agency: agencyShortName } = useParams()
@@ -27,30 +27,32 @@ const AgencyLogo = () => {
       borderRadius="10px"
       bg="#fff"
     >
-      <Box
-        width="100%"
-        height="100%"
-        display="flex"
-        alignItems="center"
-        overflow="hidden"
-        border="1px solid #DADCE3"
-        borderRadius="10px"
-      >
-        {agency && (
-          <Image
-            src={agency.logo}
-            alt="Agency Logo"
-            loading="lazy"
-            display="inline"
-            htmlWidth="120px"
-            htmlHeight="120px"
-            maxW="100%"
-            maxH="100%"
-            width="auto"
-            height="auto"
-          />
-        )}
-      </Box>
+      <Link as={RouterLink} to={agency ? `/agency/${agency.shortname}` : '/'}>
+        <Box
+          width="100%"
+          height="100%"
+          display="flex"
+          alignItems="center"
+          overflow="hidden"
+          border="1px solid #DADCE3"
+          borderRadius="10px"
+        >
+          {agency && (
+            <Image
+              src={agency.logo}
+              alt="Agency Logo"
+              loading="lazy"
+              display="inline"
+              htmlWidth="120px"
+              htmlHeight="120px"
+              maxW="100%"
+              maxH="100%"
+              width="auto"
+              height="auto"
+            />
+          )}
+        </Box>
+      </Link>
     </Box>
   )
 }


### PR DESCRIPTION
## Problem

Users would expect agency logo (on the main page) to direct them to the main agency page, but tapping it does not do anything.

## Solution

Wrap the AgencyLogo with a link to the agency specific page so clicking it will bring them to the agency specific page.

**Features**:

- Wrap the AgencyLogo with a link to the agency specific page.

**Improvements**:

- Reordered imports on AgencyLogo.

## Tests

On an agency-specific page, click on a tag. After which, click on the agency logo. The user should be directed to the agency main page again (i.e. /agency/<agency name>, without the tag queries).
