### PR TITLE
fix(postitem): center post title vertically

### DIFF
--- a/client/src/components/PostItem/PostItem.styles.scss
+++ b/client/src/components/PostItem/PostItem.styles.scss
@@ -47,7 +47,6 @@
       .post-description-container {
         @include body-2;
         color: $sec-500;
-        padding-bottom: 16px;
 
         .public-DraftStyleDefault-block {
           margin-top: 0px;


### PR DESCRIPTION
## Problem

Posts are not aligned vertically in the home page, as specified on [Figma](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5568%3A19305)

## Solution

- remove bottom padding in PostItem


## Before & After Screenshots

**BEFORE**:
Mobile:
![image](https://user-images.githubusercontent.com/56983748/136743414-c41f685e-a5b1-455b-9711-eed712799ffd.png)

Desktop: 
![image](https://user-images.githubusercontent.com/56983748/136743376-6b860fb5-d07e-45e8-a898-5fea528eddd4.png)


**AFTER**:
Mobile:
![image](https://user-images.githubusercontent.com/56983748/136743283-f383dfb1-6465-4bfb-b842-e45d3b0c0f87.png)

Desktop:
![image](https://user-images.githubusercontent.com/56983748/136743252-4ed6d5c9-d072-4d83-9ed4-4f451900bb9d.png)


## Tests

- Check that post titles and descriptions are centred vertically

