### PR TITLE
fix(header): enable query only if postId defined

### DIFF
--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -37,11 +37,11 @@ const Header = () => {
     path: '/questions/:id',
   })
   const postId = matchPost?.params?.id
-  const { data: post } = postId
-    ? useQuery([GET_POST_BY_ID_QUERY_KEY, postId], () => getPostById(postId, 3))
-    : {
-        data: undefined,
-      }
+  const { data: post } = useQuery(
+    [GET_POST_BY_ID_QUERY_KEY, postId],
+    () => getPostById(postId, 3),
+    { enabled: Boolean(postId) },
+  )
 
   // Similar logic to find agency as login component
   // if post is linked to multiple agencies via agencyTag


### PR DESCRIPTION
## Problem

We foolishly thought that react hooks can be selected in and out at will, so we conditionally assigned a 
variable, causing React to panic when the number of hooks involved changed

## Solution

Ensure hooks are always called, preventing a network fetch using `enabled` field = postId being defined