### PR TITLE
fix(post): modify horizontal margins

### DIFF
--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -128,7 +128,7 @@ const Post = () => {
       <Center>
         <Stack
           maxW="1188px"
-          px="48px"
+          px={{ base: '24px', sm: '88px' }}
           direction={{ base: 'column', lg: 'row' }}
           spacing={{ base: '20px', lg: '88px' }}
         >


### PR DESCRIPTION
## Problem

Horizontal margins on mobile were too large, making content look squished

## Solution

Adjust margins for mobile and tablet view, according to the [mobile and tablet layouts](https://www.figma.com/file/Y2sqYzAkssq5xSFTN9KZeX/AskGov-Design-Master-v1?node-id=5603%3A20476)

## Before & After Screenshots

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/56983748/137054048-d1007af2-445d-4dcd-bb8f-bae3233e2534.png) | ![image](https://user-images.githubusercontent.com/56983748/137054106-9c21820f-6566-4771-af43-4e67a36424ac.png) |
