### PR TITLE
fix(homepage): add questions list title to mobile view

### DIFF
--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -153,16 +153,15 @@ const HomePage = ({ match }) => {
               ) : null
             })}
           <Flex
-            flexDir={{ base: 'column', sm: 'row' }}
+            flexDir={{ base: 'column-reverse', sm: 'row' }}
             mb={5}
             justifyContent="space-between"
           >
             <Text
               color="secondary.500"
               textStyle="subhead-3"
-              mb={{ base: '20px', sm: 0 }}
-              mr={{ base: 0, sm: '20px' }}
-              d={{ base: 'none', sm: 'block' }}
+              mt={{ base: '32px', sm: 0 }}
+              d="block"
             >
               {hasTagsKey
                 ? queryState


### PR DESCRIPTION
## Problem

The heading above the list of posts does not appear in mobile view

## Solution

- Remove "none" for base display size
- Change flexdir to row-reverse for mobile so that the view sorting menu appears above the heading, as indicated on [Figma](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5604%3A20970)

**BEFORE**:
![image](https://user-images.githubusercontent.com/56983748/136734477-c9762ea3-29bf-41ea-97ae-1f064a55337b.png)


**AFTER**:

https://user-images.githubusercontent.com/56983748/136734587-f4ad7bdf-d196-45d0-a033-e643dfb84b5d.mov


## Tests

- In mobile view, ensure that the following title appears before the list of posts
  - Main page: 'TOP QUESTIONS'
  - Main page after clicking 'View all questions': 'ALL QUESTIONS'
  - Topic page: 'QUESTIONS ON THIS TOPIC'
