### PR TITLE
feat(sitemap): add sitemap

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://ask.gov.sg/sitemap.xml

--- a/server/src/bootstrap/config/base.ts
+++ b/server/src/bootstrap/config/base.ts
@@ -10,6 +10,7 @@ export type BaseConfig = {
   nodeEnv: Environment
   serverPort: number
   logoHost: string
+  hostUrl: string
 }
 
 const baseSchema: Schema<BaseConfig> = {
@@ -30,6 +31,12 @@ const baseSchema: Schema<BaseConfig> = {
     format: String,
     default: 'https://s3-ap-southeast-1.amazonaws.com/',
     env: 'LOGOS_HOST',
+  },
+  hostUrl: {
+    doc: 'Host url',
+    format: String,
+    default: 'https://ask.gov.sg',
+    env: 'HOST_URL',
   },
 }
 

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -59,6 +59,7 @@ import {
   User,
 } from './sequelize'
 import sessionMiddleware from './session'
+import { SortType } from '../types/sort-type'
 
 export { sequelize } from './sequelize'
 export const app = express()
@@ -195,7 +196,7 @@ if (baseConfig.nodeEnv === Environment.Prod) {
 
 app.use('/api/v1', api(apiOptions))
 
-const getSitemapUrls = () => {
+const getSitemapUrls = async () => {
   const visibleStaticPaths = ['/', '/terms', '/privacy']
   const sitemapLeaves: SitemapLeaf[] = []
   for (const path of visibleStaticPaths) {
@@ -204,7 +205,16 @@ const getSitemapUrls = () => {
       lastMod: true,
     })
   }
-
+  const { posts: allPosts } = await postService.listPosts({
+    sort: SortType.Top,
+    tags: '',
+  })
+  for (const post of allPosts) {
+    sitemapLeaves.push({
+      url: `/questions/${post.id}`,
+      lastMod: true,
+    })
+  }
   return sitemapLeaves
 }
 

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -33,6 +33,7 @@ import { routeWeb } from '../modules/web/web.routes'
 import { WebService } from '../modules/web/web.service'
 import { api } from '../routes'
 import { RecaptchaService } from '../services/recaptcha/recaptcha.service'
+import { SortType } from '../types/sort-type'
 import { bannerConfig } from './config/banner'
 import { baseConfig, Environment } from './config/base'
 import { datadogConfig } from './config/datadog'
@@ -59,7 +60,6 @@ import {
   User,
 } from './sequelize'
 import sessionMiddleware from './session'
-import { SortType } from '../types/sort-type'
 
 export { sequelize } from './sequelize'
 export const app = express()
@@ -209,11 +209,20 @@ const getSitemapUrls = async () => {
     sort: SortType.Top,
     tags: '',
   })
+  const allAgencyShortnames = await agencyService.listAgencyShortnames()
   for (const post of allPosts) {
     sitemapLeaves.push({
       url: `/questions/${post.id}`,
       lastMod: true,
     })
+  }
+  if (allAgencyShortnames.isOk()) {
+    for (const agency of allAgencyShortnames.value) {
+      sitemapLeaves.push({
+        url: `/agency/${agency.shortname}`,
+        lastMod: true,
+      })
+    }
   }
   return sitemapLeaves
 }

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -3,6 +3,7 @@ import compression from 'compression'
 import connectDatadog from 'connect-datadog'
 import cors from 'cors'
 import express from 'express'
+import expressSitemapXml, { SitemapLeaf } from 'express-sitemap-xml'
 import fs from 'fs'
 import helmet from 'helmet'
 import { StatsD } from 'hot-shots'
