### PR TITLE
fix(tagmenu/panel): left-align tags in tagmenu and tagpanel

### DIFF
--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -142,7 +142,7 @@ const TagMenu = (): ReactElement => {
                       py="24px"
                       w="100%"
                       h="72px"
-                      textAlign="center"
+                      textAlign="left"
                       textStyle="h4"
                       borderBottomWidth="1px"
                       role="group"

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -3,14 +3,12 @@ import {
   AccordionButton,
   AccordionItem,
   AccordionPanel,
-  Box,
   Link,
   Spinner,
   Text,
   VStack,
   Flex,
   Spacer,
-  Center,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -125,7 +123,7 @@ const TagPanel = (): ReactElement => {
                       py="24px"
                       w="100%"
                       h="72px"
-                      textAlign="center"
+                      textAlign="left"
                       textStyle="h4"
                       borderBottomWidth="1px"
                       role="group"


### PR DESCRIPTION
## Problem

Topics in TagMenu and TagPanel were centralised if they had >1 line

## Solution

Change alignment to left-align
