### PR TITLE
feat(question-link): update question link color for default and on hover

### DIFF
--- a/client/src/components/PostItem/PostItem.component.jsx
+++ b/client/src/components/PostItem/PostItem.component.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { useAuth } from '../../contexts/AuthContext'
+import { Link, Text } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
 import { TagType } from '~shared/types/base'
+import { useAuth } from '../../contexts/AuthContext'
 import EditButton from '../EditButton/EditButton.component'
 import { RichTextFrontPreview } from '../RichText/RichTextEditor.component'
 import TagBadge from '../TagBadge/TagBadge.component'
@@ -35,10 +35,16 @@ const PostItem = ({
     <div className="post-with-stats flex">
       <div className="post-item">
         <div className="post-text">
-          <h2>
-            {/* Title display area */}
-            <Link to={`/questions/${id}`}>{title}</Link>
-          </h2>
+          {/* Title display area */}
+          <Link as={RouterLink} to={`/questions/${id}`}>
+            <Text
+              color="primary.900"
+              _hover={{ color: 'primary.600' }}
+              textStyle="h4"
+            >
+              {title}
+            </Text>
+          </Link>
           <div className="post-description-container">
             {description && <RichTextFrontPreview value={description} />}
           </div>


### PR DESCRIPTION
## Problem

Currently the color of question links screams out at users + Users might not know that questions are clickable.

## Solution

Update question link color based on [AskGov Design Master v1](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5685%3A8300).

**Features**:

- Update default question link color to primary 900 (very dark blue).
- Change question link color to primary 600 (ultramarine blue)

## Before & After Screenshots

**BEFORE**:

<img width="618" alt="Screenshot 2021-10-08 at 3 44 13 PM" src="https://user-images.githubusercontent.com/37061143/136517956-27e337a3-6a65-49f1-bc78-66735b605e56.png">

**AFTER**:

Default: 

<img width="195" alt="Screenshot 2021-10-08 at 3 43 29 PM" src="https://user-images.githubusercontent.com/37061143/136517855-0119c177-af1d-4cfe-bb9b-457c82f65da3.png">

On hover: 

![Screenshot 2021-10-08 at 3 42 29 PM](https://user-images.githubusercontent.com/37061143/136517778-9cef653c-e7fa-4405-801e-8fbb54ac494f.png)


## Tests

View questions in questions list, check color before and after hover.
