### PR TITLE
fix(post): adjust colors for readability

### DIFF
--- a/client/src/pages/Post/AnswerSection/AnswerItem/AnswerItem.component.tsx
+++ b/client/src/pages/Post/AnswerSection/AnswerItem/AnswerItem.component.tsx
@@ -1,9 +1,11 @@
-import PropTypes from 'prop-types'
-import React from 'react'
 import { RichTextPreview } from '../../../../components/RichText/RichTextEditor.component'
 import './AnswerItem.styles.scss'
 
-const AnswerItem = ({ answer: { body } }) => {
+const AnswerItem = ({
+  answer: { body },
+}: {
+  answer: { body: string }
+}): JSX.Element => {
   return (
     <div className="answer-item">
       <div className="answer-body">
@@ -12,10 +14,6 @@ const AnswerItem = ({ answer: { body } }) => {
       </div>
     </div>
   )
-}
-
-AnswerItem.propTypes = {
-  answer: PropTypes.object.isRequired,
 }
 
 export default AnswerItem

--- a/client/src/pages/Post/AnswerSection/AnswerItem/AnswerItem.styles.scss
+++ b/client/src/pages/Post/AnswerSection/AnswerItem/AnswerItem.styles.scss
@@ -12,28 +12,10 @@
     grid-template-columns: 1fr 3fr;
   }
 
-  .agency-logo {
-    margin-right: 32px;
-    grid-row: 1/4;
-
-    @media not all and (min-width: $tablet) {
-      grid-row: 1/2;
-    }
-
-    img {
-      height: 40px;
-    }
-  }
-
-  .answer-metadata {
-    @include body-2;
-    color: $sec-400;
-  }
-
   .answer-body {
     @include body-1;
     margin-top: 4px;
-    color: $sec-500;
+    color: var(--chakra-colors-secondary-900);
 
     @media not all and (min-width: $tablet) {
       grid-column: 1/3;
@@ -44,53 +26,6 @@
       color: $pri-500;
     }
 
-    .answer-form {
-      textarea {
-        @include body-2;
-        padding: 8px;
-        width: 100%;
-        min-height: 100px;
-        border-radius: $radius-l;
-      }
-
-      .update-answer {
-        display: flex;
-        justify-content: flex-end;
-
-        button {
-          @include body-2;
-          background: none;
-          border: none;
-          color: $pri-500;
-          cursor: pointer;
-          margin-top: 8px;
-          margin-right: 16px;
-          padding: 0;
-        }
-      }
-    }
   }
 
-  .answer-btns {
-    margin-top: 8px;
-    margin-left: auto;
-
-    @media not all and (min-width: $tablet) {
-      grid-column: 2/3;
-    }
-
-    button {
-      @include body-2;
-      margin-left: 0;
-      margin-right: 16px;
-      background: none;
-      border: none;
-      color: $pri-500;
-      cursor: pointer;
-
-      &.delete-answer {
-        color: $danger-500;
-      }
-    }
-  }
 }

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -179,7 +179,12 @@ const Post = () => {
             </Text>
             {post.relatedPosts.map((relatedPost) => (
               <Link to={`/questions/${relatedPost.id}`}>
-                <Text mb="24px" textStyle="subhead-2" fontWeight="normal">
+                <Text
+                  mb="24px"
+                  color="primary.900"
+                  textStyle="subhead-2"
+                  fontWeight="normal"
+                >
                   {relatedPost.title}
                 </Text>
               </Link>


### PR DESCRIPTION
## Problem

When clicking through to a question, answer text and related question entries are
unreadable due to bad use of colour

## Solution

- Convert AnswerItem to tsx
- Remove spurious styling in AnswerItem.styles
- Set answer text color as secondary 900, related text as primary 900


## Screenshot
![image](https://user-images.githubusercontent.com/10572368/136147821-895afe91-4fe8-403a-a2d2-d55279461207.png)
