### PR TITLE
feat(sticky-nav): add sticky navigation bar for desktop and mobile

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -13,7 +13,7 @@
 .App {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: auto;
 }
 
 body {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,10 +1,8 @@
 import { ChakraProvider } from '@chakra-ui/react'
-import React from 'react'
 import './App.css'
 import { Banner } from './components/Banner/Banner.component'
 import Footer from './components/Footer/Footer.component'
 import Header from './components/Header/Header.component'
-import Masthead from './components/Masthead/Masthead.component'
 import { AuthProvider } from './contexts/AuthContext'
 import { GoogleAnalyticsProvider } from './contexts/googleAnalytics'
 import { useFullstory } from './hooks/useFullstory'
@@ -19,7 +17,6 @@ const App = () => {
       <ChakraProvider theme={theme}>
         <AuthProvider>
           <div className="App">
-            <Masthead />
             <Banner />
             <Header />
             <div className="main-content">

--- a/client/src/components/AgencyLogo/AgencyLogo.component.jsx
+++ b/client/src/components/AgencyLogo/AgencyLogo.component.jsx
@@ -1,18 +1,7 @@
-import { Box, Image, Link } from '@chakra-ui/react'
-import { useQuery } from 'react-query'
-import { Link as RouterLink, useParams } from 'react-router-dom'
-import {
-  getAgencyByShortName,
-  GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
-} from '../../services/AgencyService'
+import { Box, Image, Link, Spinner } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
 
-const AgencyLogo = () => {
-  const { agency: agencyShortName } = useParams()
-  const { data: agency } = useQuery(
-    [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
-    () => getAgencyByShortName({ shortname: agencyShortName }),
-    { enabled: !!agencyShortName },
-  )
+const AgencyLogo = ({ agency }) => {
   return (
     <Box
       width="120px"
@@ -26,37 +15,41 @@ const AgencyLogo = () => {
       borderRadius="10px"
       bg="#fff"
     >
-      <Link
-        width="100%"
-        height="100%"
-        as={RouterLink}
-        to={agency ? `/agency/${agency.shortname}` : '/'}
-      >
-        <Box
+      {agency ? (
+        <Link
           width="100%"
           height="100%"
-          display="flex"
-          alignItems="center"
-          overflow="hidden"
-          border="1px solid #DADCE3"
-          borderRadius="10px"
+          as={RouterLink}
+          to={agency ? `/agency/${agency.shortname}` : '/'}
         >
-          {agency && (
-            <Image
-              src={agency.logo}
-              alt="Agency Logo"
-              loading="lazy"
-              display="inline"
-              htmlWidth="120px"
-              htmlHeight="120px"
-              maxW="100%"
-              maxH="100%"
-              width="auto"
-              height="auto"
-            />
-          )}
-        </Box>
-      </Link>
+          <Box
+            width="100%"
+            height="100%"
+            display="flex"
+            alignItems="center"
+            overflow="hidden"
+            border="1px solid #DADCE3"
+            borderRadius="10px"
+          >
+            {agency && (
+              <Image
+                src={agency.logo}
+                alt="Agency Logo"
+                loading="lazy"
+                display="inline"
+                htmlWidth="120px"
+                htmlHeight="120px"
+                maxW="100%"
+                maxH="100%"
+                width="auto"
+                height="auto"
+              />
+            )}
+          </Box>
+        </Link>
+      ) : (
+        <Spinner />
+      )}
     </Box>
   )
 }

--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -1,26 +1,33 @@
 import {
+  Box,
   Button,
+  Fade,
   Flex,
   Image,
   Link,
   Stack,
-  Spacer,
   Text,
+  useDisclosure,
+  useBreakpointValue,
 } from '@chakra-ui/react'
+import { useEffect } from 'react'
 import { BiLinkExternal } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { matchPath, useLocation, Link as RouterLink } from 'react-router-dom'
-import { ReactComponent as Logo } from '../../assets/logo-white-alpha.svg'
-import { useAuth } from '../../contexts/AuthContext'
+import { Link as RouterLink, matchPath, useLocation } from 'react-router-dom'
 import { TagType } from '~shared/types/base'
-import {
-  getPostById,
-  GET_POST_BY_ID_QUERY_KEY,
-} from '../../services/PostService'
+import { ReactComponent as Logo } from '../../assets/logo-white-alpha.svg'
+import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
+import Masthead from '../../components/Masthead/Masthead.component'
+import SearchBoxComponent from '../../components/SearchBox/SearchBox.component'
+import { useAuth } from '../../contexts/AuthContext'
 import {
   getAgencyByShortName,
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
 } from '../../services/AgencyService'
+import {
+  getPostById,
+  GET_POST_BY_ID_QUERY_KEY,
+} from '../../services/PostService'
 import LinkButton from '../LinkButton/LinkButton.component'
 import Spinner from '../Spinner/Spinner.component'
 
@@ -56,7 +63,7 @@ const Header = () => {
   const { isLoading, data: agency } = useQuery(
     [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
     () => getAgencyByShortName({ shortname: agencyShortName }),
-    { enabled: !!agencyShortName },
+    { enabled: Boolean(agencyShortName) },
   )
 
   const authLinks = (
@@ -103,53 +110,152 @@ const Header = () => {
     )
   }
 
+  // look for /questions to catch search result and post pages
+  const matchQuestions = matchPath(location.pathname, {
+    path: '/questions',
+  })
+  const {
+    isOpen: headerIsOpen,
+    onOpen: openHeader,
+    onClose: closeHeader,
+  } = useDisclosure({ defaultIsOpen: true })
+
+  const checkHeaderState = () => {
+    if (window.pageYOffset > 280) closeHeader()
+    else openHeader()
+  }
+
+  // useSticky is implemented with window.innerWidth instead of useBreakpointValue
+  // as useBreakpointValue switches value to true between 345px - 465px for some reason
+  const useSticky = window.innerWidth < 1440 ? false : true // 1440px = 90em is the breakpoint for desktop
+
+  useEffect(() => {
+    if (!matchQuestions && useSticky) {
+      openHeader()
+      window.addEventListener('scroll', checkHeaderState)
+      return () => window.removeEventListener('scroll', checkHeaderState)
+    } else {
+      closeHeader()
+    }
+  }, [matchQuestions, useSticky])
+
+  const expandedSearch = () => {
+    return (
+      <Box
+        bg="primary.500"
+        h={
+          agency
+            ? { base: '120px', md: '176px' }
+            : { base: '120px', xl: '176px' }
+        }
+        className="top-background"
+      >
+        <Flex
+          direction="row"
+          justifyContent="flex-start"
+          className="home-search"
+        >
+          {/* TODO: might need to do some enforcing to ensure you can only */}
+          {/* enter a single agency in the URL */}
+
+          <Flex
+            h="56px"
+            m="auto"
+            mt={
+              agency
+                ? { base: '20px', md: '56px' }
+                : { base: '4px', xl: '56px' }
+            }
+            pt="!52px"
+            px={{ base: '24px', md: 'auto' }}
+            maxW="680px"
+            w="100%"
+          >
+            <SearchBoxComponent agencyShortName={agency?.shortname} />
+          </Flex>
+        </Flex>
+        {Boolean(agency) ? (
+          <Box px="36px" mt="-20px" display={{ base: 'none', lg: 'flex' }}>
+            <AgencyLogo agency={agency} />
+          </Box>
+        ) : null}
+      </Box>
+    )
+  }
   return (
     <Flex
-      background="primary.500"
-      display="flex"
-      justify="space-between"
-      align="center"
-      px={8}
-      py={4}
-      shrink={0}
+      direction="column"
+      sx={{
+        position: { base: 'static', xl: '-webkit-sticky' } /* Safari */,
+        position: { base: 'static', xl: 'sticky' },
+        top: '0',
+        'z-index': '999',
+      }}
     >
-      <Link as={RouterLink} to={agency ? `/agency/${agency.shortname}` : '/'}>
-        <Stack
-          direction={{ base: 'column', md: 'row' }}
-          textDecor="none"
-          align={{ base: 'flex-start', md: 'center' }}
-          position="relative"
-        >
-          <Logo />
-          {agency ? (
-            <>
-              <Text
-                d={{ base: 'none', md: 'block' }}
-                px={{ base: 0, md: 2 }}
-                textStyle="h4"
-                fontWeight={300}
-                color="white"
-              >
-                |
-              </Text>
-              <Text
-                position={{ base: 'relative', md: 'static' }}
-                top={{ base: '-6px', md: 0 }}
-                textStyle="h4"
-                fontWeight={400}
-                color="white"
-              >
-                {agency.longname}
-              </Text>
-            </>
-          ) : null}
-        </Stack>
-      </Link>
-      <Spacer />
-      <Flex d={{ base: 'none', sm: 'block' }}>
-        {agency?.website && websiteLinks()}
+      <Masthead />
+      <Flex
+        background="primary.500"
+        justify="space-between"
+        align="center"
+        px={8}
+        py={4}
+        shrink={0}
+      >
+        <Link as={RouterLink} to={agency ? `/agency/${agency.shortname}` : '/'}>
+          <Stack
+            direction={{ base: 'column', md: 'row' }}
+            textDecor="none"
+            align={{ base: 'flex-start', md: 'center' }}
+            position="relative"
+          >
+            <Logo />
+            {agency ? (
+              <>
+                <Text
+                  d={{ base: 'none', md: 'block' }}
+                  px={{ base: 0, md: 2 }}
+                  textStyle="h4"
+                  fontWeight={300}
+                  color="white"
+                >
+                  |
+                </Text>
+                <Text
+                  position={{ base: 'relative', md: 'static' }}
+                  top={{ base: '-6px', md: 0 }}
+                  textStyle="h4"
+                  fontWeight={400}
+                  color="white"
+                >
+                  {agency.shortname.toUpperCase()}
+                </Text>
+              </>
+            ) : null}
+          </Stack>
+        </Link>
+        <Flex d={{ base: 'none', sm: 'block' }}>
+          {agency?.website && websiteLinks()}
+        </Flex>
+        {user && authLinks}
       </Flex>
-      {user && authLinks}
+      {(useSticky && !headerIsOpen) || matchQuestions ? (
+        <Flex
+          h="56px"
+          m="auto"
+          px={{ base: '24px', md: 'auto' }}
+          maxW="680px"
+          w="100%"
+          mt="-68px"
+          d={{ base: 'none', xl: 'block' }}
+        >
+          <SearchBoxComponent agencyShortName={agency?.shortname} />
+        </Flex>
+      ) : null}
+      {!matchQuestions && useSticky ? (
+        <Fade in={headerIsOpen}>{expandedSearch()}</Fade>
+      ) : matchQuestions ? null : (
+        expandedSearch()
+      )}
     </Flex>
   )
 }

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -13,28 +13,25 @@ import {
 import { useEffect, useState } from 'react'
 import { BiSortAlt2 } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { useLocation, useHistory, useParams } from 'react-router-dom'
-import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
+import { useHistory, useLocation, useParams } from 'react-router-dom'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostQuestionButton from '../../components/PostQuestionButton/PostQuestionButton.component'
 import QuestionsListComponent from '../../components/QuestionsList/QuestionsList.component'
-import SearchBoxComponent from '../../components/SearchBox/SearchBox.component'
-import TagPanel from '../../components/TagPanel/TagPanel.component'
 import TagMenu from '../../components/TagMenu/TagMenu.component'
+import TagPanel from '../../components/TagPanel/TagPanel.component'
 import { useAuth } from '../../contexts/AuthContext'
+import {
+  getAgencyByShortName,
+  GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
+} from '../../services/AgencyService'
 import {
   fetchTags,
   FETCH_TAGS_QUERY_KEY,
   getTagsUsedByAgency,
   GET_TAGS_USED_BY_AGENCY_QUERY_KEY,
 } from '../../services/TagService'
-import {
-  getAgencyByShortName,
-  GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
-} from '../../services/AgencyService'
 import { isUserPublicOfficer } from '../../services/user.service'
-import { mergeTags } from '../../util/tagsmerger'
 import { getTagsQuery, isSpecified } from '../../util/urlparser'
 
 const HomePage = ({ match }) => {
@@ -72,7 +69,6 @@ const HomePage = ({ match }) => {
   const [sortState, setSortState] = useState(options[1])
   const [queryState, setQueryState] = useState('')
 
-  const agencyAndTags = mergeTags(match.params.agency, queryState)
   const isAuthenticatedOfficer = isUserPublicOfficer(user)
 
   return (
@@ -89,49 +85,6 @@ const HomePage = ({ match }) => {
             : undefined
         }
       />
-      <Box
-        bg="primary.500"
-        h={
-          agency
-            ? { base: '120px', md: '176px' }
-            : { base: '120px', xl: '176px' }
-        }
-        className="top-background"
-      >
-        <Flex
-          direction="row"
-          justifyContent="flex-start"
-          className="home-search"
-        >
-          {/* TODO: might need to do some enforcing to ensure you can only */}
-          {/* enter a single agency in the URL */}
-
-          <Flex
-            h="56px"
-            m="auto"
-            mt={
-              agency
-                ? { base: '20px', md: '56px' }
-                : { base: '4px', xl: '56px' }
-            }
-            pt="!52px"
-            px={{ base: '24px', md: 'auto' }}
-            maxW="680px"
-            w="100%"
-          >
-            <SearchBoxComponent
-              agencyShortName={match.params.agency || agency?.shortname}
-            />
-          </Flex>
-        </Flex>
-        {match.params.agency || agency ? (
-          <Box px="36px" mt="-20px" display={{ base: 'none', lg: 'flex' }}>
-            <AgencyLogo
-              agencyShortName={match.params.agency || agency.shortname}
-            />
-          </Box>
-        ) : null}
-      </Box>
       <Box flex="1">{hasTagsKey ? <TagMenu /> : <TagPanel />}</Box>
       <Flex
         maxW="680px"


### PR DESCRIPTION
## Problem

Closes #561 

## Solution

Implement sticky navigation bar for mobile and desktop.

**Features**:

- add MastHead to Header
- add search bar portion of HomePage to Header
- make Header sticky
- change App height to auto
- clean up AgencyLogo to take in agency object
- add window resize hook for non-desktop users

## Before & After Screenshots

### BEFORE

#### Mobile

##### Non-Question pages

https://user-images.githubusercontent.com/37061143/138031422-b4e6da25-18f4-4fb8-8503-d7243f3ddce8.mov

##### Question pages

https://user-images.githubusercontent.com/37061143/138031417-030570cf-5e86-4922-92a3-5ec2f6136c11.mov

#### Desktop

##### Non-Question pages

https://user-images.githubusercontent.com/37061143/138031286-5d651e97-0788-499d-ac34-7c05e2c734d2.mov

##### Question pages

https://user-images.githubusercontent.com/37061143/138031277-1da8f5db-c637-4da7-b709-0dd6009476e5.mov

**AFTER**:

#### Mobile

##### Non-Question pages

https://user-images.githubusercontent.com/37061143/138031529-b8168eef-9bdf-4767-830b-f7228782b24f.mov

##### Question pages

https://user-images.githubusercontent.com/37061143/138031569-e0cd03f8-7809-43cc-8552-5acad78e2434.mov

#### Desktop

##### Non-Question pages

https://user-images.githubusercontent.com/37061143/138031682-8655256d-67b6-4800-b70e-ae3a2609c0b0.mov

##### Question pages

https://user-images.githubusercontent.com/37061143/138031631-07fd02c8-da49-44f5-aafe-2cdc076e50b5.mov

## Tests

Check sticky navigation bar for desktop and mobile, for question and non-question pages. Behaviour of the navigation bar should be as presented above.
