### PR TITLE
feat(view-all): add 'View all questions' button on main (and agency) pages

### DIFF
--- a/client/src/components/QuestionsList/QuestionsList.component.tsx
+++ b/client/src/components/QuestionsList/QuestionsList.component.tsx
@@ -1,27 +1,38 @@
 import { Center } from '@chakra-ui/layout'
-import { useState } from 'react'
+import { Button, Text } from '@chakra-ui/react'
+import { useState, useEffect } from 'react'
 import { useQuery } from 'react-query'
 import { listPosts, LIST_POSTS_QUERY_KEY } from '../../services/PostService'
+import { mergeTags } from '../../util/tagsmerger'
+import Pagination from '../Pagination'
 import PostListComponent from '../PostList/PostList.component'
 import Spinner from '../Spinner/Spinner.component'
-import './QuestionsList.styles.scss'
-import Pagination from '../Pagination'
 
 interface QuestionsListProps {
   sort: string
+  agency: string
   tags: string
   pageSize: number
 }
 
 const QuestionsList = ({
   sort,
+  agency,
   tags,
   pageSize,
 }: QuestionsListProps): JSX.Element => {
   // Pagination
   const [page, setPage] = useState(1)
+  const [expanded, setExpanded] = useState(tags.length > 0)
+
+  useEffect(() => {
+    setExpanded(tags.length > 0)
+  }, [tags])
+
+  const agencyAndTags = mergeTags(agency, tags)
+
   const { data, isLoading } = useQuery(
-    [LIST_POSTS_QUERY_KEY, { sort, tags, page, pageSize }],
+    [LIST_POSTS_QUERY_KEY, { sort, agencyAndTags, page, pageSize }],
     () => listPosts(sort, tags, page, pageSize),
     { keepPreviousData: true },
   )
@@ -37,18 +48,29 @@ const QuestionsList = ({
   ) : (
     <>
       <PostListComponent
-        posts={data?.posts}
+        posts={data?.posts.slice(0, expanded ? pageSize : 10)}
         defaultText={undefined}
         alertIfMoreThanDays={undefined}
         showViews={undefined}
       />
       <Center my={5}>
-        <Pagination
-          totalCount={data?.totalItems ?? 0}
-          pageSize={pageSize}
-          onPageChange={handlePageChange}
-          currentPage={page}
-        ></Pagination>
+        {expanded ? (
+          <Pagination
+            totalCount={data?.totalItems ?? 0}
+            pageSize={pageSize}
+            onPageChange={handlePageChange}
+            currentPage={page}
+          />
+        ) : (
+          <Button
+            variant="outline"
+            color="primary.500"
+            borderColor="primary.500"
+            onClick={() => setExpanded(true)}
+          >
+            <Text textStyle="subhead-1">View all questions</Text>
+          </Button>
+        )}
       </Center>
     </>
   )

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -244,8 +244,9 @@ const HomePage = ({ match }) => {
           ) : (
             <QuestionsListComponent
               sort={sortState.value}
-              tags={agencyAndTags}
-              pageSize={50}
+              agency={match.params.agency}
+              tags={queryState}
+              pageSize={30}
             />
           )}
         </Box>


### PR DESCRIPTION
## Problem

Cluttered UI with lots of scrolling which users have to do.

Closes #352

## Solution

As according to [design on AskGov Design Master v1](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5592%3A25597), following the changes were made: 

1. on main (/agency) pages: show top 10 with the 'View all questions' button at the end
2. on tag-specific page/ when 'View all questions' button is clicked: paginate with 30 questions per page

**Improvements**:

- Removed spurious QuestionsList styling sheet (it was empty...)

## Before & After Screenshots

**BEFORE**:

There were 50 questions per page. Users can browse through paginated questions with the following controls.

Pagination on mobile:

<img width="177" alt="Screenshot 2021-10-07 at 4 22 31 PM" src="https://user-images.githubusercontent.com/37061143/136347604-65cba54d-b568-4967-94ee-e6aa853801b5.png">

Pagination on desktop:

<img width="308" alt="Screenshot 2021-10-07 at 4 22 51 PM" src="https://user-images.githubusercontent.com/37061143/136347326-8693a703-c0fb-472e-bf3e-66a2ecae5914.png">

**AFTER**:

On main (/agency) pages, show top 10 questions. The following button is added to the end of the list for users to view more.

<img width="180" alt="Screenshot 2021-10-07 at 4 25 23 PM" src="https://user-images.githubusercontent.com/37061143/136347726-3cec726c-6ab2-4e19-aa69-d6e7f440bce0.png">

On tag-specific page/ when 'View all questions' button is clicked, pagination controls are the same as before.

## Tests

1. Navigate to a main (/agency) page - there should be only 10 questions with the 'View all questions' button at the end.
2. Click 'View all questions' - page should show at most 30 questions per page.
3. Click any tag - page should show paginated questions with at most 30 questions per page.
4. Try to break this by clicking around?
