### PR TITLE
fix(sort-icon): change sort icon to BiSortAlt2

### DIFF
--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -11,7 +11,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
-import { BiSort } from 'react-icons/bi'
+import { BiSortAlt2 } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { useLocation, useHistory, useParams } from 'react-router-dom'
 import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
@@ -193,7 +193,7 @@ const HomePage = ({ match }) => {
                     >
                       <Flex justifyContent="space-between" alignItems="center">
                         <Text textStyle="body-1">{sortState.label}</Text>
-                        <BiSort />
+                        <BiSortAlt2 />
                       </Flex>
                     </MenuButton>
                     <MenuList


### PR DESCRIPTION
Change sort icon to BiSortAlt2.

## Before & After Screenshots

**BEFORE**:


<img width="632" alt="Screenshot 2021-10-19 at 9 56 59 AM" src="https://user-images.githubusercontent.com/37061143/137831319-a35ad6ce-4e47-4d80-a215-eb2c5b40b067.png">

**AFTER**:

<img width="638" alt="Screenshot 2021-10-19 at 9 56 38 AM" src="https://user-images.githubusercontent.com/37061143/137831349-23f2a2f4-061b-4fd5-8362-e7e0b3afa5c7.png">

## Tests

Go to a topics page and check the icon on the right of the sorting field.
