### PR TITLE
fix(agency-logo): set height and width of AgencyLogo Link component to 100%

### DIFF
--- a/client/src/components/AgencyLogo/AgencyLogo.component.jsx
+++ b/client/src/components/AgencyLogo/AgencyLogo.component.jsx
@@ -27,7 +27,12 @@ const AgencyLogo = () => {
       borderRadius="10px"
       bg="#fff"
     >
-      <Link as={RouterLink} to={agency ? `/agency/${agency.shortname}` : '/'}>
+      <Link
+        width="100%"
+        height="100%"
+        as={RouterLink}
+        to={agency ? `/agency/${agency.shortname}` : '/'}
+      >
         <Box
           width="100%"
           height="100%"


### PR DESCRIPTION
- set height and width of Link to 100% so that the borders will still be flushed to a square
<img width="129" alt="Screenshot 2021-10-02 at 6 56 58 PM" src="https://user-images.githubusercontent.com/37061143/135713260-9d8c2c72-b056-44f3-af3c-e7876fbb679d.png">

