### PR TITLE
feat(nav-bar): add agency logo to navbar for post and search pages

### DIFF
--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -23,10 +23,12 @@ const Header = () => {
   const { user, logout } = useAuth()
 
   const location = useLocation()
+  const { search } = useLocation()
   const match = matchPath(location.pathname, {
     path: '/agency/:agency',
   })
-  const agencyShortName = match?.params?.agency
+  const searchParams = new URLSearchParams(search)
+  const agencyShortName = match?.params?.agency || searchParams.get('agency')
   const { isLoading, data: agency } = useQuery(
     [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
     () => getAgencyByShortName({ shortname: agencyShortName }),


### PR DESCRIPTION
## Problem

When a user views a post or searches for a result, the navigation bar shows only the AskGov logo without an agency name. Clicking on the AskGov logo brings the user to `ask.gov.sg` instead of the agency's main page.

Closes #459 

## Solution

Identify the agency for both post and search pages, update the AskGov logo with the agency name in the navigation bar accordingly

Details:
- Search page: agency is identified by search parameter
- Post page: agency is identified by the first `agencyTag`
- `[GET_POST_BY_ID_QUERY_KEY, postId]` useQuery is identical to the one used in the Post component
  - No variations were made to the useQuery (e.g. change in Query Key / Query Function) as both components make use of the same data. Only one request is triggered for all instances of the same query key (within the default cache time of 5 minutes) - refer to [react-query caching example](https://react-query.tanstack.com/guides/caching).


## Before & After Screenshots

**BEFORE**:


https://user-images.githubusercontent.com/56983748/135813772-3fa5d30c-15b9-493a-b85e-433817fa2206.mov


**AFTER**:

Mobile:

https://user-images.githubusercontent.com/56983748/135814169-84ce0671-03d8-4f95-8da1-ecbdd79b3510.mov


Desktop:

https://user-images.githubusercontent.com/56983748/135813918-2cda50a7-1f42-49ef-adea-49fc173ed75d.mov


## Tests
For the following 2 pages, check that the navigation bar at the top reflects agency's name. Clicking on the AskGov logo should bring you back to the agency's main page.
- View a post
- Search for a result
