### PR TITLE
fix(back-button): spacing

### DIFF
--- a/client/src/components/BackToHome/BackToHome.tsx
+++ b/client/src/components/BackToHome/BackToHome.tsx
@@ -1,4 +1,4 @@
-import { Center, Flex, Link, Text } from '@chakra-ui/react'
+import { Center, Link, Text } from '@chakra-ui/react'
 import { BiArrowBack } from 'react-icons/bi'
 import { Link as RouterLink } from 'react-router-dom'
 
@@ -9,12 +9,12 @@ export const BackToHome = ({
 }) => {
   return (
     <Link as={RouterLink} to={mainPageName ? `/agency/${mainPageName}` : '/'}>
-      <Flex direction="row">
-        <Center color="secondary.600">
-          <BiArrowBack style={{ marginRight: '14px' }} size="13.41px" />
-          <Text>Back to {mainPageName?.toUpperCase() ?? ''} questions</Text>
-        </Center>
-      </Flex>
+      <Center color="secondary.600">
+        <BiArrowBack style={{ marginRight: '14px' }} size="13.41px" />
+        <Text textStyle="body-1">
+          Back to {mainPageName?.toUpperCase() ?? ''} questions
+        </Text>
+      </Center>
     </Link>
   )
 }

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -139,7 +139,7 @@ const HomePage = ({ match }) => {
         </Box>
         <Box flex="5">
           {queryState ? (
-            <Flex mb="5px">
+            <Flex mb={{ base: '32px', sm: '50px' }}>
               <BackToHome
                 mainPageName={match.params.agency || agency?.shortname}
               />

--- a/client/src/pages/NotFound/NotFound.component.tsx
+++ b/client/src/pages/NotFound/NotFound.component.tsx
@@ -1,15 +1,6 @@
-import React, { Fragment } from 'react'
+import { Button, Center, Flex, Heading, Spacer, Text } from '@chakra-ui/react'
+import { Fragment } from 'react'
 import { Link as ReachLink } from 'react-router-dom'
-import {
-  Spacer,
-  Heading,
-  Text,
-  Button,
-  Center,
-  Flex,
-  Container,
-} from '@chakra-ui/react'
-
 import { BackToHome } from '../../components/BackToHome/BackToHome'
 
 const NotFound = (): JSX.Element => {
@@ -18,7 +9,7 @@ const NotFound = (): JSX.Element => {
     <Fragment>
       <Flex
         mt={{ base: '32px', sm: '60px' }}
-        mb={{ base: '32px', sm: '54px' }}
+        mb={{ base: '32px', sm: '50px' }}
         px={pagePX}
       >
         <BackToHome mainPageName={null} />

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -105,8 +105,11 @@ const Post = () => {
           spacing={{ base: '20px', lg: '88px' }}
         >
           <div className="post-page">
-            <Flex pb="14px" align="center">
-              <Flex mt={{ base: '32px', sm: '60px' }}>
+            <Flex align="center">
+              <Flex
+                mt={{ base: '32px', sm: '60px' }}
+                mb={{ base: '32px', sm: '50px' }}
+              >
                 <BackToHome mainPageName={agencyShortName} />
               </Flex>
               <Spacer />

--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -54,7 +54,7 @@ const SearchResults = () => {
       <div id="mainbar" className="questions-page fc-black-800">
         <Flex
           mt={{ base: '32px', sm: '60px' }}
-          mb={{ base: '32px', sm: '54px' }}
+          mb={{ base: '32px', sm: '50px' }}
         >
           <BackToHome mainPageName={agencyShortName} />
         </Flex>

--- a/client/src/theme/breakpoints.ts
+++ b/client/src/theme/breakpoints.ts
@@ -1,8 +1,8 @@
 import { createBreakpoints } from '@chakra-ui/theme-tools'
 // Note the following breakpoints for different devices:
-// - mobile: 479px and below
-// - tablet: 480-1439px
-// - desktop: 1440px and above
+// - mobile: 29.9375em and below
+// - tablet: 30-89.9375em
+// - desktop: 90em and above
 export const breakpoints = createBreakpoints({
   xs: '22.5em',
   sm: '30em',


### PR DESCRIPTION
## Problem

Spacing inconsistent with designs on Figma.

## Solution

Add margins around back button where it is used.

**Improvements**:

- Remove extra Flex wrapping back button
- Update comment in breakpoints for devices to use em

## Before & After Screenshots

**BEFORE**:

Mobile:

https://user-images.githubusercontent.com/37061143/135781640-67310650-7ab3-4c86-ae24-90d360f15179.mov

Desktop:

https://user-images.githubusercontent.com/37061143/135781645-cfc20a39-5f48-46b5-859d-6834d4772ab4.mov

**AFTER**:

Mobile:

https://user-images.githubusercontent.com/37061143/135804603-60d72a06-9c2a-4f71-b325-20b73ac7ef4d.mov

Desktop:

https://user-images.githubusercontent.com/37061143/135804625-2362cfa9-5d97-4f24-a64d-fe6b12cb19e1.mov


## Tests

Spacing around back button for the following pages should match spacing in design:

1. Home page when topic is selected.
2. Post page.
3. Not found page.
