### PR TITLE
fix(sort): fix 'Most recent' and search result sorting

### DIFF
--- a/client/src/pages/SearchResults/SearchResults.component.jsx
+++ b/client/src/pages/SearchResults/SearchResults.component.jsx
@@ -17,7 +17,6 @@ import {
   listPosts,
   LIST_POSTS_FOR_SEARCH_QUERY_KEY,
 } from '../../services/PostService'
-import { sortByCreatedAt } from '../../util/date'
 import './SearchResults.styles.scss'
 
 const SearchResults = () => {
@@ -40,7 +39,6 @@ const SearchResults = () => {
   })
     .search(searchQuery)
     .map((res) => res.item)
-    .sort(sortByCreatedAt)
 
   return isLoading ? (
     <Spinner centerHeight="200px" />

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -57,7 +57,7 @@ export class PostService {
 
   private sortFunction = (sortType: SortType): OrderItem => {
     if (sortType === SortType.Basic) {
-      return ['createdAt', 'DESC']
+      return ['updatedAt', 'DESC']
     }
     return ['views', 'DESC']
   }


### PR DESCRIPTION
## Problems

1. 'Most recent' sorting was based on `createdAt` attribute when it should be by `updatedAt` attribute. 
2. Search results were sorted by `createdAt` attribute rather than relevance.

## Solution

1. Change sort function in post service to use `updatedAt`.
2. Remove `.sort(sortByCreatedAt)` done to search results.

## Tests

1. Update a post which was previously not at the top of the 'Most recent' sort. The post should now show up as the top result when sorting by 'Most recent'.
2. Create a post which has a prefix of a word _x_ which appears in other questions or descriptions. When _x_ is entered in to the search bar, questions with the full word should be ranked above the one with just the prefix.
