### PR TITLE
refactor(post): retrieve answerable posts by agencyId

### DIFF
--- a/client/src/api/types/post.ts
+++ b/client/src/api/types/post.ts
@@ -4,6 +4,7 @@ import { User as UserBaseDto, PostStatus } from '~shared/types/base'
 
 export type BasePostDto = BaseModelParams & {
   userId: number
+  agencyId: number
   title: string
   description: string
   views: number

--- a/client/src/components/PostItem/PostItem.component.jsx
+++ b/client/src/components/PostItem/PostItem.component.jsx
@@ -8,26 +8,12 @@ import './PostItem.styles.scss'
 
 // Note: PostItem is the component for the homepage
 const PostItem = ({
-  post: { id, title, description, tags, views },
+  post: { id, title, description, tags, agencyId },
   agency,
 }) => {
   const { user } = useAuth()
 
-  const hasCommonAgencyTags = (user, tagsFromPost) => {
-    const { tags: userTags } = user
-    const userAgencyTagNames = userTags
-      .filter(({ tagType }) => tagType === TagType.Agency)
-      .map((userTag) => userTag.tagname)
-    const postAgencyTagNames = tagsFromPost
-      .filter(({ tagType }) => tagType === TagType.Agency)
-      .map((postTag) => postTag.tagname)
-    const interesectingTagNames = userAgencyTagNames.filter((tagName) =>
-      postAgencyTagNames.includes(tagName),
-    )
-    return interesectingTagNames.length > 0
-  }
-
-  const isAgencyMember = user && tags && hasCommonAgencyTags(user, tags)
+  const isAgencyMember = user && tags && user.agencyId === agencyId
 
   return (
     <div className="post-with-stats flex">

--- a/client/src/pages/Login/Login.component.jsx
+++ b/client/src/pages/Login/Login.component.jsx
@@ -1,22 +1,14 @@
 import { Spacer } from '@chakra-ui/react'
-import React from 'react'
 import { Redirect } from 'react-router-dom'
 import AuthForm from '../../components/AuthForm/AuthForm.component'
 import { useAuth } from '../../contexts/AuthContext'
-import { TagType } from '~shared/types/base'
 import './Login.styles.scss'
 
 const Login = () => {
   const { user } = useAuth()
 
   if (user) {
-    // if user is linked to multiple agencies via agencyTag
-    // take the first agencyTag found as agency to redirect to after login
-    const firstAgencyTagLinkedToUser = user.tags.find(
-      (tag) => tag.tagType === TagType.Agency,
-    )
-    const agencyShortName = firstAgencyTagLinkedToUser.tagname //currently link agency tag to agency via tag.tagname to agency.shortname
-    return <Redirect to={`/agency/${agencyShortName}`} />
+    return <Redirect to={`/agency/${user.agency.shortname}`} />
   } else {
     return (
       <div className="login-page">

--- a/client/src/pages/Post/Post.component.jsx
+++ b/client/src/pages/Post/Post.component.jsx
@@ -52,22 +52,8 @@ const Post = () => {
   // User can edit if it is authenticated whose agency tags intersect with
   // those found on posts
   const { user } = useAuth()
-  const hasCommonAgencyTags = (user, tagsFromPost) => {
-    const { tags: userTags } = user
-    const userAgencyTagNames = userTags
-      .filter(({ tagType }) => tagType === TagType.Agency)
-      .map((userTag) => userTag.tagname)
-    const postAgencyTagNames = tagsFromPost
-      .filter(({ tagType }) => tagType === TagType.Agency)
-      .map((postTag) => postTag.tagname)
-    const intersectingTagNames = userAgencyTagNames.filter((tagName) =>
-      postAgencyTagNames.includes(tagName),
-    )
-    return intersectingTagNames.length > 0
-  }
 
-  const isAgencyMember =
-    user && post?.tags && hasCommonAgencyTags(user, post?.tags)
+  const isAgencyMember = user && post && user.agencyId === post.agencyId
 
   const formattedTimeString = format(
     utcToZonedTime(post?.updatedAt ?? Date.now()),

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -2,15 +2,3 @@ import { PermissionType } from '~shared/types/base'
 
 export const isUserPublicOfficer = (user) =>
   !!user?.username?.endsWith('.gov.sg')
-
-export const hasAnswerPermissions = (user, post) => {
-  const hasAnswerPermissions = post.tags.every((postTag) => {
-    const userTag = user.tags.find((userTag) => userTag.id === postTag.id)
-    return (
-      userTag &&
-      userTag.permission &&
-      userTag.permission.role === PermissionType.Answerer
-    )
-  })
-  return hasAnswerPermissions
-}

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -117,7 +117,7 @@ const enquiryService = new EnquiryService({ Agency, mailService })
 const recaptchaService = new RecaptchaService({ axios, ...recaptchaConfig })
 const answersService = new AnswersService()
 const topicsService = new TopicsService({ Topic })
-const userService = new UserService({ User, Tag })
+const userService = new UserService({ User, Tag, Agency })
 
 const apiOptions = {
   agency: {

--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -86,7 +86,7 @@ describe('/posts', () => {
     Tag = getModel<TagModel>(db, ModelName.Tag)
     User = getModel<UserModel>(db, ModelName.User)
     Permission = getModel<PermissionModel>(db, ModelName.Permission)
-    userService = new UserService({ User, Tag })
+    userService = new UserService({ User, Tag, Agency })
     postService = new PostService({ Answer, Post, PostTag, Tag, User })
     const { id: agencyId } = await Agency.create({
       shortname: 'was',

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -1,20 +1,24 @@
 import { LoadUserDto } from '~shared/types/api'
-import { Tag, User } from '~shared/types/base'
+import { Agency, Tag, User } from '~shared/types/base'
 import { ModelDef } from '../../types/sequelize'
 import { getOfficerDisplayName } from './user.util'
 
 export class UserService {
   private User: ModelDef<User, Pick<User, 'username' | 'displayname'>>
   private Tag: ModelDef<Tag>
+  private Agency: ModelDef<Agency>
   constructor({
     User,
     Tag,
+    Agency,
   }: {
     User: ModelDef<User, Pick<User, 'username' | 'displayname'>>
     Tag: ModelDef<Tag>
+    Agency: ModelDef<Agency>
   }) {
     this.User = User
     this.Tag = Tag
+    this.Agency = Agency
   }
   createOfficer = async (username: string): Promise<User> => {
     return this.User.create({
@@ -25,7 +29,7 @@ export class UserService {
 
   loadUser = async (userId: number): Promise<LoadUserDto> => {
     return this.User.findByPk(userId, {
-      include: this.Tag,
+      include: [this.Agency, this.Tag],
     }) as Promise<LoadUserDto>
   }
 }

--- a/shared/src/types/api/auth.ts
+++ b/shared/src/types/api/auth.ts
@@ -1,9 +1,10 @@
-import { Permission, Tag, User } from '../base'
+import { Agency, Permission, Tag, User } from '../base'
 
 export type LoadUserDto =
   | (User & {
       tags: (Tag & {
         permission: Permission
       })[]
+      agency: Agency
     })
   | null


### PR DESCRIPTION
## Problem
AskGov is still using agency tags for client-side permissions checks and
retrieving answerable posts

## Solution
Stop using agency tags to do client-side permissions checks and for
listing answerable posts, favouring the use of agency id instead

- Add agency to LoadUserDto, agencyId to responses from PostService
- Rework `PostService.listAnswerablePosts` to use `agencyId`
- Make use of `user.agency` or `user.agencyId` throughout client,
  dropping the need for complicated tag comparisons

Retrieving posts by agency id will be undertaken as part of a wider PR for topics - #630