### PR TITLE
fix(text-overflow): fix text overflow issue for accordian button

### DIFF
--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -86,9 +86,9 @@ const TagMenu = (): ReactElement => {
             ref={accordionRef}
             borderBottomWidth="1px"
             px="0px"
-            py="0px"
+            pt="24px"
+            pb="16px"
             bg="primary.100"
-            h="104px"
             shadow="md"
             _expanded={{ shadow: 'none' }}
             _hover={{ bg: 'primary.200' }}
@@ -97,7 +97,7 @@ const TagMenu = (): ReactElement => {
               maxW="680px"
               m="auto"
               w="100%"
-              px={{ base: 8, md: 8 }}
+              px={8}
               textAlign="left"
               role="group"
             >
@@ -158,12 +158,7 @@ const TagMenu = (): ReactElement => {
                         accordionRef.current?.click()
                       }}
                     >
-                      <Flex
-                        maxW="680px"
-                        m="auto"
-                        w="100%"
-                        px={{ base: 8, md: 8 }}
-                      >
+                      <Flex maxW="680px" m="auto" w="100%" px={8}>
                         <Text _groupHover={{ color: 'primary.600' }}>
                           {tag.tagname}
                         </Text>

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -123,12 +123,7 @@ const TagPanel = (): ReactElement => {
                       to={getRedirectURL(tagType, tagname, agency)}
                       onClick={() => sendClickTagEventToAnalytics(tagname)}
                     >
-                      <Flex
-                        maxW="680px"
-                        m="auto"
-                        w="100%"
-                        px={{ base: 8, md: 8 }}
-                      >
+                      <Flex maxW="680px" m="auto" w="100%" px={8}>
                         <Text _groupHover={{ color: 'primary.600' }}>
                           {tag.tagname}
                         </Text>

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -139,7 +139,7 @@ const HomePage = ({ match }) => {
         m="auto"
         w="100%"
         pt="40px"
-        px={{ base: 8 }}
+        px={8}
         direction={{ base: 'column', lg: 'row' }}
       >
         <Box flex="5">


### PR DESCRIPTION
## Problem

Accordian button text still overflows. This means that topic pages where there are long topics will be ugly :(

## Solution

Remove fixed height and add 24px padding top and 16px padding bottom.

## Before & After Screenshots

**BEFORE**:

![image](https://user-images.githubusercontent.com/37061143/136730564-c651e288-415c-449a-a5fa-695a5a0436db.png)

**AFTER**:

<img width="205" alt="Screenshot 2021-10-11 at 11 48 43 AM" src="https://user-images.githubusercontent.com/37061143/136730607-b4dce077-ea0c-4a8d-85e1-0474c585dab4.png">

## Tests

Go to page where a topic is selected. Resize viewport such that text overflows to next line and check that it looks something like the screenshot (ie still has padding around text).
