### PR TITLE
refactor(post): add agencyId

### DIFF
--- a/server/migrations/20211019053050-create-post-agency-id.js
+++ b/server/migrations/20211019053050-create-post-agency-id.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.addColumn('posts', 'agencyId', {
+      allowNull: true,
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'agencies',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('posts', 'agencyId')
+  },
+}

--- a/server/migrations/20211019053110-update-post-agency-id-non-nullable.js
+++ b/server/migrations/20211019053110-update-post-agency-id-non-nullable.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('posts', 'agencyId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('posts', 'agencyId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    })
+  },
+}

--- a/server/seeders/20210826064325-was.js
+++ b/server/seeders/20210826064325-was.js
@@ -100,6 +100,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 15,
@@ -109,6 +110,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 16,
@@ -119,6 +121,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 17,
@@ -128,6 +131,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 18,
@@ -138,6 +142,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
 
         {
@@ -148,6 +153,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
 
         {
@@ -160,6 +166,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
 
         {
@@ -171,6 +178,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 22,
@@ -181,6 +189,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 23,
@@ -190,6 +199,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 24,
@@ -199,6 +209,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 25,
@@ -210,6 +221,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
 
         {
@@ -222,6 +234,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 27,
@@ -232,6 +245,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 28,
@@ -242,6 +256,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 29,
@@ -251,6 +266,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
         {
           id: 30,
@@ -261,6 +277,7 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
           userId: 4,
+          agencyId: 4,
         },
       ],
       {},

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -104,7 +104,7 @@ const authService = new AuthService({
   emailValidator,
   User,
   Permission,
-  PostTag,
+  Post,
   Topic,
 })
 const authMiddleware = new AuthMiddleware()

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -117,6 +117,7 @@ const enquiryService = new EnquiryService({ Agency, mailService })
 const recaptchaService = new RecaptchaService({ axios, ...recaptchaConfig })
 const answersService = new AnswersService()
 const topicsService = new TopicsService({ Topic })
+const userService = new UserService()
 
 const apiOptions = {
   agency: {
@@ -134,7 +135,7 @@ const apiOptions = {
     controller: new AuthController({
       mailService,
       authService,
-      userService: new UserService(),
+      userService,
       Token,
     }),
     authMiddleware,
@@ -144,6 +145,7 @@ const apiOptions = {
     controller: new PostController({
       authService,
       postService,
+      userService,
     }),
     authMiddleware,
   },

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -117,7 +117,7 @@ const enquiryService = new EnquiryService({ Agency, mailService })
 const recaptchaService = new RecaptchaService({ axios, ...recaptchaConfig })
 const answersService = new AnswersService()
 const topicsService = new TopicsService({ Topic })
-const userService = new UserService()
+const userService = new UserService({ User, Tag })
 
 const apiOptions = {
   agency: {

--- a/server/src/bootstrap/sequelize.ts
+++ b/server/src/bootstrap/sequelize.ts
@@ -24,6 +24,7 @@ export const { User, Permission } = defineUserAndPermission(sequelize, {
 export const Agency = defineAgency(sequelize, { User })
 export const Topic = defineTopic(sequelize, { Agency })
 export const { Post, PostTag } = definePostAndPostTag(sequelize, {
+  Agency,
   User,
   Tag,
   Topic,

--- a/server/src/models/agencies.model.ts
+++ b/server/src/models/agencies.model.ts
@@ -43,9 +43,6 @@ export const defineAgency = (
     // belonging to an agency
     displayOrder: {
       type: DataTypes.JSON,
-      validate: {
-        isArray: true,
-      },
       allowNull: true,
     },
   })

--- a/server/src/models/posts.model.ts
+++ b/server/src/models/posts.model.ts
@@ -1,6 +1,6 @@
-import { Sequelize, DataTypes } from 'sequelize'
-import { ModelDef, Creation } from '../types/sequelize'
-import { Post, PostStatus, Topic, User, Tag } from '~shared/types/base'
+import { DataTypes, Sequelize } from 'sequelize'
+import { Agency, Post, PostStatus, Tag, Topic, User } from '~shared/types/base'
+import { Creation, ModelDef } from '../types/sequelize'
 
 export interface PostTag {
   postId: number
@@ -21,9 +21,15 @@ export const definePostAndPostTag = (
   sequelize: Sequelize,
   {
     User,
+    Agency,
     Tag,
     Topic,
-  }: { User: ModelDef<User>; Tag: ModelDef<Tag>; Topic: ModelDef<Topic> },
+  }: {
+    User: ModelDef<User>
+    Agency: ModelDef<Agency>
+    Tag: ModelDef<Tag>
+    Topic: ModelDef<Topic>
+  },
 ): { Post: ModelDef<Post, PostCreation>; PostTag: ModelDef<PostTag> } => {
   const Post: ModelDef<Post, PostCreation> = sequelize.define('post', {
     title: {
@@ -57,6 +63,8 @@ export const definePostAndPostTag = (
   // Define associations for Post
   User.hasMany(Post)
   Post.belongsTo(User)
+  Agency.hasMany(Post)
+  Post.belongsTo(Agency)
   Topic.hasMany(Post)
   Post.belongsTo(Topic)
   Post.belongsToMany(Tag, {

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -30,7 +30,6 @@ describe('/agencies', () => {
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
-    getDisallowedTagsForUser: jest.fn(),
     verifyUserCanViewPost: jest.fn(),
     isOfficerEmail: jest.fn(),
     verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/auth/__tests__/auth.controller.spec.ts
+++ b/server/src/modules/auth/__tests__/auth.controller.spec.ts
@@ -24,7 +24,6 @@ const mailService = { sendEnquiry: jest.fn(), sendLoginOtp: jest.fn() }
 const authService = {
   checkIfWhitelistedOfficer: jest.fn(),
   hasPermissionToAnswer: jest.fn(),
-  getDisallowedTagsForUser: jest.fn(),
   verifyUserCanViewPost: jest.fn(),
   isOfficerEmail: jest.fn(),
   verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/server/src/modules/auth/__tests__/auth.service.spec.ts
@@ -1,0 +1,105 @@
+import minimatch from 'minimatch'
+import { Model, ModelCtor, Sequelize } from 'sequelize'
+import { Agency, Post, PostStatus, Topic } from '~shared/types/base'
+import {
+  Permission as PermissionModel,
+  User as UserModel,
+} from '../../../models'
+import { PostCreation } from '../../../models/posts.model'
+import { ModelDef, ModelInstance } from '../../../types/sequelize'
+import {
+  createTestDatabase,
+  getModel,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
+import { AuthService } from '../auth.service'
+
+describe('AuthService', () => {
+  const emailValidator = new minimatch.Minimatch('*')
+  let db: Sequelize
+  let Agency: ModelDef<Agency>
+  let User: ModelCtor<UserModel>
+  let Permission: ModelCtor<PermissionModel>
+  let Topic: ModelDef<Topic>
+  let Post: ModelDef<Post, PostCreation>
+
+  let authService: AuthService
+  let mockUser: UserModel
+  let mockAgency: ModelInstance<Agency>
+
+  beforeAll(async () => {
+    db = await createTestDatabase()
+    Agency = getModelDef<Agency>(db, ModelName.Agency)
+    User = getModel<UserModel>(db, ModelName.User)
+    Permission = getModel<PermissionModel>(db, ModelName.Permission)
+    Post = getModelDef<Post, PostCreation>(db, ModelName.Post)
+    mockAgency = await Agency.create({
+      shortname: 'was',
+      longname: 'Work Allocation Singapore',
+      email: 'enquiries@was.gov.sg',
+      website: null,
+      noEnquiriesMessage: null,
+      logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+      displayOrder: [],
+    })
+    mockUser = await User.create({
+      username: 'enquiries@was.gov.sg',
+      displayname: '',
+      agencyId: mockAgency.id,
+    })
+    authService = new AuthService({
+      emailValidator,
+      User,
+      Permission,
+      Post,
+      Topic,
+    })
+  })
+  describe('hasPermissionToAnswer', () => {
+    afterEach(async () => {
+      Post.destroy({ truncate: true })
+    })
+    it('returns true if user and post agency id match', async () => {
+      const { id: postId } = await Post.create({
+        agencyId: mockAgency.id,
+        description: null,
+        status: PostStatus.Public,
+        title: 'Question belonging to mock agency',
+        userId: mockUser.id,
+      })
+
+      const hasPermission = await authService.hasPermissionToAnswer(
+        mockUser.id,
+        postId,
+      )
+
+      expect(hasPermission).toBe(true)
+    })
+    it('returns false if user and post agency id do not match', async () => {
+      const { id: agencyId } = await Agency.create({
+        shortname: 'bad',
+        longname: 'Bad Allocation Singapore',
+        email: 'enquiries@bad.gov.sg',
+        website: null,
+        noEnquiriesMessage: null,
+        logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+        displayOrder: [],
+      })
+      const { id: postId } = await Post.create({
+        agencyId,
+        description: null,
+        status: PostStatus.Public,
+        title: 'Question belonging to mock agency',
+        userId: mockUser.id,
+      })
+
+      const hasPermission = await authService.hasPermissionToAnswer(
+        mockUser.id,
+        postId,
+      )
+
+      expect(hasPermission).toBe(false)
+    })
+  })
+})

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -1,10 +1,10 @@
 import minimatch from 'minimatch'
-
-import { PermissionType, Post, PostStatus, Topic } from '~shared/types/base'
-import { Permission, PostTag, Tag, User } from '../../models'
-import { createLogger } from '../../bootstrap/logging'
 import { ModelCtor } from 'sequelize/types'
-import { ModelDef } from 'src/types/sequelize'
+import { PermissionType, Post, PostStatus, Topic } from '~shared/types/base'
+import { createLogger } from '../../bootstrap/logging'
+import { Permission, Tag, User } from '../../models'
+import { PostCreation } from '../../models/posts.model'
+import { ModelDef } from '../../types/sequelize'
 
 const logger = createLogger(module)
 
@@ -19,26 +19,26 @@ export type PostWithRelations = Post & {
 export class AuthService {
   private emailValidator
   private User: ModelCtor<User>
-  private PostTag: ModelDef<PostTag>
+  private Post: ModelDef<Post, PostCreation>
   private Permission: ModelCtor<Permission>
   private Topic: ModelDef<Topic>
 
   constructor({
     emailValidator,
     User,
-    PostTag,
+    Post,
     Permission,
     Topic,
   }: {
     emailValidator: minimatch.IMinimatch
     User: ModelCtor<User>
-    PostTag: ModelDef<PostTag>
+    Post: ModelDef<Post, PostCreation>
     Permission: ModelCtor<Permission>
     Topic: ModelDef<Topic>
   }) {
     this.emailValidator = emailValidator
     this.User = User
-    this.PostTag = PostTag
+    this.Post = Post
     this.Permission = Permission
     this.Topic = Topic
   }
@@ -75,40 +75,10 @@ export class AuthService {
     userId: number,
     postId: number,
   ): Promise<boolean> => {
-    const userTags = (await this.Permission.findAll({
-      where: { userId },
-    })) as PermissionWithRelations[]
-    const postTags = await this.PostTag.findAll({
-      where: { postId },
-    })
+    const user = await this.User.findByPk(userId)
+    const post = await this.Post.findByPk(postId)
 
-    return postTags.every((postTag) => {
-      const permission = userTags.find(
-        (userTag) => userTag.tagId === postTag.tagId,
-      )
-      return permission && permission.role === PermissionType.Answerer
-    })
-  }
-
-  /**
-   * Get all tags that user does not have permission to add
-   * @param userId of user
-   * @param tagList list of tags
-   * @returns subset of tagList that user is not allowed to add
-   */
-  getDisallowedTagsForUser = async (
-    userId: number,
-    tagList: Tag[],
-  ): Promise<Tag[]> => {
-    const userTags = (await this.Permission.findAll({
-      where: { userId },
-    })) as PermissionWithRelations[]
-    return tagList.filter((postTag) => {
-      const permission = userTags.find(
-        (userTag) => userTag.tagId === postTag.id,
-      )
-      return !(permission && permission.role === PermissionType.Answerer)
-    })
+    return Boolean(post && user && post.agencyId === user.agencyId)
   }
 
   /**

--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -10,7 +10,6 @@ describe('PostController', () => {
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
-    getDisallowedTagsForUser: jest.fn(),
     verifyUserCanViewPost: jest.fn(),
     isOfficerEmail: jest.fn(),
     verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -28,7 +28,16 @@ describe('PostController', () => {
     listPosts: jest.fn(),
   }
 
-  const controller = new PostController({ authService, postService })
+  const userService = {
+    loadUser: jest.fn(),
+    createOfficer: jest.fn(),
+  }
+
+  const controller = new PostController({
+    authService,
+    postService,
+    userService,
+  })
 
   // Set up auth middleware to inject user
   let user: Express.User | undefined = { id: 1 }

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -58,7 +58,6 @@ describe('/posts', () => {
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
-    getDisallowedTagsForUser: jest.fn(),
     verifyUserCanViewPost: jest.fn(),
     isOfficerEmail: jest.fn(),
     verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -203,4 +203,35 @@ describe('PostService', () => {
       expect(result.posts[4].title).toStrictEqual(mockPosts[19].title)
     })
   })
+
+  describe('createPost', () => {
+    it('throws on bad tag', async () => {
+      const badPost = {
+        title: 'Bad',
+        description: 'Bad',
+        userId: mockUser.id,
+        agencyId: mockUser.agencyId,
+        tagname: ['badtag'],
+      }
+      await expect(postService.createPost(badPost)).rejects.toStrictEqual(
+        new Error('At least one tag does not exist'),
+      )
+    })
+    it('creates post on good input', async () => {
+      const postParams = {
+        title: 'Title',
+        description: 'Description',
+        userId: mockUser.id,
+        agencyId: mockUser.agencyId,
+        tagname: [mockTag.tagname],
+      }
+
+      const postId = await postService.createPost(postParams)
+
+      const post = await Post.findByPk(postId)
+      const postTags = await PostTag.findAll({ where: { postId } })
+      expect(post).toBeDefined()
+      expect(postTags.length).toBe(postParams.tagname.length)
+    })
+  })
 })

--- a/server/src/modules/post/__tests__/post.service.spec.ts
+++ b/server/src/modules/post/__tests__/post.service.spec.ts
@@ -6,7 +6,13 @@ import {
   User as UserModel,
   Permission as PermissionModel,
 } from '../../../models'
-import { PermissionType, Post, PostStatus, TagType } from '~shared/types/base'
+import {
+  Agency,
+  PermissionType,
+  Post,
+  PostStatus,
+  TagType,
+} from '~shared/types/base'
 import { SortType } from '../../../types/sort-type'
 import {
   createTestDatabase,
@@ -20,6 +26,7 @@ import { PostCreation } from '../../../models/posts.model'
 
 describe('PostService', () => {
   let db: Sequelize
+  let Agency: ModelDef<Agency>
   let Answer: ModelCtor<AnswerModel>
   let Post: ModelDef<Post, PostCreation>
   let PostTag: ModelDef<PostTag>
@@ -33,6 +40,7 @@ describe('PostService', () => {
 
   beforeAll(async () => {
     db = await createTestDatabase()
+    Agency = getModelDef<Agency>(db, ModelName.Agency)
     Answer = getModel<AnswerModel>(db, ModelName.Answer)
     Post = getModelDef<Post, PostCreation>(db, ModelName.Post)
     PostTag = getModelDef<PostTag>(db, ModelName.PostTag)
@@ -40,9 +48,19 @@ describe('PostService', () => {
     User = getModel<UserModel>(db, ModelName.User)
     Permission = getModel<PermissionModel>(db, ModelName.Permission)
     postService = new PostService({ Answer, Post, PostTag, Tag, User })
+    const { id: agencyId } = await Agency.create({
+      shortname: 'was',
+      longname: 'Work Allocation Singapore',
+      email: 'enquiries@was.gov.sg',
+      website: null,
+      noEnquiriesMessage: null,
+      logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+      displayOrder: [],
+    })
     mockUser = await User.create({
       username: 'answerer@test.gov.sg',
       displayname: '',
+      agencyId,
     })
     mockTag = await Tag.create({
       tagname: 'test',
@@ -57,6 +75,7 @@ describe('PostService', () => {
         description: null,
         status: PostStatus.Public,
         userId: mockUser.id,
+        agencyId: mockUser.agencyId,
       })
       mockPosts.push(mockPost)
       await PostTag.create({ postId: mockPost.id, tagId: mockTag.id })

--- a/server/src/modules/post/post.controller.ts
+++ b/server/src/modules/post/post.controller.ts
@@ -246,22 +246,6 @@ export class PostController {
     }
 
     try {
-      // check permissions
-      const listOfDisallowedTags =
-        await this.authService.getDisallowedTagsForUser(
-          req.user?.id,
-          await this.postService.getExistingTagsFromRequestTags(
-            req.body.tagname,
-          ),
-        )
-      if (listOfDisallowedTags.length > 0) {
-        return res.status(StatusCodes.FORBIDDEN).json({
-          message:
-            'You do not have permissions to post this question with the following tags: ' +
-            listOfDisallowedTags.map((x) => x.tagname).join(', '),
-        })
-      }
-
       const user = await this.userService.loadUser(req.user?.id)
 
       if (!user?.agencyId) {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -462,6 +462,7 @@ export class PostService {
     title: string
     description: string
     userId: number
+    agencyId: number
     tagname: string[]
   }): Promise<number> => {
     const tagList = await this.getExistingTagsFromRequestTags(newPost.tagname)
@@ -478,6 +479,7 @@ export class PostService {
         title: newPost.title,
         description: newPost.description,
         userId: newPost.userId,
+        agencyId: newPost.agencyId,
         status: PostStatus.Private,
       })
       for (const tag of tagList) {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -83,10 +83,6 @@ export class PostService {
     }
   }
 
-  private checkOneAgency = (arr: Tag[]): boolean => {
-    return arr.some((e) => e.tagType === 'AGENCY')
-  }
-
   /**
    * Get posts related to the one provided
    * There is room to improve on finding related posts, using a better algorithm
@@ -470,10 +466,6 @@ export class PostService {
     if (newPost.tagname.length !== tagList.length) {
       throw new Error('At least one tag does not exist')
     } else {
-      // check if at least one agency tag exists
-      if (!this.checkOneAgency(tagList)) {
-        throw new Error('At least one tag must be an agency tag')
-      }
       // Only create post if tag exists
       const post = await this.Post.create({
         title: newPost.title,

--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -26,7 +26,6 @@ describe('TopicsController', () => {
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
-    getDisallowedTagsForUser: jest.fn(),
     verifyUserCanViewPost: jest.fn(),
     isOfficerEmail: jest.fn(),
     verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/topics/__tests__/topics.routes.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.routes.spec.ts
@@ -27,7 +27,6 @@ describe('/topics', () => {
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
-    getDisallowedTagsForUser: jest.fn(),
     verifyUserCanViewPost: jest.fn(),
     isOfficerEmail: jest.fn(),
     verifyUserCanModifyTopic: jest.fn(),

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -1,19 +1,31 @@
-import { getOfficerDisplayName } from './user.util'
-import { User as UserModel, Tag as TagModel } from '../../bootstrap/sequelize'
-import { User } from '../../models'
 import { LoadUserDto } from '~shared/types/api'
+import { Tag, User } from '~shared/types/base'
+import { ModelDef } from '../../types/sequelize'
+import { getOfficerDisplayName } from './user.util'
 
 export class UserService {
+  private User: ModelDef<User, Pick<User, 'username' | 'displayname'>>
+  private Tag: ModelDef<Tag>
+  constructor({
+    User,
+    Tag,
+  }: {
+    User: ModelDef<User, Pick<User, 'username' | 'displayname'>>
+    Tag: ModelDef<Tag>
+  }) {
+    this.User = User
+    this.Tag = Tag
+  }
   createOfficer = async (username: string): Promise<User> => {
-    return UserModel.create({
+    return this.User.create({
       username,
       displayname: getOfficerDisplayName(username),
     })
   }
 
   loadUser = async (userId: number): Promise<LoadUserDto> => {
-    return UserModel.findByPk(userId, {
-      include: TagModel,
+    return this.User.findByPk(userId, {
+      include: this.Tag,
     }) as Promise<LoadUserDto>
   }
 }

--- a/server/src/types/sequelize.ts
+++ b/server/src/types/sequelize.ts
@@ -2,4 +2,6 @@ import { Model, ModelCtor } from 'sequelize'
 
 export type Creation<M> = Omit<M, 'createdAt' | 'updatedAt' | 'id'>
 
-export type ModelDef<M, C = Creation<M>> = ModelCtor<Model<M, C> & M>
+export type ModelInstance<M, C = Creation<M>> = Model<M, C> & M
+
+export type ModelDef<M, C = Creation<M>> = ModelCtor<ModelInstance<M, C>>

--- a/server/src/util/jest-db.ts
+++ b/server/src/util/jest-db.ts
@@ -38,6 +38,7 @@ export const createTestDatabase = async (): Promise<Sequelize> => {
   const Agency = defineAgency(sequelize, { User })
   const Topic = defineTopic(sequelize, { Agency })
   const { Post, PostTag } = definePostAndPostTag(sequelize, {
+    Agency,
     User,
     Tag,
     Topic,

--- a/server/src/util/seedAskGovFromCSV.ts
+++ b/server/src/util/seedAskGovFromCSV.ts
@@ -36,6 +36,7 @@ import { promises as fs } from 'fs'
 // Agency ID is the ID of agency tag
 const user = { id: 4 }
 const agencyTag = { id: 5 }
+const agencyId = 5
 const fileName = 'example_data.csv'
 // **********************************
 
@@ -117,6 +118,7 @@ const fileName = 'example_data.csv'
           description: description,
           status: PostStatus.Public,
           userId: user.id,
+          agencyId,
         },
         { transaction: t },
       )

--- a/shared/src/types/base/post.ts
+++ b/shared/src/types/base/post.ts
@@ -13,6 +13,7 @@ export const Post = BaseModel.extend({
   views: z.number().nonnegative(),
   status: z.nativeEnum(PostStatus),
   userId: z.number().nonnegative(),
+  agencyId: z.number().nonnegative(),
 })
 
 export type Post = z.infer<typeof Post>


### PR DESCRIPTION
## Problem

Closes #3 
Closes #603

## Solution

Establish a relationship between Post and Agency to facilitate work
to migrate to topics

- Add agencyId to shared and sequelize type
- Infer agencyId from user when creating posts
- Drop isArray validator for Agency.displayOrder, invalid
- Match permissions for users to manage posts on agencyIds
- Provide test coverage for posts
  - Take the trouble to introduce dep injection to UserService to provide more realistic tests

## Tests

- [ ] verify users can continue to create/update/delete posts

## Deploy Notes

**New scripts**:
- `20211019053050-create-post-agency-id` : invoke this migration first, then perform backfill to ensure agency ids for posts in place
- `20211019053110-update-post-agency-id-non-nullable`: enforce Posts to have agency ids
