### PR TITLE
fix(questions): list by one page size, merged tags

### DIFF
--- a/client/src/components/QuestionsList/QuestionsList.component.tsx
+++ b/client/src/components/QuestionsList/QuestionsList.component.tsx
@@ -1,5 +1,5 @@
 import { Center } from '@chakra-ui/layout'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useQuery } from 'react-query'
 import { listPosts, LIST_POSTS_QUERY_KEY } from '../../services/PostService'
 import { mergeTags } from '../../util/tagsmerger'
@@ -24,17 +24,11 @@ const QuestionsList = ({
 }: QuestionsListProps): JSX.Element => {
   // Pagination
   const [page, setPage] = useState(1)
-  const [expanded, setExpanded] = useState(tags.length > 0)
-
-  useEffect(() => {
-    setExpanded(tags.length > 0)
-  }, [tags])
-
   const agencyAndTags = mergeTags(agency, tags)
 
   const { data, isLoading } = useQuery(
     [LIST_POSTS_QUERY_KEY, { sort, agencyAndTags, page, pageSize }],
-    () => listPosts(sort, tags, page, pageSize),
+    () => listPosts(sort, agencyAndTags, page, pageSize),
     { keepPreviousData: true },
   )
 
@@ -49,7 +43,7 @@ const QuestionsList = ({
   ) : (
     <>
       <PostListComponent
-        posts={data?.posts.slice(0, expanded ? pageSize : 10)}
+        posts={data?.posts.slice(0, pageSize)}
         defaultText={undefined}
         alertIfMoreThanDays={undefined}
       />


### PR DESCRIPTION
## Problem

Correct typos introduced in previous PRs before the frontend design
was committed to

## Solution

- Just use one page size, don't switch page sizes depending on tags
- Ensure that agency is included when querying for posts