@@ -194,11 +195,26 @@ if (baseConfig.nodeEnv === Environment.Prod) {
 
 app.use('/api/v1', api(apiOptions))
 
+const getSitemapUrls = () => {
+  const visibleStaticPaths = ['/', '/terms', '/privacy']
+  const sitemapLeaves: SitemapLeaf[] = []
+  for (const path of visibleStaticPaths) {
+    sitemapLeaves.push({
+      url: path,
+      lastMod: true,
+    })
+  }
+
+  return sitemapLeaves
+}
+
 // connection with client setup
 if (baseConfig.nodeEnv === Environment.Prod) {
   app.use(
     express.static(path.resolve(__dirname, '../../..', 'client', 'build')),
   )
+
+  app.use(expressSitemapXml(getSitemapUrls, baseConfig.hostUrl))
 
   app.use('/', routeWeb({ controller: webController }))
 

--- a/server/src/modules/agency/__tests__/agency.controller.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.controller.spec.ts
@@ -17,6 +17,7 @@ describe('AgencyController', () => {
   const agencyService = {
     findOneByName: jest.fn(),
     findOneById: jest.fn(),
+    listAgencyShortnames: jest.fn(),
   }
   const agencyController = new AgencyController({ agencyService })
 

--- a/server/src/modules/agency/agency.service.ts
+++ b/server/src/modules/agency/agency.service.ts
@@ -81,4 +81,25 @@ export class AgencyService {
       return okAsync(agency)
     })
   }
+
+  listAgencyShortnames = (): ResultAsync<Agency[], DatabaseError> => {
+    return ResultAsync.fromPromise(
+      this.Agency.findAll({ attributes: ['shortname'] }),
+      (error) => {
+        logger.error({
+          message: 'Database error while retrieving all agency shortnames',
+          meta: {
+            function: 'listAgencyShortnames',
+          },
+          error,
+        })
+        return new DatabaseError()
+      },
+    ).andThen((agencyShortnames) => {
+      if (!agencyShortnames) {
+        return errAsync(new MissingAgencyError())
+      }
+      return okAsync(agencyShortnames)
+    })
+  }
 }

--- a/server/src/modules/file/file.controller.ts
+++ b/server/src/modules/file/file.controller.ts
@@ -1,4 +1,3 @@
-import { Request, Response } from 'express'
 import { ControllerHandler } from '../../types/response-handler'
 import { createLogger } from '../../bootstrap/logging'
 import { FileService } from './file.service'

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
 import { createLogger } from '../../bootstrap/logging'
 import { ControllerHandler } from '../../types/response-handler'
+import { SortType } from '../../types/sort-type'
 import { AgencyService } from '../agency/agency.service'
 import { AnswersService } from '../answers/answers.service'
 import { PostService } from '../post/post.service'
@@ -70,11 +71,10 @@ export class WebController {
           },
           error: agency.error,
         })
-        if (agency.error.statusCode === StatusCodes.NOT_FOUND) {
+        if (agency.error.statusCode === StatusCodes.NOT_FOUND)
           return res.status(StatusCodes.NOT_FOUND).redirect('/not-found')
-        } else {
+        else
           return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
-        }
       }
     } catch (error) {
       logger.error({
@@ -115,9 +115,8 @@ export class WebController {
           answers[0].body,
         )
         return res.status(StatusCodes.OK).send(postPage)
-      } else {
+      } else
         return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
-      }
     } catch (error) {
       logger.error({
         message: 'Error while getting post page',
@@ -128,6 +127,36 @@ export class WebController {
         error,
       })
       return res.status(StatusCodes.NOT_FOUND).redirect('/not-found')
+    }
+  }
+
+  /**
+   * Gets sitemap urls
+   * @returns list of sitemap urls
+   */
+  getSitemapUrls = async () => {
+    try {
+      const { posts: allPosts } = await this.postService.listPosts({
+        sort: SortType.Top,
+        tags: '',
+      })
+      const allAgencyShortnames =
+        await this.agencyService.listAgencyShortnames()
+      if (allAgencyShortnames.isOk())
+        return await this.webService.getSitemapUrls(
+          allPosts,
+          allAgencyShortnames.value,
+        )
+      else return []
+    } catch (error) {
+      logger.error({
+        message: 'Error while getting sitemap urls',
+        meta: {
+          function: 'getSitemapUrls',
+        },
+        error,
+      })
+      return []
     }
   }
 }

--- a/server/src/modules/web/web.routes.ts
+++ b/server/src/modules/web/web.routes.ts
@@ -1,5 +1,7 @@
 import express from 'express'
