### PR TITLE
fix(text-overflow): remove height restriction on tag menu and panel items

### DIFF
--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -141,7 +141,6 @@ const TagMenu = (): ReactElement => {
                     <Link
                       py="24px"
                       w="100%"
-                      h="72px"
                       textAlign="left"
                       textStyle="h4"
                       borderBottomWidth="1px"

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -89,26 +89,17 @@ const TagPanel = (): ReactElement => {
   return (
     <Accordion defaultIndex={[0]} allowMultiple>
       <AccordionItem border="none">
-        <h2>
-          <AccordionButton
-            h="72px"
-            px="0px"
-            py="0px"
-            _expanded={!agency ? { color: 'primary.500' } : undefined}
-          >
-            <Flex
-              maxW="680px"
-              m="auto"
-              w="100%"
-              px={{ base: 8, md: 8 }}
-              textAlign="left"
-            >
-              <Text textStyle="subhead-3" color="secondary.500" mt="36px">
-                TOPICS
-              </Text>
-            </Flex>
-          </AccordionButton>
-        </h2>
+        <AccordionButton
+          px="0px"
+          py="0px"
+          _expanded={!agency ? { color: 'primary.500' } : undefined}
+        >
+          <Flex maxW="680px" m="auto" w="100%" px={8} textAlign="left">
+            <Text textStyle="subhead-3" color="secondary.500" mt="36px">
+              TOPICS
+            </Text>
+          </Flex>
+        </AccordionButton>
         <AccordionPanel p={0} shadow="md">
           {isLoading && <Spinner />}
           {tags && (
@@ -122,7 +113,6 @@ const TagPanel = (): ReactElement => {
                     <Link
                       py="24px"
                       w="100%"
-                      h="72px"
                       textAlign="left"
                       textStyle="h4"
                       borderBottomWidth="1px"


### PR DESCRIPTION
## Problem

Text overflow on tag panel and menu due to fixed height.



## Solution

Remove height restriction and use padding instead.

## Before & After Screenshots

**BEFORE**:

<img width="246" alt="Screenshot 2021-10-11 at 11 08 32 AM" src="https://user-images.githubusercontent.com/37061143/136727962-6fbc5c04-dc65-485f-9b21-c77c5cc77ef5.png">

**AFTER**:


<img width="220" alt="Screenshot 2021-10-11 at 11 06 20 AM" src="https://user-images.githubusercontent.com/37061143/136727829-78c491ea-a2da-4bca-97e9-b36005e93f68.png">

<img width="220" alt="Screenshot 2021-10-11 at 11 06 33 AM" src="https://user-images.githubusercontent.com/37061143/136727835-2d11ee33-b4b8-4321-92cd-eec56ba59ca4.png">

## Tests

Reduce size of screen such that text for tag panel and menu items overflow to multiple lines.
