### PR TITLE
fix(search): wraparound text for autosuggest entries

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -214,7 +214,7 @@ const SearchItem = ({
         backgroundColor:
           highlightedIndex === index
             ? // TODO use classes instead of inlining styles
-              '#e4e7f6' //using primary 200
+              'primary.200'
             : 'white',
       },
       className: 'search-item',

--- a/client/src/components/SearchBox/SearchBox.styles.scss
+++ b/client/src/components/SearchBox/SearchBox.styles.scss
@@ -1,4 +1,3 @@
-@import '../../styles/colours';
 @import '../../styles/misc';
 @import '../../styles/text';
 
@@ -17,8 +16,8 @@
       flex: 1;
 
       .search-box {
-        color: $neutral-900;
-        background-color: $white;
+        color: var(--chakra-colors-neutral-900);
+        background-color: white;
         border: 1px solid var(--chakra-colors-gray-800);
         border-radius: 4px;
         width: 100%;
@@ -30,7 +29,7 @@
       }
 
       .search-box .search-input::placeholder{
-        color: $neutral-500
+        color: var(--chakra-colors-neutral-500);
       }
 
       .search-results {
@@ -50,16 +49,12 @@
       .search-item {
         display: flex;
         align-items: center;
-        padding: 0 16px;
-        height: 50px;
+        padding: 10px 16px;
         box-sizing: border-box;
         width: 100%;
 
         .search-item-text {
-          color: $neutral-800;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-          overflow: hidden;
+          color: var(--chakra-colors-neutral-800);
         }
       }
     }

--- a/client/src/components/SearchBox/SearchBox.styles.scss
+++ b/client/src/components/SearchBox/SearchBox.styles.scss
@@ -18,7 +18,6 @@
       .search-box {
         color: var(--chakra-colors-neutral-900);
         background-color: white;
-        border: 1px solid var(--chakra-colors-gray-800);
         border-radius: 4px;
         width: 100%;
         height: 100%;


### PR DESCRIPTION
## Problem and Solution 
- Change fixed height and truncated text overflow to variable height,
  padding and text wraparound
- Take the chance to use chakra-specified theme colours where possible

## Before & After Screenshots

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/10572368/136913143-8919dbe7-d2c3-4cca-8626-0149abdba75b.png) | ![image](https://user-images.githubusercontent.com/10572368/136912887-cea12978-9c43-4cf0-a6f6-662f97513ccd.png) |