+import expressSitemapXml from 'express-sitemap-xml'
 import { param } from 'express-validator'
+import { baseConfig } from '../../bootstrap/config/base'
 import { WebController } from './web.controller'
 
 export const routeWeb = ({
@@ -32,6 +34,14 @@ export const routeWeb = ({
     [param('id').isInt().toInt()],
     controller.getQuestionPage,
   )
+
+  /**
+   * Serves sitemap
+   * @route   USE /sitemap.xml
+   * @returns sitemap
+   * @access  Public
+   */
+  router.use(expressSitemapXml(controller.getSitemapUrls, baseConfig.hostUrl))
 
   return router
 }

--- a/server/src/modules/web/web.service.ts
+++ b/server/src/modules/web/web.service.ts
@@ -1,6 +1,9 @@
 import cheerio from 'cheerio'
+import { SitemapLeaf } from 'express-sitemap-xml'
 import fs from 'fs'
 import path from 'path'
+import { Agency } from '~shared/types/base'
+import { Post } from '../../models'
 
 const index = fs.readFileSync(
   path.resolve(__dirname, '../../../..', 'client', 'build', 'index.html'),
@@ -57,5 +60,38 @@ export class WebService {
     $('meta[property="og:description"]').attr('content', `${description}`)
 
     return $.html()
+  }
+
+  /**
+   * Returns list of sitemap urls
+   * @param allPosts list of public posts
+   * @param allAgencies list of agencies
+   * @returns list of sitemap urls
+   */
+  getSitemapUrls = async (
+    allPosts: Post[],
+    allAgencies: Agency[],
+  ): Promise<SitemapLeaf[]> => {
+    const visibleStaticPaths = ['/', '/terms', '/privacy']
+    const sitemapLeaves: SitemapLeaf[] = []
+    for (const path of visibleStaticPaths) {
+      sitemapLeaves.push({
+        url: path,
+        lastMod: true,
+      })
+    }
+    for (const post of allPosts) {
+      sitemapLeaves.push({
+        url: `/questions/${post.id}`,
+        lastMod: true,
+      })
+    }
+    for (const agency of allAgencies) {
+      sitemapLeaves.push({
+        url: `/agency/${agency.shortname}`,
+        lastMod: true,
+      })
+    }
+    return sitemapLeaves
   }
 }


### PR DESCRIPTION
## Problem

Search crawlers may not be able to understand the structure of the site, resulting more time spent crawling unnecessary URLs on the site. This waste of time translates to a waste of crawl budget, meaning that search crawlers might not be able to index the whole site in time.

A sitemap helps in our case as our agency pages are in silos.

Closes #400 

## Solution

Use `express-sitemap-xml` to generate and serve sitemap. Sitemap is served at `/sitemap.xml`. Sitemap checkers (e.g. https://seositecheckup.com/tools/sitemap-test) should be able to see sitemap.

**Features**:

- add all paths which members of public should be able to see to the sitemap

## Before & After Screenshots

**BEFORE**:

When we `GET` `/sitemap.xml`, users will be directed to `/not-found`.

Sitemap checkers are unable to detect the sitemap either:

<img width="934" alt="Screenshot 2021-10-13 at 1 58 10 PM" src="https://user-images.githubusercontent.com/37061143/137075503-41dc5f29-1e4c-446e-9515-f78bd8ec34ad.png">


**AFTER**:

Sitemap file is served at `/sitemap.xml`.

<img width="752" alt="Screenshot 2021-10-13 at 1 55 05 PM" src="https://user-images.githubusercontent.com/37061143/137075152-ccc02db3-54a4-44da-a846-abcbdf33fc2e.png">

Sitemap checker is able to detect the sitemap.

<img width="938" alt="Screenshot 2021-10-13 at 1 54 34 PM" src="https://user-images.githubusercontent.com/37061143/137075098-6a8faa85-9964-451c-9b08-8dd0066fce57.png">

## Tests

1. Check `/sitemap.xml` to ensure that a sitemap is served and that it includes static paths (visible to public), post pages and agency pages.
2. Use a sitemap checker to check that sitemap can be detected.
