### PR TITLE
fix(web): sanitize html of question page description content

### DIFF
--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -56,6 +56,7 @@ export class WebController {
       })
       if (agency.isOk()) {
         const agencyPage = await this.webService.getAgencyPage(
+          this.index,
           req.params.shortname,
           agency.value.longname,
         )
@@ -111,6 +112,7 @@ export class WebController {
       const answers = await this.answersService.listAnswers(req.params.id)
       if (answers && answers.length > 0) {
         const postPage = await this.webService.getQuestionPage(
+          this.index,
           post.title,
           answers[0].body,
         )

--- a/server/src/modules/web/web.controller.ts
+++ b/server/src/modules/web/web.controller.ts
@@ -1,5 +1,6 @@
 import { validationResult } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
+import sanitizeHtml from 'sanitize-html'
 import { createLogger } from '../../bootstrap/logging'
 import { ControllerHandler } from '../../types/response-handler'
 import { SortType } from '../../types/sort-type'
@@ -111,19 +112,23 @@ export class WebController {
       const post = await this.postService.getSinglePost(req.params.id, 0, false)
       const answers = await this.answersService.listAnswers(req.params.id)
       if (answers && answers.length > 0) {
-        const postPage = await this.webService.getQuestionPage(
+        const answerBody = sanitizeHtml(answers[0].body, {
+          allowedTags: [],
+          allowedAttributes: {},
+        })
+        const questionPage = await this.webService.getQuestionPage(
           this.index,
           post.title,
-          answers[0].body,
+          answerBody,
         )
-        return res.status(StatusCodes.OK).send(postPage)
+        return res.status(StatusCodes.OK).send(questionPage)
       } else
         return res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(this.index)
     } catch (error) {
       logger.error({
         message: 'Error while getting post page',
         meta: {
-          function: 'getPostPage',
+          function: 'getQuestionPage',
           shortname: req.params.id,
         },
         error,

--- a/server/src/modules/web/web.service.ts
+++ b/server/src/modules/web/web.service.ts
@@ -1,12 +1,6 @@
 import cheerio from 'cheerio'
 import { SitemapLeaf } from 'express-sitemap-xml'
-import fs from 'fs'
-import path from 'path'
 import { Post, Agency } from '~shared/types/base'
-
-const index = fs.readFileSync(
-  path.resolve(__dirname, '../../../..', 'client', 'build', 'index.html'),
-)
 
 export class WebService {
   /**
@@ -16,9 +10,10 @@ export class WebService {
    * @returns html of agency page
    */
   getAgencyPage = async (
+    index: Buffer,
     shortname: string,
     longname: string,
-  ): Promise<string | undefined> => {
+  ): Promise<string> => {
     const $ = cheerio.load(index)
 
     $('title').text(`${shortname.toUpperCase()} FAQ - AskGov`)
@@ -45,9 +40,10 @@ export class WebService {
    * @returns html of post page
    */
   getQuestionPage = async (
+    index: Buffer,
     title: string,
     description: string,
-  ): Promise<string | undefined> => {
+  ): Promise<string> => {
     const $ = cheerio.load(index)
 
     $('meta[property="og:type"]').attr('content', 'article')


### PR DESCRIPTION
## Problem

I forgot to sanitize the description after I refactored the code into the web module...

## Solution

- use `sanitize-html` to sanitize first answer of a post before putting it into the description tags
- refactor code so index file is only loaded once

## Before & After Screenshots

**BEFORE**:

On [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/), raw description fields appear as white space:

<img width="355" alt="Screenshot 2021-10-18 at 6 12 55 PM" src="https://user-images.githubusercontent.com/37061143/137713021-a101eb25-b4e1-420e-950c-ddbcbb935bb7.png">

**AFTER**:

On [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/), raw description fields are populated:

<img width="974" alt="Screenshot 2021-10-18 at 6 24 39 PM" src="https://user-images.githubusercontent.com/37061143/137713748-55cdacfd-f067-4f55-b2d1-8d4a629acc87.png">

## Tests

Check a question page on Facebook Sharing Debugger. The raw tags should have text for the description fields.
