### PR TITLE
chore(post): add scripts to remove and readd agency id fk

### DIFF
--- a/server/migrations/20211019053109-remove-post-agency-id-fk.js
+++ b/server/migrations/20211019053109-remove-post-agency-id-fk.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.removeConstraint('posts', 'posts_agencyId_foreign_idx')
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.addConstraint('posts', {
+      type: 'FOREIGN KEY',
+      name: 'posts_agencyId_foreign_idx',
+      fields: ['agencyId'],
+      references: {
+        table: 'agencies',
+        field: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    })
+  },
+}

--- a/server/migrations/20211019053111-recreate-post-agency-id-fk.js
+++ b/server/migrations/20211019053111-recreate-post-agency-id-fk.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addConstraint('posts', {
+      type: 'FOREIGN KEY',
+      name: 'posts_agencyId_foreign_idx',
+      fields: ['agencyId'],
+      references: {
+        table: 'agencies',
+        field: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeConstraint('posts', 'posts_agencyId_foreign_idx')
+  },
+}


### PR DESCRIPTION
## Problem and Solution

MySQL does not take kindly to column changes when a foreign key is
present, so provide scripts that would cleanly remove and readd the
fk before/after the setting of agency id to not null

## Deploy notes

Already invoked in production, no further action needed