### PR TITLE
fix(post-title): update UI for post titles

### DIFF
--- a/client/src/pages/EditForm/EditForm.styles.scss
+++ b/client/src/pages/EditForm/EditForm.styles.scss
@@ -1,10 +1,6 @@
 @import '../../styles/text';
 @import '../../styles/colours';
 
-.back-to-home {
-  max-width: calc(793px + 48px * 2);
-}
-
 .edit-form-container {
   box-sizing: border-box;
   width: 100%;

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -122,11 +122,11 @@ const Post = () => {
                 </div>
               )}
             </Flex>
-            <Text textStyle="h1" color="primary.500" pb="14px">
+            <Text textStyle="h2" color="secondary.500">
               {post.title}
             </Text>
-            <div className="subtitle-bar">
-              {post.status === PostStatus.Private ? (
+            {post.status === PostStatus.Private ? (
+              <div className="subtitle-bar">
                 <div className="private-subtitle">
                   <BiXCircle
                     style={{ marginRight: '4px' }}
@@ -137,8 +137,8 @@ const Post = () => {
                     This question remains private until an answer is posted.
                   </span>
                 </div>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
             <div className="question-main">
               <QuestionSection post={post} />
               <AnswerSection answers={answers} />

--- a/client/src/pages/Post/Post.styles.scss
+++ b/client/src/pages/Post/Post.styles.scss
@@ -2,10 +2,6 @@
 @import '../../styles/text';
 @import '../../styles/colours';
 
-.back-to-home {
-  max-width: calc(796px + 48px * 2);
-}
-
 .post-page {
 
   .btn-bar {

--- a/client/src/pages/Post/QuestionSection/PostCell/PostCell.styles.scss
+++ b/client/src/pages/Post/QuestionSection/PostCell/PostCell.styles.scss
@@ -14,6 +14,7 @@
     @include body-1;
     width: 100%;
     color: $sec-500;
+    margin-top: 16px;
     margin-bottom: 16px;
 
     .public-DraftStyleDefault-block {

--- a/client/src/pages/PostForm/PostForm.styles.scss
+++ b/client/src/pages/PostForm/PostForm.styles.scss
@@ -1,10 +1,6 @@
 @import '../../styles/text';
 @import '../../styles/colours';
 
-.back-to-home {
-  max-width: calc(793px + 48px * 2);
-}
-
 .post-form-container {
   box-sizing: border-box;
   width: 100%;


### PR DESCRIPTION
## Problem

Update post title styling based on [AskGov Design Master v1](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5779%3A8258)

## Solution

- change color
- remove unnecessary padding
- remove back-to-home styling

## Before & After Screenshots

**BEFORE**:

<img width="776" alt="Screenshot 2021-10-12 at 3 43 19 PM" src="https://user-images.githubusercontent.com/37061143/136913450-5b66474c-faf1-467a-a1f9-2c29d8b1505e.png">


**AFTER**:

<img width="773" alt="Screenshot 2021-10-12 at 3 42 54 PM" src="https://user-images.githubusercontent.com/37061143/136913487-9c2a7a48-107f-410d-8635-448d2a24c198.png">

## Tests

Go to a post page and check title styling against figma mentioned above.