### PR TITLE
fix(archived-posts): redirect to /not-found when public post with postId doesn't exist

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -28,6 +28,7 @@ import './Post.styles.scss'
 import QuestionSection from './QuestionSection/QuestionSection.component'
 
 const Post = () => {
+  // Does not need to handle logic when public post with id postId is not found because this is handled by server
   const { id: postId } = useParams()
   const { data: post, isLoading } = useQuery(
     [GET_POST_BY_ID_QUERY_KEY, postId],
@@ -75,6 +76,7 @@ const Post = () => {
   const { _, data: answers } = useQuery(
     [GET_ANSWERS_FOR_POST_QUERY_KEY, post?.id],
     () => getAnswersForPost(post?.id),
+    { enabled: Boolean(post?.id) },
   )
 
   return isLoading ? (

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -410,6 +410,7 @@ export class PostService {
     }
     const post = (await this.Post.findOne({
       where: {
+        status: PostStatus.Public,
         id: postId,
       },
       include: [this.Tag, { model: this.User, attributes: ['displayname'] }],
@@ -432,13 +433,13 @@ export class PostService {
         ],
       ],
     })) as PostWithUserTagRelatedPostRelations
-    if (noOfRelatedPosts > 0) {
-      const relatedPosts = await this.getRelatedPosts(post, noOfRelatedPosts)
-      post.setDataValue('relatedPosts', relatedPosts)
-    }
     if (!post) {
-      throw new Error('No post with this id')
+      throw new Error('No public post with this id')
     } else {
+      if (noOfRelatedPosts > 0) {
+        const relatedPosts = await this.getRelatedPosts(post, noOfRelatedPosts)
+        post.setDataValue('relatedPosts', relatedPosts)
+      }
       return post
     }
   }


### PR DESCRIPTION
## Problem

Archived post pages are still indexed by google search crawlers and do not redirect to not-found page.

Closes #540

## Solution

Modify `getSinglePost` in post service to only query for public posts.

**Features**:

- (post.service) edit sequelize query for getSinglePost to only query for public posts
- (post.service) query for related posts only when post with postId is found

**Improvements**:

- (Post.component) query for answers only when post.id exists

## Before & After Screenshots

**BEFORE**:

Post page is crawled by google search crawler.

When post page is accessed:

https://user-images.githubusercontent.com/37061143/136732192-a5b2ddc8-7b63-4ffa-b0d6-e69977254fac.mov

When checked on FB sharing debugger:

https://user-images.githubusercontent.com/37061143/136763939-1517fbd5-4886-4a86-a3d1-b2be017ff529.mov

**AFTER**:

https://user-images.githubusercontent.com/37061143/136762664-201881b0-4406-4e87-8699-9f4b6c7d95cf.mov

## Tests

0. Find a post page's URL where the post has been archived. Such a post can be found by first creating a post, saving the post page's URL, then deleting the post. The post page URL referred to subsequent steps would be the URL found in this step.
1. Try to access the post page. You should be redirected to /not-found.
2. On [FB Sharing Debugger](https://developers.facebook.com/tools/debug/), debug the URL found. The response code should be 404 and all the other details should be the same as other invalid URLs.
