### PR TITLE
fix(read-me): update README ERD with new fields in agencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Optionally [DBeaver](https://dbeaver.io/download/) to view database with GUI
 
 * Check that your Database ER Diagram looks like this:
   
-![image](https://user-images.githubusercontent.com/56983748/136761810-b064eead-afa1-4b17-810a-6a864d4ad392.png)
+![image](https://user-images.githubusercontent.com/56983748/136875947-1ca6b005-a413-4e89-8eb8-d79761ca2c35.png)
 
 
 * Stop docker compose (`npm run dev` will spin it up again):


### PR DESCRIPTION
## Problem

The ERD from the topics model PR (#405) is outdated as changes were made to the ERD after that PR was created.

## Solution
Update ER Diagram with 'noEnquiriesMessages', 'website' and 'displayOrder' fields in agencies model, to account for database schema changes made after the topics model was introduced