### PR TITLE
feat(social-media-share): serve different static index.html files based on path

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -37,6 +37,10 @@
       content="Answers from the Singapore Government"
       data-rh="true"
     />
+    <meta property="og:title" content="AskGov" />
+    <meta property="og:description" content="Answers from the Singapore Government" />
+    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta property="og:type" content="website" />
 
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 import {
   AgencyPrivacy,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3525,6 +3525,15 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "@types/sanitize-html": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.3.2.tgz",
+      "integrity": "sha512-DnmoXsiqG2/RoSf6/lD3Hrs+TCM8ILtzNuuSjmOtRaP/ud9Sy3M3ctwD+SB50EIDs5GzVFF1dJk2Fq/ID/PNCQ==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^6.0.0"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -5214,8 +5223,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -7167,6 +7175,11 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -9481,6 +9494,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -10703,6 +10721,11 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -10789,6 +10812,11 @@
       "dev": true,
       "optional": true
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -10856,6 +10884,16 @@
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
+      }
+    },
+    "postcss": {
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
+      "requires": {
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
+        "source-map-js": "^0.6.2"
       }
     },
     "prelude-ls": {
@@ -11320,6 +11358,27 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize-html": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.5.1.tgz",
+      "integrity": "sha512-hUITPitQk+eFNLtr4dEkaaiAJndG2YE87IOpcfBSL1XdklWgwcNDJdr9Ppe8QKL/C3jFt1xH/Mbj20e0GZQOfg==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -11665,6 +11724,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-support": {
       "version": "0.5.19",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4149,6 +4149,11 @@
         }
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -4316,6 +4321,39 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "requires": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "cheerio-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
+      "requires": {
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.7.0"
+      }
     },
     "chokidar": {
       "version": "3.5.2",
@@ -4996,6 +5034,23 @@
         }
       }
     },
+    "css-select": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
+      }
+    },
+    "css-what": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -5281,6 +5336,21 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -5296,6 +5366,24 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "dottie": {
@@ -6699,6 +6787,17 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -10421,6 +10520,14 @@
         "set-blocking": "~2.0.0"
       }
     },
