### PR TITLE
feat(agencies): add display ordering of tags

### DIFF
--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -1,11 +1,10 @@
-import { Switch, Alert, AlertIcon } from '@chakra-ui/react'
-import React, { useMemo } from 'react'
+import { Alert, AlertIcon, Switch } from '@chakra-ui/react'
+import { useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { useHistory } from 'react-router-dom'
 import Select from 'react-select'
+import { Tag, TagType } from '~shared/types/base'
 import { RichTextEditor } from '../../../components/RichText/RichTextEditor.component'
-import { Tag } from '../../../services/tag.service'
-import { TagType } from '~shared/types/base'
 import './AskForm.styles.scss'
 
 export type AskFormSubmission = {

--- a/client/src/services/tag.service.ts
+++ b/client/src/services/tag.service.ts
@@ -1,14 +1,5 @@
+import { Tag } from '~shared/types/base'
 import { ApiClient } from '../api'
-
-// TODO: refactor into shared types between frontend and backend
-export interface Tag {
-  id: number
-  tagname: string
-  description: string
-  link: string
-  hasPilot: boolean
-  tagType: string
-}
 
 export const fetchTags = async (): Promise<Tag[]> =>
   ApiClient.get('/tags').then(({ data }) => data)

--- a/server/migrations/20211006020849-add-agency-order.js
+++ b/server/migrations/20211006020849-add-agency-order.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.addColumn('agencies', 'displayOrder', {
+      type: Sequelize.JSON,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface) => {
+    queryInterface.removeColumn('agencies', 'displayOrder')
+  },
+}

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -39,6 +39,15 @@ export const defineAgency = (
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    // Enforces a display order for categories
+    // belonging to an agency
+    displayOrder: {
+      type: DataTypes.JSON,
+      validate: {
+        isArray: true,
+      },
+      allowNull: true,
+    },
   })
   // Define associations for Agency
   Agency.hasMany(User)

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -1,15 +1,13 @@
-import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
-import { Agency as AgencyBaseDto } from '~shared/types/base'
-import { User } from './users.model'
-
-export interface Agency extends Model, AgencyBaseDto {}
+import { DataTypes, Sequelize } from 'sequelize'
+import { Agency, User } from '~shared/types/base'
+import { ModelDef } from '../types/sequelize'
 
 // constructor
 export const defineAgency = (
   sequelize: Sequelize,
-  { User }: { User: ModelCtor<User> },
-): ModelCtor<Agency> => {
-  const Agency: ModelCtor<Agency> = sequelize.define('agency', {
+  { User }: { User: ModelDef<User> },
+): ModelDef<Agency> => {
+  const Agency: ModelDef<Agency> = sequelize.define('agency', {
     shortname: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,4 +1,4 @@
-export { Agency, defineAgency } from './agencies.model'
+export { defineAgency } from './agencies.model'
 export { Answer, defineAnswer } from './answers.model'
 export { Post, PostTag, definePostAndPostTag } from './posts.model'
 export { Tag, defineTag } from './tags.model'

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -28,6 +28,7 @@ describe('/agencies', () => {
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
       noEnquiriesMessage: null,
       website: null,
+      displayOrder: null,
     })
     const agencyService = new AgencyService({ Agency })
     const controller = new AgencyController({ agencyService })

--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -21,6 +21,7 @@ describe('AgencyService', () => {
       logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
       noEnquiriesMessage: null,
       website: null,
+      displayOrder: null,
     })
     service = new AgencyService({ Agency })
   })

--- a/server/src/modules/enquiry/__tests__/enquiry.routes.spec.ts
+++ b/server/src/modules/enquiry/__tests__/enquiry.routes.spec.ts
@@ -1,11 +1,16 @@
 import bodyParser from 'body-parser'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { ModelCtor, Sequelize } from 'sequelize'
+import { Sequelize } from 'sequelize'
 import supertest from 'supertest'
-import { Agency as AgencyModel } from '../../../models'
+import { ModelDef } from '../../../types/sequelize'
+import { Agency } from '~shared/types/base'
 import { RecaptchaService } from '../../../services/recaptcha/recaptcha.service'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import {
+  createTestDatabase,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { MailService } from '../../mail/mail.service'
 import { EnquiryController } from '../enquiry.controller'
 import { routeEnquiries } from '../enquiry.routes'
@@ -19,10 +24,10 @@ describe('/enquiries', () => {
 
   // Set up sequelize
   let db: Sequelize
-  let Agency: ModelCtor<AgencyModel>
+  let Agency: ModelDef<Agency>
   let enquiryService: EnquiryService
   let enquiryController: EnquiryController
-  let mockAgency1: AgencyModel
+  let mockAgency1: Agency
 
   const axios = { get: jest.fn() }
   const googleRecaptchaURL = 'https://recaptcha.net'
@@ -41,12 +46,15 @@ describe('/enquiries', () => {
 
   beforeAll(async () => {
     db = await createTestDatabase()
-    Agency = getModel<AgencyModel>(db, ModelName.Agency)
+    Agency = getModelDef<Agency>(db, ModelName.Agency)
     mockAgency1 = await Agency.create({
       shortname: '1',
       longname: '',
       logo: 'www.url.com',
       email: 'agency1@ask.gov.sg',
+      noEnquiriesMessage: null,
+      website: null,
+      displayOrder: null,
     })
     enquiryService = new EnquiryService({ Agency, mailService })
     enquiryController = new EnquiryController({

--- a/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
+++ b/server/src/modules/enquiry/__tests__/enquiry.service.spec.ts
@@ -1,15 +1,21 @@
-import { ModelCtor, Sequelize } from 'sequelize'
-import { Agency as AgencyModel } from '../../../models'
+import { Sequelize } from 'sequelize'
+
+import { ModelDef } from '../../../types/sequelize'
+import { Agency } from '~shared/types/base'
 import { Enquiry } from '../../../types/mail-type'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import {
+  createTestDatabase,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { EnquiryService } from '../enquiry.service'
 
 describe('EnquiryService', () => {
   let db: Sequelize
-  let Agency: ModelCtor<AgencyModel>
+  let Agency: ModelDef<Agency>
   let enquiryService: EnquiryService
-  let mockAgency1: AgencyModel
-  let mockAgency2: AgencyModel
+  let mockAgency1: Agency
+  let mockAgency2: Agency
 
   const mailService = { sendEnquiry: jest.fn(), sendLoginOtp: jest.fn() }
 
@@ -21,18 +27,24 @@ describe('EnquiryService', () => {
 
   beforeAll(async () => {
     db = await createTestDatabase()
-    Agency = getModel<AgencyModel>(db, ModelName.Agency)
+    Agency = getModelDef<Agency>(db, ModelName.Agency)
     mockAgency1 = await Agency.create({
       shortname: '1',
       longname: '',
       logo: 'www.url.com',
       email: 'agency1@ask.gov.sg',
+      noEnquiriesMessage: null,
+      website: null,
+      displayOrder: null,
     })
     mockAgency2 = await Agency.create({
       shortname: '2',
       longname: '',
       logo: 'www.url.com',
       email: 'agency2@ask.gov.sg',
+      noEnquiriesMessage: null,
+      website: null,
+      displayOrder: null,
     })
     enquiryService = new EnquiryService({ Agency, mailService })
   })

--- a/server/src/modules/enquiry/enquiry.service.ts
+++ b/server/src/modules/enquiry/enquiry.service.ts
@@ -25,11 +25,11 @@ export class EnquiryService {
   }): Promise<void> => {
     const agencyEmail = await Promise.all(
       agencyId.map(
-        async (Id) =>
+        async (id) =>
           (
             await this.Agency.findOne({
               attributes: ['email'],
-              where: { Id },
+              where: { id },
             })
           )?.email ?? '',
       ),

--- a/server/src/modules/enquiry/enquiry.service.ts
+++ b/server/src/modules/enquiry/enquiry.service.ts
@@ -1,16 +1,16 @@
-import { ModelCtor } from 'sequelize/types'
-import { Agency } from '../../models'
+import { Agency } from '~shared/types/base'
 import { Enquiry } from '../../types/mail-type'
+import { ModelDef } from '../../types/sequelize'
 import { MailService } from '../mail/mail.service'
 
 export class EnquiryService {
-  private Agency: ModelCtor<Agency>
+  private Agency: ModelDef<Agency>
   private mailService: Public<MailService>
   constructor({
     Agency,
     mailService,
   }: {
-    Agency: ModelCtor<Agency>
+    Agency: ModelDef<Agency>
     mailService: Public<MailService>
   }) {
     this.Agency = Agency

--- a/server/src/util/jest-db.ts
+++ b/server/src/util/jest-db.ts
@@ -1,5 +1,6 @@
 import minimatch from 'minimatch'
 import { Model, ModelCtor, Sequelize } from 'sequelize'
+import { ModelDef } from '../types/sequelize'
 import {
   defineAgency,
   defineAnswer,
@@ -49,4 +50,11 @@ export function getModel<T extends Model>(
   modelName: ModelName,
 ): ModelCtor<T> {
   return sequelize.models[modelName] as ModelCtor<T>
+}
+
+export function getModelDef<T>(
+  sequelize: Sequelize,
+  modelName: ModelName,
+): ModelDef<T> {
+  return sequelize.models[modelName] as ModelDef<T>
 }

--- a/shared/src/types/base/agency.ts
+++ b/shared/src/types/base/agency.ts
@@ -8,6 +8,7 @@ export const Agency = BaseModel.extend({
   logo: z.string(),
   noEnquiriesMessage: z.string().nullable(),
   website: z.string().nullable(),
+  displayOrder: z.array(z.number()).nullable(),
 })
 
 export type Agency = z.infer<typeof Agency>


### PR DESCRIPTION
## Problem

Closes #490 

## Solution

Allow agencies to specify a display order by tag id

- Define displayOrder as JSON (MySQL does not support DataTypes.ARRAY)
- Add necessary Sequelize migration
- Use displayOrder to determine order of tag, depending on if a tag
  is specified. Fallback on alphabetical ordering as needed

Take the opportunity to move to using shared types

## Screenshot
![image](https://user-images.githubusercontent.com/10572368/136144463-679c95d8-1f5c-4240-a5f2-bb30015fe64d.png)


## Tests

- [ ] Ensure that display order for EMA in staging is not alphabetical, per screenshot

## Deploy Notes

- `20211006020849-add-agency-order` - already invoked in staging and prod
