### PR TITLE
fix(links): fallback to https if cannot parse url

### DIFF
--- a/client/src/components/RichText/LinkDecorator.tsx
+++ b/client/src/components/RichText/LinkDecorator.tsx
@@ -34,7 +34,16 @@ const PreviewLinkSpan = ({
   entityKey: string
 }): JSX.Element => {
   const { url } = contentState.getEntity(entityKey).getData()
-  const protocol = new URL(url).protocol.toString()
+  let protocol
+  try {
+    protocol = new URL(url).protocol.toString()
+  } catch {
+    // If we fail to parse the URL, assume that it is bad,
+    // and default to https
+    // TODO: Find a way to flag this both to the public viewer
+    // and the public servant
+    protocol = 'https:'
+  }
   if (protocol in targetOptions) {
     return (
       <span className="rdw-link-decorator-wrapper">


### PR DESCRIPTION
## Problem

AskGov's frontend crashes if it cannot parse a malformed URL found in the content of the post

## Solution

Since we parse the URL only to obtain the protocol, gracefully fallback on `https:` if we fail to do so

TODO:
Prevent the user from creating malformed users, and warn the public or users if bad URLs are encountered
in content

## Tests
- Create a question with a badly formed URL 
- Verify that the page continues to render