+    "nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -10599,8 +10706,15 @@
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "requires": {
+        "parse5": "^6.0.1"
+      }
     },
     "parseurl": {
       "version": "1.3.3",

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "nodemailer": "^6.6.5",
     "passport": "^0.5.0",
     "passport-local": "^1.0.0",
+    "sanitize-html": "^2.5.1",
     "sequelize": "^6.3.5",
     "triple-beam": "^1.3.0",
     "winston": "^3.3.3"
@@ -72,6 +73,7 @@
     "@types/nodemailer": "^6.4.1",
     "@types/passport": "^1.0.6",
     "@types/passport-local": "^1.0.34",
+    "@types/sanitize-html": "^2.3.2",
     "@types/supertest": "^2.0.11",
     "@types/triple-beam": "^1.3.2",
     "@typescript-eslint/eslint-plugin": "^4.32.0",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "bcrypt": "^5.0.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
+    "cheerio": "^1.0.0-rc.10",
     "compression": "1.7.4",
     "config": "^3.3.1",
     "connect-datadog": "0.0.9",

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -228,7 +228,6 @@ if (baseConfig.nodeEnv === Environment.Prod) {
             agency.value.longname
           } (${req.params.shortname.toUpperCase()})`,
         )
-        $('meta[property="og:image"]').attr('content', `${agency.value.logo}`)
       } else {
         $('meta[name="description"]').attr(
           'content',

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -161,11 +161,11 @@ const index = fs.readFileSync(
 )
 
 const webController = new WebController({
-  index,
   agencyService,
   answersService,
   postService,
   webService: new WebService(),
+  index,
 })
 
 const moduleLogger = createLogger(module)
@@ -220,11 +220,15 @@ if (baseConfig.nodeEnv === Environment.Prod) {
     )
   }
 
-  app.get('*', (_req, res) =>
+  app.get('/not-found', (_req, res) =>
     res
       .header('content-type', 'text/html')
       .status(StatusCodes.NOT_FOUND)
       .send(index),
+  )
+
+  app.get('*', (_req, res) =>
+    res.header('content-type', 'text/html').redirect('/not-found'),
   )
 }
 

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -206,7 +206,10 @@ if (baseConfig.nodeEnv === Environment.Prod) {
       'content',
       `${req.params.shortname.toUpperCase()} FAQ - AskGov`,
     )
-    $('meta[property="og:url"]').attr('content', `${req.url.toLowerCase()}`)
+    $('meta[property="og:url"]').attr(
+      'content',
+      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
+    )
 
     const agencyPromise = async () => {
       return await agencyService.findOneByName({
@@ -246,7 +249,10 @@ if (baseConfig.nodeEnv === Environment.Prod) {
     const $ = cheerio.load(index)
 
     $('meta[property="og:type"]').attr('content', 'article')
-    $('meta[property="og:url"]').attr('content', `${req.url.toLowerCase()}`)
+    $('meta[property="og:url"]').attr(
+      'content',
+      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
+    )
 
     const postId: number = +req.params.id
     const postPromise = async () => {
@@ -280,7 +286,10 @@ if (baseConfig.nodeEnv === Environment.Prod) {
 
   app.get('*', (req, res) => {
     const $ = cheerio.load(index)
-    $('meta[property="og:url"]').attr('content', `${req.url.toLowerCase()}`)
+    $('meta[property="og:url"]').attr(
+      'content',
+      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
+    )
     res.header('content-type', 'text/html').send($.html())
   })
 }

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -63,6 +63,7 @@ import { passportConfig } from './passport'
 import sessionMiddleware from './session'
 
 import cheerio from 'cheerio'
+import sanitizeHtml from 'sanitize-html'
 
 export { sequelize } from './sequelize'
 export const app = express()
@@ -261,11 +262,12 @@ if (baseConfig.nodeEnv === Environment.Prod) {
       $('meta[property="og:title"]').attr('content', `${post.title} - AskGov`)
       const answers = await answersPromise()
       if (answers && answers.length > 0) {
-        $('meta[name="description"]').attr('content', `${answers[0].body}`)
-        $('meta[property="og:description"]').attr(
-          'content',
-          `${answers[0].body}`,
-        )
+        const answerBody = sanitizeHtml(answers[0].body, {
+          allowedTags: [],
+          allowedAttributes: {},
+        })
+        $('meta[name="description"]').attr('content', `${answerBody}`)
+        $('meta[property="og:description"]').attr('content', `${answerBody}`)
       } else {
         $('meta[name="description"]').attr('content', `${post.description}`)
         $('meta[property="og:description"]').attr(

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -1,69 +1,63 @@
-import helmet from 'helmet'
-import cors from 'cors'
-import compression from 'compression'
-import fs from 'fs'
-import path from 'path'
 import axios from 'axios'
-
+import compression from 'compression'
 import connectDatadog from 'connect-datadog'
-import { StatsD } from 'hot-shots'
-
+import cors from 'cors'
 import express from 'express'
-
+import fs from 'fs'
+import helmet from 'helmet'
+import { StatsD } from 'hot-shots'
+import { StatusCodes } from 'http-status-codes'
 import { createTransport } from 'nodemailer'
-
-import { api } from '../routes'
-import { EnvController } from '../modules/environment/env.controller'
+import path from 'path'
 import { AgencyController } from '../modules/agency/agency.controller'
-import { AnswersController } from '../modules/answers/answers.controller'
-import { PostController } from '../modules/post/post.controller'
-import { AuthController } from '../modules/auth/auth.controller'
-import { TagsController } from '../modules/tags/tags.controller'
-import { MailService } from '../modules/mail/mail.service'
-import { EnquiryController } from '../modules/enquiry/enquiry.controller'
 import { AgencyService } from '../modules/agency/agency.service'
-import { UserService } from '../modules/user/user.service'
-import { AuthService } from '../modules/auth/auth.service'
-import { TagsService } from '../modules/tags/tags.service'
+import { AnswersController } from '../modules/answers/answers.controller'
 import { AnswersService } from '../modules/answers/answers.service'
-import { PostService } from '../modules/post/post.service'
+import { AuthController } from '../modules/auth/auth.controller'
 import { AuthMiddleware } from '../modules/auth/auth.middleware'
-import { baseConfig, Environment } from './config/base'
+import { AuthService } from '../modules/auth/auth.service'
+import { EnquiryController } from '../modules/enquiry/enquiry.controller'
+import { EnquiryService } from '../modules/enquiry/enquiry.service'
+import { EnvController } from '../modules/environment/env.controller'
+import { FileController } from '../modules/file/file.controller'
+import { FileService } from '../modules/file/file.service'
+import { MailService } from '../modules/mail/mail.service'
+import { PostController } from '../modules/post/post.controller'
+import { PostService } from '../modules/post/post.service'
+import { TagsController } from '../modules/tags/tags.controller'
+import { TagsService } from '../modules/tags/tags.service'
+import { UserService } from '../modules/user/user.service'
+import { WebController } from '../modules/web/web.controller'
+import { routeWeb } from '../modules/web/web.routes'
+import { WebService } from '../modules/web/web.service'
+import { api } from '../routes'
+import { RecaptchaService } from '../services/recaptcha/recaptcha.service'
 import { bannerConfig } from './config/banner'
-import { googleAnalyticsConfig } from './config/googleAnalytics'
-import { fullStoryConfig } from './config/fullstory'
-import { mailConfig } from './config/mail'
+import { baseConfig, Environment } from './config/base'
+import { datadogConfig } from './config/datadog'
 import { fileConfig } from './config/file'
+import { fullStoryConfig } from './config/fullstory'
+import { googleAnalyticsConfig } from './config/googleAnalytics'
+import { mailConfig } from './config/mail'
 import { recaptchaConfig } from './config/recaptcha'
+import { emailValidator } from './email-validator'
+import { helmetOptions } from './helmet-options'
 import { createLogger } from './logging'
 import { requestLoggingMiddleware } from './logging/request-logging'
-
-import { helmetOptions } from './helmet-options'
-import { emailValidator } from './email-validator'
-import { EnquiryService } from '../modules/enquiry/enquiry.service'
+import { passportConfig } from './passport'
+import { bucket, host, s3 } from './s3'
 import {
   Agency,
   Answer,
   Permission,
   Post,
   PostTag,
-  Tag,
-  User,
-  Token,
   sequelize,
+  Tag,
+  Token,
+  User,
 } from './sequelize'
-import { RecaptchaService } from '../services/recaptcha/recaptcha.service'
-
-import { s3, bucket, host } from './s3'
-import { FileController } from '../modules/file/file.controller'
-import { FileService } from '../modules/file/file.service'
-import { datadogConfig } from './config/datadog'
-
-import { passportConfig } from './passport'
 import sessionMiddleware from './session'
-
-import cheerio from 'cheerio'
-import sanitizeHtml from 'sanitize-html'
 
 export { sequelize } from './sequelize'
 export const app = express()
@@ -124,7 +118,7 @@ const apiOptions = {
   answers: {
     controller: new AnswersController({
       authService,
-      answersService: answersService,
+      answersService,
     }),
     authMiddleware,
   },
@@ -141,7 +135,7 @@ const apiOptions = {
   post: {
     controller: new PostController({
       authService,
-      postService: postService,
+      postService,
     }),
     authMiddleware,
   },
@@ -161,6 +155,18 @@ const apiOptions = {
   },
   enquiries: new EnquiryController({ enquiryService, recaptchaService }),
 }
+
+const index = fs.readFileSync(
+  path.resolve(__dirname, '../../..', 'client', 'build', 'index.html'),
+)
+
+const webController = new WebController({
+  index,
+  agencyService,
+  answersService,
+  postService,
+  webService: new WebService(),
+})
 
 const moduleLogger = createLogger(module)
 
@@ -194,104 +200,32 @@ if (baseConfig.nodeEnv === Environment.Prod) {
     express.static(path.resolve(__dirname, '../../..', 'client', 'build')),
   )
 
-  const index = fs.readFileSync(
-    path.resolve(__dirname, '../../..', 'client', 'build', 'index.html'),
+  app.use('/', routeWeb({ controller: webController }))
+
+  // iterate through list of possible paths to serve index file
+  const allStaticPaths = [
+    '/',
+    '/questions',
+    '/login',
+    '/add/question',
+    '/edit/question/:id',
+    '/terms',
+    '/agency-terms',
+    '/privacy',
+    '/agency-privacy',
+  ]
+  for (const path of allStaticPaths) {
+    app.get(path, (_req, res) =>
+      res.header('content-type', 'text/html').send(index),
+    )
+  }
+
+  app.get('*', (_req, res) =>
+    res
+      .header('content-type', 'text/html')
+      .status(StatusCodes.NOT_FOUND)
+      .send(index),
   )
-
-  app.get('/agency/:shortname', (req, res) => {
-    const $ = cheerio.load(index)
-
-    $('title').text(`${req.params.shortname.toUpperCase()} FAQ - AskGov`)
-    $('meta[property="og:title"]').attr(
-      'content',
-      `${req.params.shortname.toUpperCase()} FAQ - AskGov`,
-    )
-    $('meta[property="og:url"]').attr(
-      'content',
-      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
-    )
-
-    const agencyPromise = async () => {
-      return await agencyService.findOneByName({
-        shortname: req.params.shortname,
-      })
-    }
-    ;(async () => {
-      const agency = await agencyPromise()
-      if (agency.isOk()) {
-        $('meta[name="description"]').attr(
-          'content',
-          `Answers from ${
-            agency.value.longname
-          } (${req.params.shortname.toUpperCase()})`,
-        )
-        $('meta[property="og:description"]').attr(
-          'content',
-          `Answers from ${
-            agency.value.longname
-          } (${req.params.shortname.toUpperCase()})`,
-        )
-      } else {
-        $('meta[name="description"]').attr(
-          'content',
-          `Answers from ${req.params.shortname.toUpperCase()}`,
-        )
-        $('meta[property="og:description"]').attr(
-          'content',
-          `Answers from ${req.params.shortname.toUpperCase()}`,
-        )
-      }
-      res.header('content-type', 'text/html').send($.html())
-    })()
-  })
-
-  app.get('/questions/:id', (req, res) => {
-    const $ = cheerio.load(index)
-
-    $('meta[property="og:type"]').attr('content', 'article')
-    $('meta[property="og:url"]').attr(
-      'content',
-      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
-    )
-
-    const postId: number = +req.params.id
-    const postPromise = async () => {
-      return await postService.getSinglePost(postId)
-    }
-    const answersPromise = async () => {
-      return await answersService.listAnswers(postId)
-    }
-    ;(async () => {
-      const post = await postPromise()
-      $('title').text(`${post.title} - AskGov`)
-      $('meta[property="og:title"]').attr('content', `${post.title} - AskGov`)
-      const answers = await answersPromise()
-      if (answers && answers.length > 0) {
-        const answerBody = sanitizeHtml(answers[0].body, {
-          allowedTags: [],
-          allowedAttributes: {},
-        })
-        $('meta[name="description"]').attr('content', `${answerBody}`)
-        $('meta[property="og:description"]').attr('content', `${answerBody}`)
-      } else {
-        $('meta[name="description"]').attr('content', `${post.description}`)
-        $('meta[property="og:description"]').attr(
-          'content',
-          `${post.description}`,
-        )
-      }
-      res.header('content-type', 'text/html').send($.html())
-    })()
-  })
-
-  app.get('*', (req, res) => {
-    const $ = cheerio.load(index)
-    $('meta[property="og:url"]').attr(
-      'content',
-      `${req.protocol}://${req.hostname}${req.originalUrl.toLowerCase()}`,
-    )
-    res.header('content-type', 'text/html').send($.html())
-  })
 }
 
 export default app

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -391,21 +391,23 @@ export class PostService {
   getSinglePost = async (
     postId: number,
     noOfRelatedPosts = 0,
+    updateViewCount = true,
   ): Promise<
     PostWithUserTagRelations | PostWithUserTagRelatedPostRelations
   > => {
-    await this.Post.increment(
-      {
-        views: +1,
-      },
-      {
-        where: {
-          id: postId,
+    if (updateViewCount) {
+      await this.Post.increment(
+        {
+          views: +1,
         },
-        silent: true,
-      },
-    )
-
+        {
+          where: {
+            id: postId,
+          },
+          silent: true,
+        },
+      )
+    }
     const post = (await this.Post.findOne({
       where: {
         id: postId,

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -6,8 +6,6 @@ import { AgencyService } from '../agency/agency.service'
 import { AnswersService } from '../answers/answers.service'
 import { PostService } from '../post/post.service'
 import { WebService } from './web.service'
-import { MissingAgencyError } from '../agency/agency.errors'
-import { err } from 'neverthrow'
 
 const logger = createLogger(module)
 
@@ -62,19 +60,26 @@ export class WebController {
         return res.status(StatusCodes.OK).send(agencyPage)
       } else {
         logger.error({
-          message: 'Error while getting agency page',
+          message: `${
+            agency.error.name ?? 'Error'
+          } while getting agency page: ${agency.error.message}`,
           meta: {
             function: 'getAgencyPage',
             shortname: req.params.shortname,
           },
+          error: agency.error,
         })
-        if (String(agency.error.statusCode === StatusCodes.NOT_FOUND))
+        if (agency.error.statusCode === StatusCodes.NOT_FOUND) {
           return res.status(StatusCodes.NOT_FOUND).redirect('/not-found')
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+        } else {
+          return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+        }
       }
     } catch (error) {
       logger.error({
-        message: 'Error while getting agency page',
+        message: `${error.name ?? 'Error'} while getting agency page: ${
+          error.message
+        }`,
         meta: {
           function: 'getAgencyPage',
           shortname: req.params.shortname,
@@ -115,7 +120,9 @@ export class WebController {
       }
     } catch (error) {
       logger.error({
-        message: 'Error while getting post page',
+        message: `${error.name ?? 'Error'} while getting post page: ${
+          error.message
+        }`,
         meta: {
           function: 'getPostPage',
           shortname: req.params.id,

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -1,0 +1,122 @@
+import { validationResult } from 'express-validator'
+import { StatusCodes } from 'http-status-codes'
+import { createLogger } from '../../bootstrap/logging'
+import { ControllerHandler } from '../../types/response-handler'
+import { AgencyService } from '../agency/agency.service'
+import { AnswersService } from '../answers/answers.service'
+import { PostService } from '../post/post.service'
+import { WebService } from './web.service'
+
+const logger = createLogger(module)
+
+export class WebController {
+  private agencyService: Public<AgencyService>
+  private answersService: Public<AnswersService>
+  private postService: Public<PostService>
+  private webService: Public<WebService>
+  private index: Buffer
+
+  constructor({
+    agencyService,
+    answersService,
+    postService,
+    webService,
+    index,
+  }: {
+    agencyService: Public<AgencyService>
+    answersService: Public<AnswersService>
+    postService: Public<PostService>
+    webService: Public<WebService>
+    index: Buffer
+  }) {
+    this.agencyService = agencyService
+    this.answersService = answersService
+    this.postService = postService
+    this.webService = webService
+    this.index = index
+  }
+
+  /**
+   * Gets static agency page
+   * @param shortname agency shortname
+   * @returns 200 with static agency page
+   * @returns 500 if agency does not exist
+   */
+  getAgencyPage: ControllerHandler<
+    { shortname: string },
+    Buffer | string,
+    undefined,
+    undefined
+  > = async (req, res) => {
+    try {
+      const agency = await this.agencyService.findOneByName({
+        shortname: req.params.shortname,
+      })
+      if (agency.isOk()) {
+        const agencyPage = await this.webService.getAgencyPage(
+          req.params.shortname,
+          agency.value.longname,
+        )
+        return res.status(StatusCodes.OK).send(agencyPage)
+      } else {
+        logger.error({
+          message: 'Error while getting agency page',
+          meta: {
+            function: 'getAgencyPage',
+            shortname: req.params.shortname,
+          },
+        })
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+      }
+    } catch (error) {
+      logger.error({
+        message: 'Error while getting agency page',
+        meta: {
+          function: 'getAgencyPage',
+          shortname: req.params.shortname,
+        },
+        error,
+      })
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+    }
+  }
+
+  /**
+   * Gets static post page
+   * @param postId post id
+   * @returns 200 with static post page
+   * @returns 500 if post or answers do not exist
+   */
+  getQuestionPage: ControllerHandler<
+    { id: number },
+    Buffer | string,
+    undefined,
+    undefined
+  > = async (req, res) => {
+    try {
+      const errors = validationResult(req)
+      if (!errors.isEmpty()) {
+        return res.status(StatusCodes.BAD_REQUEST).send(this.index)
+      }
+      const post = await this.postService.getSinglePost(req.params.id)
+      const answers = await this.answersService.listAnswers(req.params.id)
+      if (answers && answers.length > 0) {
+        const postPage = await this.webService.getQuestionPage(
+          post.title,
+          answers[0].body,
+        )
+        return res.status(StatusCodes.OK).send(postPage)
+      }
+    } catch (error) {
+      logger.error({
+        message: 'Error while getting post page',
+        meta: {
+          function: 'getPostPage',
+          shortname: req.params.id,
+        },
+        error,
+      })
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+    }
+  }
+}

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -102,7 +102,7 @@ export class WebController {
       if (!errors.isEmpty()) {
         return res.status(StatusCodes.BAD_REQUEST).send(this.index)
       }
-      const post = await this.postService.getSinglePost(req.params.id)
+      const post = await this.postService.getSinglePost(req.params.id, 0, false)
       const answers = await this.answersService.listAnswers(req.params.id)
       if (answers && answers.length > 0) {
         const postPage = await this.webService.getQuestionPage(

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -6,6 +6,8 @@ import { AgencyService } from '../agency/agency.service'
 import { AnswersService } from '../answers/answers.service'
 import { PostService } from '../post/post.service'
 import { WebService } from './web.service'
+import { MissingAgencyError } from '../agency/agency.errors'
+import { err } from 'neverthrow'
 
 const logger = createLogger(module)
 
@@ -66,6 +68,8 @@ export class WebController {
             shortname: req.params.shortname,
           },
         })
+        if (String(agency.error.statusCode === StatusCodes.NOT_FOUND))
+          return res.status(StatusCodes.NOT_FOUND).redirect('/not-found')
         return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
       }
     } catch (error) {
@@ -106,6 +110,8 @@ export class WebController {
           answers[0].body,
         )
         return res.status(StatusCodes.OK).send(postPage)
+      } else {
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
       }
     } catch (error) {
       logger.error({
@@ -116,7 +122,7 @@ export class WebController {
         },
         error,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
+      return res.status(StatusCodes.NOT_FOUND).redirect('/not-found')
     }
   }
 }

--- a/server/src/modules/web/web.routes.ts
+++ b/server/src/modules/web/web.routes.ts
@@ -1,0 +1,35 @@
+import express from 'express'
+import { param } from 'express-validator'
+import { WebController } from './web.controller'
+
+export const routeWeb = ({
+  controller,
+}: {
+  controller: WebController
+}): express.Router => {
+  const router = express.Router()
+
+  /**
+   * Lists all answers to a post
+   * @route   GET /agency/:shortname
+   * @returns 200 with static agency page
+   * @returns 500 if agency does not exist
+   * @access  Private
+   */
+  router.get('/agency/:shortname', controller.getAgencyPage)
+
+  /**
+   * Lists all answers to a post
+   * @route   GET /questions/:id
+   * @returns 200 with static post page
+   * @returns 500 if post or answers do not exist
+   * @access  Public
+   */
+  router.get(
+    '/questions/:id',
+    [param('id').isInt().toInt()],
+    controller.getQuestionPage,
+  )
+
+  return router
+}

--- a/server/src/modules/web/web.service.ts
+++ b/server/src/modules/web/web.service.ts
@@ -1,0 +1,64 @@
+import cheerio from 'cheerio'
+import fs from 'fs'
+import path from 'path'
+
+const index = fs.readFileSync(
+  path.resolve(__dirname, '../../../..', 'client', 'build', 'index.html'),
+)
+
+export class WebService {
+  /**
+   * Returns agency page if agency exists
+   * @param index default index.html buffer
+   * @param req request made
+   * @param agencyService agency service initialised
+   * @returns html of agency page if agency exists
+   */
+  getAgencyPage = async (
+    shortname: string,
+    longname: string,
+  ): Promise<string | undefined> => {
+    const $ = cheerio.load(index)
+
+    $('title').text(`${shortname.toUpperCase()} FAQ - AskGov`)
+    $('meta[property="og:title"]').attr(
+      'content',
+      `${shortname.toUpperCase()} FAQ - AskGov`,
+    )
+    $('meta[name="description"]').attr(
+      'content',
+      `Answers from ${longname} (${shortname.toUpperCase()})`,
+    )
+    $('meta[property="og:description"]').attr(
+      'content',
+      `Answers from ${longname} (${shortname.toUpperCase()})`,
+    )
+
+    return $.html()
+  }
+
+  /**
+   * Returns post page
+   * @param index default index.html buffer
+   * @param req request made
+   * @param postService post service initialised
+   * @param answersService answers service initialised
+   * @returns html of post page
+   */
+  getQuestionPage = async (
+    title: string,
+    description: string,
+  ): Promise<string | undefined> => {
+    const $ = cheerio.load(index)
+
+    $('meta[property="og:type"]').attr('content', 'article')
+
+    $('title').text(`${title} - AskGov`)
+    $('meta[property="og:title"]').attr('content', `${title} - AskGov`)
+
+    $('meta[name="description"]').attr('content', `${description}`)
+    $('meta[property="og:description"]').attr('content', `${description}`)
+
+    return $.html()
+  }
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,24 +1,21 @@
 import express from 'express'
-
-import { routeAuth } from '../modules/auth/auth.routes'
-import { routePosts } from '../modules/post/post.routes'
-import { routeTags } from '../modules/tags/tags.routes'
-import { routeAnswers } from '../modules/answers/answers.routes'
-import { routeAgencies } from '../modules/agency/agency.routes'
-import { routeEnv } from '../modules/environment/env.routes'
-import { routeEnquiries } from '../modules/enquiry/enquiry.routes'
-import { routeFiles } from '../modules/file/file.routes'
-
-import { EnvController } from '../modules/environment/env.controller'
 import { AgencyController } from '../modules/agency/agency.controller'
+import { routeAgencies } from '../modules/agency/agency.routes'
 import { AnswersController } from '../modules/answers/answers.controller'
+import { routeAnswers } from '../modules/answers/answers.routes'
 import { AuthController } from '../modules/auth/auth.controller'
-import { PostController } from '../modules/post/post.controller'
-import { TagsController } from '../modules/tags/tags.controller'
-import { FileController } from '../modules/file/file.controller'
-
 import { AuthMiddleware } from '../modules/auth/auth.middleware'
+import { routeAuth } from '../modules/auth/auth.routes'
 import { EnquiryController } from '../modules/enquiry/enquiry.controller'
+import { routeEnquiries } from '../modules/enquiry/enquiry.routes'
+import { EnvController } from '../modules/environment/env.controller'
+import { routeEnv } from '../modules/environment/env.routes'
+import { FileController } from '../modules/file/file.controller'
+import { routeFiles } from '../modules/file/file.routes'
+import { PostController } from '../modules/post/post.controller'
+import { routePosts } from '../modules/post/post.routes'
+import { TagsController } from '../modules/tags/tags.controller'
+import { routeTags } from '../modules/tags/tags.routes'
 
 type ApiRouterOptions = {
   agency: AgencyController
@@ -58,5 +55,6 @@ export const api = (options: ApiRouterOptions): express.Router => {
   router.use('/posts/answers', routeAnswers(options.answers))
   router.use('/agencies', routeAgencies({ controller: options.agency }))
   router.use('/enquiries', routeEnquiries({ controller: options.enquiries }))
+
   return router
 }


### PR DESCRIPTION
## Problem

Social media crawlers are only able to see initial files served statically by server (i.e. `index.html`). To make our website more shareable on social media, these initial files should be populated with titles, meta description and open graph tags.

Related to #394 

## Solution

Get `server/src/bootstrap/index.ts` to modify `index.html` before serving them.

**Features**:

- (server/src/bootstrap/index.ts) send modified index.html for /agency/:shortname and /questions/:id paths for production

**Improvements**:

- (client/public/index.html) added og tags

## Before & After Screenshots

**BEFORE**:

Social media link preview:

<img width="529" alt="Screenshot 2021-10-05 at 5 07 44 PM" src="https://user-images.githubusercontent.com/37061143/135994304-7eadefdd-77b4-417d-89f8-cced2eff953e.png">

**AFTER**:

Main AskGov page:

<img width="528" alt="Screenshot 2021-10-05 at 5 13 29 PM" src="https://user-images.githubusercontent.com/37061143/135995145-d75ab4e6-98fc-4649-a836-bbfe5fe66fde.png">

Agency-specific page:

<img width="528" alt="Screenshot 2021-10-05 at 5 13 56 PM" src="https://user-images.githubusercontent.com/37061143/135995234-9fe125b5-4758-4723-aa42-85465fae9e7d.png">

Post page:

<img width="991" alt="Screenshot 2021-10-05 at 5 14 58 PM" src="https://user-images.githubusercontent.com/37061143/135995408-1ea3fa3e-a42d-446e-8fd1-c8fddd28cb03.png">

## Tests

Use [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) to check that the title, meta description and og tags are populated. Specifically, test this for the following pages:

1. Main AskGov page
2. Agency-specific page
3. Post page

## Deploy Notes

**New dependencies**:

- `dependency` on `server`: 
  - `sanitize-html`
  - `cheerio`

**New dev dependencies**:

- `dependency` on `server`:  `@types/sanitize-html`
