### PR TITLE
refactor(posts): move to ModelDef

### DIFF
--- a/server/src/middleware/checkOwnership.ts
+++ b/server/src/middleware/checkOwnership.ts
@@ -5,8 +5,8 @@ import {
   User as UserModel,
 } from '../bootstrap/sequelize'
 import { Request, Response, NextFunction } from 'express'
-import { Answer, Post, Tag } from '../models'
-import { TagType } from '~shared/types/base'
+import { Answer, Tag } from '../models'
+import { TagType, Post } from '~shared/types/base'
 import { StatusCodes } from 'http-status-codes'
 
 type AnswerWithRelations = Answer & {

--- a/server/src/models/answers.model.ts
+++ b/server/src/models/answers.model.ts
@@ -1,7 +1,8 @@
 import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
-import { Answer as AnswerBaseDto } from '~shared/types/base'
+import { ModelDef } from '../types/sequelize'
+import { Post, Answer as AnswerBaseDto } from '~shared/types/base'
 import { User } from './users.model'
-import { Post } from './posts.model'
+import { PostCreation } from './posts.model'
 
 // TODO (#225): Remove this and replace ModelCtor below with ModelDefined
 export interface Answer extends Model, AnswerBaseDto {}
@@ -9,7 +10,7 @@ export interface Answer extends Model, AnswerBaseDto {}
 // constructor
 export const defineAnswer = (
   sequelize: Sequelize,
-  { User, Post }: { User: ModelCtor<User>; Post: ModelCtor<Post> },
+  { User, Post }: { User: ModelCtor<User>; Post: ModelDef<Post, PostCreation> },
 ): ModelCtor<Answer> => {
   const Answer: ModelCtor<Answer> = sequelize.define('answer', {
     body: {

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,6 +1,6 @@
 export { defineAgency } from './agencies.model'
 export { Answer, defineAnswer } from './answers.model'
-export { Post, PostTag, definePostAndPostTag } from './posts.model'
+export { PostTag, definePostAndPostTag } from './posts.model'
 export { Tag, defineTag } from './tags.model'
 export { Token, defineToken } from './token.model'
 export { User, Permission, defineUserAndPermission } from './users.model'

--- a/server/src/models/posts.model.ts
+++ b/server/src/models/posts.model.ts
@@ -1,11 +1,20 @@
 import { Sequelize, DataTypes } from 'sequelize'
-import { ModelDef } from '../types/sequelize'
+import { ModelDef, Creation } from '../types/sequelize'
 import { Post, PostStatus, Topic, User, Tag } from '~shared/types/base'
 
 export interface PostTag {
   postId: number
   tagId: number
 }
+
+// We explicitly make views optional because Sequelize
+// is lacking in its type support such that it blindly takes your
+// creation attributes as canonical, not inferring defaults as optional
+export type PostCreation = Creation<
+  Omit<Post, 'views'> & {
+    views?: number
+  }
+>
 
 // constructor
 export const definePostAndPostTag = (
@@ -15,8 +24,8 @@ export const definePostAndPostTag = (
     Tag,
     Topic,
   }: { User: ModelDef<User>; Tag: ModelDef<Tag>; Topic: ModelDef<Topic> },
-): { Post: ModelDef<Post>; PostTag: ModelDef<PostTag> } => {
-  const Post: ModelDef<Post> = sequelize.define('post', {
+): { Post: ModelDef<Post, PostCreation>; PostTag: ModelDef<PostTag> } => {
+  const Post: ModelDef<Post, PostCreation> = sequelize.define('post', {
     title: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/server/src/models/posts.model.ts
+++ b/server/src/models/posts.model.ts
@@ -1,13 +1,8 @@
-import { Sequelize, DataTypes, Model, ModelCtor } from 'sequelize'
+import { Sequelize, DataTypes } from 'sequelize'
 import { ModelDef } from '../types/sequelize'
-import { User } from './users.model'
-import { Tag } from './tags.model'
-import { Post as PostBaseDto, PostStatus, Topic } from '~shared/types/base'
+import { Post, PostStatus, Topic, User, Tag } from '~shared/types/base'
 
-// TODO (#225): Remove this and replace ModelCtor below with ModelDefined
-export interface Post extends Model, PostBaseDto {}
-
-export interface PostTag extends Model {
+export interface PostTag {
   postId: number
   tagId: number
 }
@@ -19,9 +14,9 @@ export const definePostAndPostTag = (
     User,
     Tag,
     Topic,
-  }: { User: ModelCtor<User>; Tag: ModelCtor<Tag>; Topic: ModelDef<Topic> },
-): { Post: ModelCtor<Post>; PostTag: ModelCtor<PostTag> } => {
-  const Post: ModelCtor<Post> = sequelize.define('post', {
+  }: { User: ModelDef<User>; Tag: ModelDef<Tag>; Topic: ModelDef<Topic> },
+): { Post: ModelDef<Post>; PostTag: ModelDef<PostTag> } => {
+  const Post: ModelDef<Post> = sequelize.define('post', {
     title: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -44,7 +39,11 @@ export const definePostAndPostTag = (
     },
   })
 
-  const PostTag: ModelCtor<PostTag> = sequelize.define('posttag', {})
+  // Silence tsc errors since we will be adding the relevant
+  // foreign key relations to PostTag later on
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const PostTag: ModelDef<PostTag> = sequelize.define('posttag', {})
 
   // Define associations for Post
   User.hasMany(Post)

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -4,18 +4,19 @@ import {
   Agency as AgencyModel,
   Answer as AnswerModel,
 } from '../../bootstrap/sequelize'
-import { PostStatus } from '~shared/types/base'
-import { Answer, Post } from '../../models'
-import { FindOptions } from 'sequelize/types'
+import { PostStatus, Post } from '~shared/types/base'
+import { Answer } from '../../models'
+import { FindOptions, Model } from 'sequelize'
 
 type AnswerWithRelations = Answer & {
   postId: number
   userId: number
 }
 
-type PostWithRelations = Post & {
-  getAnswers: (options: FindOptions) => AnswerWithRelations[]
-}
+type PostWithRelations = Model &
+  Post & {
+    getAnswers: (options: FindOptions) => AnswerWithRelations[]
+  }
 
 type AnswerJSON = Pick<Answer, 'body'> & {
   user: {

--- a/server/src/modules/auth/__tests__/auth.routes.spec.ts
+++ b/server/src/modules/auth/__tests__/auth.routes.spec.ts
@@ -1,18 +1,24 @@
 import express from 'express'
+import session from 'express-session'
 import { StatusCodes } from 'http-status-codes'
 import minimatch from 'minimatch'
-import session from 'express-session'
 import { ModelCtor, Sequelize } from 'sequelize'
 import supertest, { Session } from 'supertest-session'
+import { createAuthedSession, logoutSession } from '../../../../tests/mock-auth'
 import { passportConfig } from '../../../bootstrap/passport'
 import {
+  Permission as PermissionModel,
+  PostTag,
   Token as TokenModel,
   User as UserModel,
-  Permission as PermissionModel,
-  PostTag as PostTagModel,
 } from '../../../models'
-import { createAuthedSession, logoutSession } from '../../../../tests/mock-auth'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import { ModelDef } from '../../../types/sequelize'
+import {
+  createTestDatabase,
+  getModel,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { AuthController } from '../auth.controller'
 import { AuthMiddleware } from '../auth.middleware'
 import { routeAuth } from '../auth.routes'
@@ -44,7 +50,7 @@ describe('/auth', () => {
   let Token: ModelCtor<TokenModel>
   let User: ModelCtor<UserModel>
   let Permission: ModelCtor<PermissionModel>
-  let PostTag: ModelCtor<PostTagModel>
+  let PostTag: ModelDef<PostTag>
   let mockUser: UserModel
 
   beforeAll(async () => {
@@ -52,7 +58,7 @@ describe('/auth', () => {
     Token = getModel<TokenModel>(db, ModelName.Token)
     User = getModel<UserModel>(db, ModelName.User)
     Permission = getModel<PermissionModel>(db, ModelName.Permission)
-    PostTag = getModel<PostTagModel>(db, ModelName.PostTag)
+    PostTag = getModelDef<PostTag>(db, ModelName.PostTag)
     mockUser = await User.create({
       username: VALID_EMAIL,
       displayname: '',

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -1,17 +1,14 @@
 import minimatch from 'minimatch'
 
-import { PermissionType, PostStatus } from '~shared/types/base'
-import { Permission, Post, PostTag, Tag, User } from '../../models'
+import { PermissionType, Post, PostStatus } from '~shared/types/base'
+import { Permission, PostTag, Tag, User } from '../../models'
 import { createLogger } from '../../bootstrap/logging'
 import { ModelCtor } from 'sequelize/types'
+import { ModelDef } from 'src/types/sequelize'
 
 const logger = createLogger(module)
 
 export type PermissionWithRelations = Permission & {
-  tagId: number
-}
-
-export type PostTagWithRelations = PostTag & {
   tagId: number
 }
 
@@ -22,7 +19,7 @@ export type PostWithRelations = Post & {
 export class AuthService {
   private emailValidator
   private User: ModelCtor<User>
-  private PostTag: ModelCtor<PostTag>
+  private PostTag: ModelDef<PostTag>
   private Permission: ModelCtor<Permission>
 
   constructor({
@@ -33,7 +30,7 @@ export class AuthService {
   }: {
     emailValidator: minimatch.IMinimatch
     User: ModelCtor<User>
-    PostTag: ModelCtor<PostTag>
+    PostTag: ModelDef<PostTag>
     Permission: ModelCtor<Permission>
   }) {
     this.emailValidator = emailValidator
@@ -77,9 +74,9 @@ export class AuthService {
     const userTags = (await this.Permission.findAll({
       where: { userId },
     })) as PermissionWithRelations[]
-    const postTags = (await this.PostTag.findAll({
+    const postTags = await this.PostTag.findAll({
       where: { postId },
-    })) as PostTagWithRelations[]
+    })
 
     return postTags.every((postTag) => {
       const permission = userTags.find(

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -4,18 +4,24 @@ import { StatusCodes } from 'http-status-codes'
 import { Sequelize } from 'sequelize'
 import { ModelCtor } from 'sequelize/types'
 import supertest from 'supertest'
+import { PermissionType, Post, PostStatus, TagType } from '~shared/types/base'
 import {
   Answer as AnswerModel,
   Permission as PermissionModel,
-  Post as PostModel,
-  PostTag as PostTagModel,
+  PostTag,
   Tag as TagModel,
   User as UserModel,
 } from '../../../models'
-import { PermissionType, PostStatus, TagType } from '~shared/types/base'
+import { PostCreation } from '../../../models/posts.model'
 import { ControllerHandler } from '../../../types/response-handler'
+import { ModelDef } from '../../../types/sequelize'
 import { SortType } from '../../../types/sort-type'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import {
+  createTestDatabase,
+  getModel,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { PostController } from '../post.controller'
 import { routePosts } from '../post.routes'
 import { PostService } from '../post.service'
@@ -23,8 +29,8 @@ import { PostService } from '../post.service'
 describe('/posts', () => {
   let db: Sequelize
   let Answer: ModelCtor<AnswerModel>
-  let Post: ModelCtor<PostModel>
-  let PostTag: ModelCtor<PostTagModel>
+  let Post: ModelDef<Post, PostCreation>
+  let PostTag: ModelDef<PostTag>
   let Tag: ModelCtor<TagModel>
   let User: ModelCtor<UserModel>
   let Permission: ModelCtor<PermissionModel>
@@ -32,7 +38,7 @@ describe('/posts', () => {
   let postService: PostService
   let controller: PostController
 
-  const mockPosts: PostModel[] = []
+  const mockPosts: Post[] = []
   let mockUser: UserModel
   let mockTag: TagModel
 
@@ -64,8 +70,8 @@ describe('/posts', () => {
   beforeAll(async () => {
     db = await createTestDatabase()
     Answer = getModel<AnswerModel>(db, ModelName.Answer)
-    Post = getModel<PostModel>(db, ModelName.Post)
-    PostTag = getModel<PostTagModel>(db, ModelName.PostTag)
+    Post = getModelDef<Post, PostCreation>(db, ModelName.Post)
+    PostTag = getModelDef<PostTag>(db, ModelName.PostTag)
     Tag = getModel<TagModel>(db, ModelName.Tag)
     User = getModel<UserModel>(db, ModelName.User)
     Permission = getModel<PermissionModel>(db, ModelName.Permission)
@@ -84,6 +90,7 @@ describe('/posts', () => {
     for (let title = 1; title <= 20; title++) {
       const mockPost = await Post.create({
         title: title.toString(),
+        description: null,
         status: PostStatus.Public,
         userId: mockUser.id,
       })

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -1,35 +1,41 @@
 import { ModelCtor, Sequelize } from 'sequelize/types'
 import {
   Answer as AnswerModel,
-  Post as PostModel,
   Tag as TagModel,
-  PostTag as PostTagModel,
+  PostTag,
   User as UserModel,
   Permission as PermissionModel,
 } from '../../../models'
-import { PermissionType, PostStatus, TagType } from '~shared/types/base'
+import { PermissionType, Post, PostStatus, TagType } from '~shared/types/base'
 import { SortType } from '../../../types/sort-type'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import {
+  createTestDatabase,
+  getModel,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { PostService } from '../post.service'
+import { ModelDef } from '../../../types/sequelize'
+import { PostCreation } from '../../../models/posts.model'
 
 describe('PostService', () => {
   let db: Sequelize
   let Answer: ModelCtor<AnswerModel>
-  let Post: ModelCtor<PostModel>
-  let PostTag: ModelCtor<PostTagModel>
+  let Post: ModelDef<Post, PostCreation>
+  let PostTag: ModelDef<PostTag>
   let Tag: ModelCtor<TagModel>
   let User: ModelCtor<UserModel>
   let Permission: ModelCtor<PermissionModel>
   let postService: PostService
-  const mockPosts: PostModel[] = []
+  const mockPosts: Post[] = []
   let mockUser: UserModel
   let mockTag: TagModel
 
   beforeAll(async () => {
     db = await createTestDatabase()
     Answer = getModel<AnswerModel>(db, ModelName.Answer)
-    Post = getModel<PostModel>(db, ModelName.Post)
-    PostTag = getModel<PostTagModel>(db, ModelName.PostTag)
+    Post = getModelDef<Post, PostCreation>(db, ModelName.Post)
+    PostTag = getModelDef<PostTag>(db, ModelName.PostTag)
     Tag = getModel<TagModel>(db, ModelName.Tag)
     User = getModel<UserModel>(db, ModelName.User)
     Permission = getModel<PermissionModel>(db, ModelName.Permission)
@@ -48,6 +54,7 @@ describe('PostService', () => {
     for (let title = 1; title <= 20; title++) {
       const mockPost = await Post.create({
         title: title.toString(),
+        description: null,
         status: PostStatus.Public,
         userId: mockUser.id,
       })

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -1,4 +1,10 @@
 import { validationResult } from 'express-validator'
+import { StatusCodes } from 'http-status-codes'
+import { Post } from '~shared/types/base'
+import { createLogger } from '../../bootstrap/logging'
+import { Message } from '../../types/message-type'
+import { UpdatePostRequestDto } from '../../types/post-type'
+import { ControllerHandler } from '../../types/response-handler'
 import { SortType } from '../../types/sort-type'
 import { createValidationErrMessage } from '../../util/validation-error'
 import { AuthService } from '../auth/auth.service'
@@ -7,13 +13,6 @@ import {
   PostWithUserTagRelatedPostRelations,
   PostWithUserTagRelations,
 } from './post.service'
-
-import { Message } from '../../types/message-type'
-import { UpdatePostRequestDto } from '../../types/post-type'
-import { createLogger } from '../../bootstrap/logging'
-import { ControllerHandler } from '../../types/response-handler'
-import { Post } from '../../models'
-import { StatusCodes } from 'http-status-codes'
 
 const logger = createLogger(module)
 

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -1,7 +1,15 @@
-import Sequelize, { ModelCtor, Op, OrderItem, ProjectionAlias } from 'sequelize'
-import { Answer, Post, PostTag, Tag, User } from '../../models'
-import { PostStatus } from '~shared/types/base'
+import Sequelize, {
+  Model,
+  ModelCtor,
+  Op,
+  OrderItem,
+  ProjectionAlias,
+} from 'sequelize'
+import { PostCreation } from 'src/models/posts.model'
+import { Post, PostStatus } from '~shared/types/base'
+import { Answer, PostTag, Tag, User } from '../../models'
 import { PostEditType } from '../../types/post-type'
+import { ModelDef } from '../../types/sequelize'
 import { SortType } from '../../types/sort-type'
 import { PostWithRelations } from '../auth/auth.service'
 
@@ -9,10 +17,11 @@ export type UserWithTagRelations = {
   getTags: () => Tag[]
 }
 
-export type PostWithUserTagRelations = PostWithRelations & {
-  countAnswers: () => number
-  tags: Tag[]
-}
+export type PostWithUserTagRelations = Model &
+  PostWithRelations & {
+    countAnswers: () => number
+    tags: Tag[]
+  }
 
 export type PostWithUserTagRelatedPostRelations = PostWithRelations &
   PostWithUserTagRelations & {
@@ -21,8 +30,8 @@ export type PostWithUserTagRelatedPostRelations = PostWithRelations &
 
 export class PostService {
   private Answer: ModelCtor<Answer>
-  private Post: ModelCtor<Post>
-  private PostTag: ModelCtor<PostTag>
+  private Post: ModelDef<Post, PostCreation>
+  private PostTag: ModelDef<PostTag>
   private Tag: ModelCtor<Tag>
   private User: ModelCtor<User>
   constructor({
@@ -33,8 +42,8 @@ export class PostService {
     User,
   }: {
     Answer: ModelCtor<Answer>
-    Post: ModelCtor<Post>
-    PostTag: ModelCtor<PostTag>
+    Post: ModelDef<Post, PostCreation>
+    PostTag: ModelDef<PostTag>
     Tag: ModelCtor<Tag>
     User: ModelCtor<User>
   }) {
@@ -489,7 +498,7 @@ export class PostService {
    */
   deletePost = async (id: number): Promise<void> => {
     const update = await this.Post.update(
-      { status: 'ARCHIVED' },
+      { status: PostStatus.Archived },
       { where: { id: id } },
     )
     if (!update) {

--- a/server/src/types/post-type.ts
+++ b/server/src/types/post-type.ts
@@ -1,4 +1,4 @@
-import { Post } from '../models'
+import { Post } from '~shared/types/base'
 
 export type PostEditType = {
   id: number

--- a/server/src/types/sequelize.ts
+++ b/server/src/types/sequelize.ts
@@ -1,6 +1,5 @@
 import { Model, ModelCtor } from 'sequelize'
 
-export type ModelDef<
-  M,
-  C = Omit<M, 'createdAt' | 'updatedAt' | 'id'>,
-> = ModelCtor<Model<M, C> & M>
+export type Creation<M> = Omit<M, 'createdAt' | 'updatedAt' | 'id'>
+
+export type ModelDef<M, C = Creation<M>> = ModelCtor<Model<M, C> & M>

--- a/server/src/util/jest-db.ts
+++ b/server/src/util/jest-db.ts
@@ -1,6 +1,6 @@
 import minimatch from 'minimatch'
 import { Model, ModelCtor, Sequelize } from 'sequelize'
-import { ModelDef } from '../types/sequelize'
+import { Creation, ModelDef } from '../types/sequelize'
 import {
   defineAgency,
   defineAnswer,
@@ -56,9 +56,9 @@ export function getModel<T extends Model>(
   return sequelize.models[modelName] as ModelCtor<T>
 }
 
-export function getModelDef<T>(
+export function getModelDef<T, C = Creation<T>>(
   sequelize: Sequelize,
   modelName: ModelName,
-): ModelDef<T> {
-  return sequelize.models[modelName] as ModelDef<T>
+): ModelDef<T, C> {
+  return sequelize.models[modelName] as ModelDef<T, C>
 }

--- a/shared/src/types/base/post.ts
+++ b/shared/src/types/base/post.ts
@@ -12,6 +12,7 @@ export const Post = BaseModel.extend({
   description: z.string().nullable(),
   views: z.number().nonnegative(),
   status: z.nativeEnum(PostStatus),
+  userId: z.number().nonnegative(),
 })
 
 export type Post = z.infer<typeof Post>


### PR DESCRIPTION
## Problem

Post currently has an object definition that extends Sequelize.Model, in addition
to a shared Post type defined earlier. The codebase should move to use the latter.

Part of #225 

## Solution

Replace use of ModelCtor with ModelDef, carefully silencing tsc errors
arising from the definition of PostTag without any attributes. We can
safely do this since we will be defining the foreign key relations for
the model later on.
