### PR TITLE
fix(topic): make topic base type fields nullable

### DIFF
--- a/shared/src/types/base/topic.ts
+++ b/shared/src/types/base/topic.ts
@@ -3,8 +3,8 @@ import { BaseModel } from './common'
 
 export const Topic = BaseModel.extend({
   name: z.string(),
-  description: z.string(),
-  parentId: z.number(),
+  description: z.string().nullable(),
+  parentId: z.number().nullable(),
   agencyId: z.number(),
 })
 


### PR DESCRIPTION
## Problem

`description` and `parentId` in the topic base type were not nullable, which does not match the Topic model

## Solution
Add `.nullable()` to `description` and `parentId` 