### PR TITLE
feat(tags): Add cards view for topics selection (desktop and tablet)

### DIFF
--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -11,6 +11,8 @@ import {
   Flex,
   Spacer,
   Stack,
+  SimpleGrid,
+  Box,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -77,7 +79,6 @@ const TagMenu = (): ReactElement => {
       )
     : useQuery(FETCH_TAGS_QUERY_KEY, () => fetchTags())
 
-  // TODO - create an AccordionItem for agency tags
   return (
     <Accordion allowMultiple allowToggle>
       <AccordionItem border="none">
@@ -125,7 +126,12 @@ const TagMenu = (): ReactElement => {
             </Flex>
           </AccordionButton>
         </h2>
-        <AccordionPanel p={0} shadow="md">
+        {/* Accordion for mobile */}
+        <AccordionPanel
+          p={0}
+          shadow="md"
+          display={{ base: 'block', sm: 'none' }}
+        >
           {isLoading && <Spinner />}
           {tags && (
             <VStack align="left" spacing={0}>
@@ -143,7 +149,6 @@ const TagMenu = (): ReactElement => {
                       w="100%"
                       textAlign="left"
                       textStyle="h4"
-                      borderBottomWidth="1px"
                       role="group"
                       _hover={{ bg: 'primary.100' }}
                       _focus={{
@@ -159,7 +164,11 @@ const TagMenu = (): ReactElement => {
                       }}
                     >
                       <Flex maxW="680px" m="auto" w="100%" px={8}>
-                        <Text _groupHover={{ color: 'primary.600' }}>
+                        <Text
+                          _groupHover={{
+                            color: 'primary.600',
+                          }}
+                        >
                           {tag.tagname}
                         </Text>
                         <Spacer />
@@ -169,6 +178,65 @@ const TagMenu = (): ReactElement => {
                   )
                 })}
             </VStack>
+          )}
+        </AccordionPanel>
+        {/* Accordion cards view for tablet and desktop */}
+        <AccordionPanel
+          p={0}
+          shadow="md"
+          display={{ base: 'none', sm: 'block' }}
+        >
+          {isLoading && <Spinner />}
+          {tags && (
+            <SimpleGrid
+              templateColumns="repeat(2, 1fr)"
+              maxW="620px"
+              m="auto"
+              spacingX="16px"
+              spacingY="16px"
+              py="48px"
+            >
+              {tags
+                .filter(
+                  ({ tagType, tagname }) =>
+                    tagType === TagType.Topic && tagname !== queryState,
+                )
+                .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
+                .map((tag) => {
+                  const { tagType, tagname } = tag
+                  return (
+                    <Box
+                      py="24px"
+                      h="72px"
+                      w="100%"
+                      textAlign="left"
+                      textStyle="h4"
+                      boxShadow="base"
+                      role="group"
+                      _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+                      _focus={{
+                        color: 'primary.600',
+                      }}
+                      as={RouterLink}
+                      key={tag.id}
+                      to={getRedirectURL(tagType, tagname, agency)}
+                      onClick={() => {
+                        sendClickTagEventToAnalytics(tagname)
+                        setQueryState(tagname)
+                        accordionRef.current?.click()
+                      }}
+                    >
+                      <Flex m="auto" w="100%" px={8}>
+                        <Text _groupHover={{ color: 'primary.600' }}>
+                          {tag.tagname}
+                        </Text>
+                        <Spacer />
+                        <BiRightArrowAlt />
+                      </Flex>
+                    </Box>
+                  )
+                })}
+            </SimpleGrid>
           )}
         </AccordionPanel>
       </AccordionItem>

--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -104,51 +104,50 @@ const TagMenu = (): ReactElement => {
     sm: false,
   })
 
-  const tagsToShow = tags || []
+  const tagsToShow = (tags || [])
+    .filter(
+      ({ tagType, tagname }) =>
+        tagType === TagType.Topic && tagname !== queryState,
+    )
+    .sort(bySpecifiedOrder)
 
   const TagMenuMobile = (
     <VStack align="left" spacing={0}>
-      {tagsToShow
-        .filter(
-          ({ tagType, tagname }) =>
-            tagType === TagType.Topic && tagname !== queryState,
+      {tagsToShow.map(({ id, tagType, tagname }) => {
+        return (
+          <Link
+            py="24px"
+            w="100%"
+            textAlign="left"
+            textStyle="h4"
+            role="group"
+            _hover={{ bg: 'primary.100' }}
+            _focus={{
+              color: 'primary.600',
+            }}
+            as={RouterLink}
+            key={id}
+            to={getRedirectURL(tagType, tagname, agency)}
+            onClick={() => {
+              sendClickTagEventToAnalytics(tagname)
+              setQueryState(tagname)
+              accordionRef.current?.click()
+            }}
+          >
+            <Flex maxW="680px" m="auto" w="100%" px={8}>
+              <Text
+                _groupHover={{
+                  color: 'primary.600',
+                }}
+              >
+                {tagname}
+              </Text>
+              <Spacer />
+              <BiRightArrowAlt />
+            </Flex>
+          </Link>
         )
-        .sort(bySpecifiedOrder)
-        .map(({ id, tagType, tagname }) => {
-          return (
-            <Link
-              py="24px"
-              w="100%"
-              textAlign="left"
-              textStyle="h4"
-              role="group"
-              _hover={{ bg: 'primary.100' }}
-              _focus={{
-                color: 'primary.600',
-              }}
-              as={RouterLink}
-              key={id}
-              to={getRedirectURL(tagType, tagname, agency)}
-              onClick={() => {
-                sendClickTagEventToAnalytics(tagname)
-                setQueryState(tagname)
-                accordionRef.current?.click()
-              }}
-            >
-              <Flex maxW="680px" m="auto" w="100%" px={8}>
-                <Text
-                  _groupHover={{
-                    color: 'primary.600',
-                  }}
-                >
-                  {tagname}
-                </Text>
-                <Spacer />
-                <BiRightArrowAlt />
-              </Flex>
-            </Link>
-          )
-        })}
+      })}
     </VStack>
   )
 
@@ -161,46 +160,37 @@ const TagMenu = (): ReactElement => {
       spacingY="16px"
       py="48px"
     >
-      {tagsToShow
-        .filter(
-          ({ tagType, tagname }) =>
-            tagType === TagType.Topic && tagname !== queryState,
+      {tagsToShow.map(({ id, tagType, tagname }) => {
+        return (
+          <Box
+            py="24px"
+            h="72px"
+            w="100%"
+            textAlign="left"
+            textStyle="h4"
+            boxShadow="base"
+            role="group"
+            _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+            _focus={{
+              color: 'primary.600',
+            }}
+            as={RouterLink}
+            key={id}
+            to={getRedirectURL(tagType, tagname, agency)}
+            onClick={() => {
+              sendClickTagEventToAnalytics(tagname)
+              setQueryState(tagname)
+              accordionRef.current?.click()
+            }}
+          >
+            <Flex m="auto" w="100%" px={8}>
+              <Text _groupHover={{ color: 'primary.600' }}>{tagname}</Text>
+              <Spacer />
+              <BiRightArrowAlt />
+            </Flex>
+          </Box>
         )
-        .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
-        .map((tag) => {
-          const { tagType, tagname } = tag
-          return (
-            <Box
-              py="24px"
-              h="72px"
-              w="100%"
-              textAlign="left"
-              textStyle="h4"
-              boxShadow="base"
-              role="group"
-              _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
-              _focus={{
-                color: 'primary.600',
-              }}
-              as={RouterLink}
-              key={tag.id}
-              to={getRedirectURL(tagType, tagname, agency)}
-              onClick={() => {
-                sendClickTagEventToAnalytics(tagname)
-                setQueryState(tagname)
-                accordionRef.current?.click()
-              }}
-            >
-              <Flex m="auto" w="100%" px={8}>
-                <Text _groupHover={{ color: 'primary.600' }}>
-                  {tag.tagname}
-                </Text>
-                <Spacer />
-                <BiRightArrowAlt />
-              </Flex>
-            </Box>
-          )
-        })}
+      })}
     </SimpleGrid>
   )
 

--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   SimpleGrid,
   Box,
+  useBreakpointValue,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -79,6 +80,114 @@ const TagMenu = (): ReactElement => {
       )
     : useQuery(FETCH_TAGS_QUERY_KEY, () => fetchTags())
 
+  const isShowMobileVariant = useBreakpointValue({
+    base: true,
+    xs: true,
+    sm: false,
+    md: false,
+    lg: false,
+    xl: false,
+  })
+
+  const TagMenuMobile = tags && (
+    <VStack align="left" spacing={0}>
+      {tags
+        .filter(
+          ({ tagType, tagname }) =>
+            tagType === TagType.Topic && tagname !== queryState,
+        )
+        .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
+        .map((tag) => {
+          const { tagType, tagname } = tag
+          return (
+            <Link
+              py="24px"
+              w="100%"
+              textAlign="left"
+              textStyle="h4"
+              role="group"
+              _hover={{ bg: 'primary.100' }}
+              _focus={{
+                color: 'primary.600',
+              }}
+              as={RouterLink}
+              key={tag.id}
+              to={getRedirectURL(tagType, tagname, agency)}
+              onClick={() => {
+                sendClickTagEventToAnalytics(tagname)
+                setQueryState(tagname)
+                accordionRef.current?.click()
+              }}
+            >
+              <Flex maxW="680px" m="auto" w="100%" px={8}>
+                <Text
+                  _groupHover={{
+                    color: 'primary.600',
+                  }}
+                >
+                  {tag.tagname}
+                </Text>
+                <Spacer />
+                <BiRightArrowAlt />
+              </Flex>
+            </Link>
+          )
+        })}
+    </VStack>
+  )
+
+  const TagMenuDesktop = tags && (
+    <SimpleGrid
+      templateColumns="repeat(2, 1fr)"
+      maxW="620px"
+      m="auto"
+      spacingX="16px"
+      spacingY="16px"
+      py="48px"
+    >
+      {tags
+        .filter(
+          ({ tagType, tagname }) =>
+            tagType === TagType.Topic && tagname !== queryState,
+        )
+        .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
+        .map((tag) => {
+          const { tagType, tagname } = tag
+          return (
+            <Box
+              py="24px"
+              h="72px"
+              w="100%"
+              textAlign="left"
+              textStyle="h4"
+              boxShadow="base"
+              role="group"
+              _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+              _focus={{
+                color: 'primary.600',
+              }}
+              as={RouterLink}
+              key={tag.id}
+              to={getRedirectURL(tagType, tagname, agency)}
+              onClick={() => {
+                sendClickTagEventToAnalytics(tagname)
+                setQueryState(tagname)
+                accordionRef.current?.click()
+              }}
+            >
+              <Flex m="auto" w="100%" px={8}>
+                <Text _groupHover={{ color: 'primary.600' }}>
+                  {tag.tagname}
+                </Text>
+                <Spacer />
+                <BiRightArrowAlt />
+              </Flex>
+            </Box>
+          )
+        })}
+    </SimpleGrid>
+  )
+
   return (
     <Accordion allowMultiple allowToggle>
       <AccordionItem border="none">
@@ -126,118 +235,9 @@ const TagMenu = (): ReactElement => {
             </Flex>
           </AccordionButton>
         </h2>
-        {/* Accordion for mobile */}
-        <AccordionPanel
-          p={0}
-          shadow="md"
-          display={{ base: 'block', sm: 'none' }}
-        >
+        <AccordionPanel p={0} shadow="md">
           {isLoading && <Spinner />}
-          {tags && (
-            <VStack align="left" spacing={0}>
-              {tags
-                .filter(
-                  ({ tagType, tagname }) =>
-                    tagType === TagType.Topic && tagname !== queryState,
-                )
-                .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
-                .map((tag) => {
-                  const { tagType, tagname } = tag
-                  return (
-                    <Link
-                      py="24px"
-                      w="100%"
-                      textAlign="left"
-                      textStyle="h4"
-                      role="group"
-                      _hover={{ bg: 'primary.100' }}
-                      _focus={{
-                        color: 'primary.600',
-                      }}
-                      as={RouterLink}
-                      key={tag.id}
-                      to={getRedirectURL(tagType, tagname, agency)}
-                      onClick={() => {
-                        sendClickTagEventToAnalytics(tagname)
-                        setQueryState(tagname)
-                        accordionRef.current?.click()
-                      }}
-                    >
-                      <Flex maxW="680px" m="auto" w="100%" px={8}>
-                        <Text
-                          _groupHover={{
-                            color: 'primary.600',
-                          }}
-                        >
-                          {tag.tagname}
-                        </Text>
-                        <Spacer />
-                        <BiRightArrowAlt />
-                      </Flex>
-                    </Link>
-                  )
-                })}
-            </VStack>
-          )}
-        </AccordionPanel>
-        {/* Accordion cards view for tablet and desktop */}
-        <AccordionPanel
-          p={0}
-          shadow="md"
-          display={{ base: 'none', sm: 'block' }}
-        >
-          {isLoading && <Spinner />}
-          {tags && (
-            <SimpleGrid
-              templateColumns="repeat(2, 1fr)"
-              maxW="620px"
-              m="auto"
-              spacingX="16px"
-              spacingY="16px"
-              py="48px"
-            >
-              {tags
-                .filter(
-                  ({ tagType, tagname }) =>
-                    tagType === TagType.Topic && tagname !== queryState,
-                )
-                .sort((a, b) => (a.tagname > b.tagname ? 1 : -1))
-                .map((tag) => {
-                  const { tagType, tagname } = tag
-                  return (
-                    <Box
-                      py="24px"
-                      h="72px"
-                      w="100%"
-                      textAlign="left"
-                      textStyle="h4"
-                      boxShadow="base"
-                      role="group"
-                      _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
-                      _focus={{
-                        color: 'primary.600',
-                      }}
-                      as={RouterLink}
-                      key={tag.id}
-                      to={getRedirectURL(tagType, tagname, agency)}
-                      onClick={() => {
-                        sendClickTagEventToAnalytics(tagname)
-                        setQueryState(tagname)
-                        accordionRef.current?.click()
-                      }}
-                    >
-                      <Flex m="auto" w="100%" px={8}>
-                        <Text _groupHover={{ color: 'primary.600' }}>
-                          {tag.tagname}
-                        </Text>
-                        <Spacer />
-                        <BiRightArrowAlt />
-                      </Flex>
-                    </Box>
-                  )
-                })}
-            </SimpleGrid>
-          )}
+          {isShowMobileVariant ? TagMenuMobile : TagMenuDesktop}
         </AccordionPanel>
       </AccordionItem>
     </Accordion>

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -11,6 +11,7 @@ import {
   Spacer,
   SimpleGrid,
   Box,
+  useBreakpointValue,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -87,6 +88,94 @@ const TagPanel = (): ReactElement => {
         }
       : (a: Tag, b: Tag) => (a.tagname > b.tagname ? 1 : -1)
 
+  const isShowMobileVariant = useBreakpointValue({
+    base: true,
+    xs: true,
+    sm: false,
+    md: false,
+    lg: false,
+    xl: false,
+  })
+
+  const TagMenuMobile = tags && (
+    <VStack align="left" spacing={0}>
+      {tags
+        .filter(({ tagType }) => tagType === TagType.Topic)
+        .sort(bySpecifiedOrder)
+        .map((tag) => {
+          const { tagType, tagname } = tag
+          return (
+            <Link
+              py="24px"
+              w="100%"
+              textAlign="left"
+              textStyle="h4"
+              borderBottomWidth="1px"
+              role="group"
+              _hover={{ bg: 'primary.100' }}
+              as={RouterLink}
+              key={tag.id}
+              to={getRedirectURL(tagType, tagname, agency)}
+              onClick={() => sendClickTagEventToAnalytics(tagname)}
+            >
+              <Flex maxW="680px" m="auto" w="100%" px={8}>
+                <Text _groupHover={{ color: 'primary.600' }}>
+                  {tag.tagname}
+                </Text>
+                <Spacer />
+                <BiRightArrowAlt />
+              </Flex>
+            </Link>
+          )
+        })}
+    </VStack>
+  )
+
+  const TagMenuDesktop = tags && (
+    <SimpleGrid
+      templateColumns="repeat(2, 1fr)"
+      maxW="620px"
+      m="auto"
+      spacingX="16px"
+      spacingY="16px"
+      py="48px"
+    >
+      {tags
+        .filter(({ tagType }) => tagType === TagType.Topic)
+        .sort(bySpecifiedOrder)
+        .map((tag) => {
+          const { tagType, tagname } = tag
+          return (
+            <Box
+              py="24px"
+              h="72px"
+              w="100%"
+              textAlign="left"
+              textStyle="h4"
+              boxShadow="base"
+              role="group"
+              _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+              _focus={{
+                color: 'primary.600',
+              }}
+              as={RouterLink}
+              key={tag.id}
+              to={getRedirectURL(tagType, tagname, agency)}
+              onClick={() => sendClickTagEventToAnalytics(tagname)}
+            >
+              <Flex m="auto" w="100%" px={8}>
+                <Text _groupHover={{ color: 'primary.600' }}>
+                  {tag.tagname}
+                </Text>
+                <Spacer />
+                <BiRightArrowAlt />
+              </Flex>
+            </Box>
+          )
+        })}
+    </SimpleGrid>
+  )
+
   return (
     <Accordion defaultIndex={[0]} allowMultiple>
       <AccordionItem border="none">
@@ -101,98 +190,9 @@ const TagPanel = (): ReactElement => {
             </Text>
           </Flex>
         </AccordionButton>
-        {/* Accordion for mobile */}
-        <AccordionPanel
-          p={0}
-          shadow="md"
-          display={{ base: 'block', sm: 'none' }}
-        >
+        <AccordionPanel p={0} shadow="md">
           {isLoading && <Spinner />}
-          {tags && (
-            <VStack align="left" spacing={0}>
-              {tags
-                .filter(({ tagType }) => tagType === TagType.Topic)
-                .sort(bySpecifiedOrder)
-                .map((tag) => {
-                  const { tagType, tagname } = tag
-                  return (
-                    <Link
-                      py="24px"
-                      w="100%"
-                      textAlign="left"
-                      textStyle="h4"
-                      borderBottomWidth="1px"
-                      role="group"
-                      _hover={{ bg: 'primary.100' }}
-                      as={RouterLink}
-                      key={tag.id}
-                      to={getRedirectURL(tagType, tagname, agency)}
-                      onClick={() => sendClickTagEventToAnalytics(tagname)}
-                    >
-                      <Flex maxW="680px" m="auto" w="100%" px={8}>
-                        <Text _groupHover={{ color: 'primary.600' }}>
-                          {tag.tagname}
-                        </Text>
-                        <Spacer />
-                        <BiRightArrowAlt />
-                      </Flex>
-                    </Link>
-                  )
-                })}
-            </VStack>
-          )}
-        </AccordionPanel>
-        {/* Accordion cards view for tablet and desktop */}
-        <AccordionPanel
-          p={0}
-          shadow="md"
-          display={{ base: 'none', sm: 'block' }}
-        >
-          {isLoading && <Spinner />}
-          {tags && (
-            <SimpleGrid
-              templateColumns="repeat(2, 1fr)"
-              maxW="620px"
-              m="auto"
-              spacingX="16px"
-              spacingY="16px"
-              py="48px"
-            >
-              {tags
-                .filter(({ tagType }) => tagType === TagType.Topic)
-                .sort(bySpecifiedOrder)
-                .map((tag) => {
-                  const { tagType, tagname } = tag
-                  return (
-                    <Box
-                      py="24px"
-                      h="72px"
-                      w="100%"
-                      textAlign="left"
-                      textStyle="h4"
-                      boxShadow="base"
-                      role="group"
-                      _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
-                      _focus={{
-                        color: 'primary.600',
-                      }}
-                      as={RouterLink}
-                      key={tag.id}
-                      to={getRedirectURL(tagType, tagname, agency)}
-                      onClick={() => sendClickTagEventToAnalytics(tagname)}
-                    >
-                      <Flex m="auto" w="100%" px={8}>
-                        <Text _groupHover={{ color: 'primary.600' }}>
-                          {tag.tagname}
-                        </Text>
-                        <Spacer />
-                        <BiRightArrowAlt />
-                      </Flex>
-                    </Box>
-                  )
-                })}
-            </SimpleGrid>
-          )}
+          {isShowMobileVariant ? TagMenuMobile : TagMenuDesktop}
         </AccordionPanel>
       </AccordionItem>
     </Accordion>

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -93,39 +93,35 @@ const TagPanel = (): ReactElement => {
     sm: false,
   })
 
-  const tagsToShow = tags || []
+  const tagsToShow = (tags || [])
+    .filter(({ tagType }) => tagType === TagType.Topic)
+    .sort(bySpecifiedOrder)
 
   const TagMenuMobile = (
     <VStack align="left" spacing={0}>
-      {tagsToShow
-        .filter(({ tagType }) => tagType === TagType.Topic)
-        .sort(bySpecifiedOrder)
-        .map((tag) => {
-          const { tagType, tagname } = tag
-          return (
-            <Link
-              py="24px"
-              w="100%"
-              textAlign="left"
-              textStyle="h4"
-              borderBottomWidth="1px"
-              role="group"
-              _hover={{ bg: 'primary.100' }}
-              as={RouterLink}
-              key={tag.id}
-              to={getRedirectURL(tagType, tagname, agency)}
-              onClick={() => sendClickTagEventToAnalytics(tagname)}
-            >
-              <Flex maxW="680px" m="auto" w="100%" px={8}>
-                <Text _groupHover={{ color: 'primary.600' }}>
-                  {tag.tagname}
-                </Text>
-                <Spacer />
-                <BiRightArrowAlt />
-              </Flex>
-            </Link>
-          )
-        })}
+      {tagsToShow.map(({ id, tagType, tagname }) => {
+        return (
+          <Link
+            py="24px"
+            w="100%"
+            textAlign="left"
+            textStyle="h4"
+            borderBottomWidth="1px"
+            role="group"
+            _hover={{ bg: 'primary.100' }}
+            as={RouterLink}
+            key={id}
+            to={getRedirectURL(tagType, tagname, agency)}
+            onClick={() => sendClickTagEventToAnalytics(tagname)}
+          >
+            <Flex maxW="680px" m="auto" w="100%" px={8}>
+              <Text _groupHover={{ color: 'primary.600' }}>{tagname}</Text>
+              <Spacer />
+              <BiRightArrowAlt />
+            </Flex>
+          </Link>
+        )
+      })}
     </VStack>
   )
 
@@ -138,36 +134,33 @@ const TagPanel = (): ReactElement => {
       spacingY="16px"
       py="48px"
     >
-      {tagsToShow
-        .filter(({ tagType }) => tagType === TagType.Topic)
-        .sort(bySpecifiedOrder)
-        .map(({ id, tagType, tagname }) => {
-          return (
-            <Box
-              py="24px"
-              h="72px"
-              w="100%"
-              textAlign="left"
-              textStyle="h4"
-              boxShadow="base"
-              role="group"
-              _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
-              _focus={{
-                color: 'primary.600',
-              }}
-              as={RouterLink}
-              key={id}
-              to={getRedirectURL(tagType, tagname, agency)}
-              onClick={() => sendClickTagEventToAnalytics(tagname)}
-            >
-              <Flex m="auto" w="100%" px={8}>
-                <Text _groupHover={{ color: 'primary.600' }}>{tagname}</Text>
-                <Spacer />
-                <BiRightArrowAlt />
-              </Flex>
-            </Box>
-          )
-        })}
+      {tagsToShow.map(({ id, tagType, tagname }) => {
+        return (
+          <Box
+            py="24px"
+            h="72px"
+            w="100%"
+            textAlign="left"
+            textStyle="h4"
+            boxShadow="base"
+            role="group"
+            _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+            _focus={{
+              color: 'primary.600',
+            }}
+            as={RouterLink}
+            key={id}
+            to={getRedirectURL(tagType, tagname, agency)}
+            onClick={() => sendClickTagEventToAnalytics(tagname)}
+          >
+            <Flex m="auto" w="100%" px={8}>
+              <Text _groupHover={{ color: 'primary.600' }}>{tagname}</Text>
+              <Spacer />
+              <BiRightArrowAlt />
+            </Flex>
+          </Box>
+        )
+      })}
     </SimpleGrid>
   )
 

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -9,6 +9,8 @@ import {
   VStack,
   Flex,
   Spacer,
+  SimpleGrid,
+  Box,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -85,7 +87,6 @@ const TagPanel = (): ReactElement => {
         }
       : (a: Tag, b: Tag) => (a.tagname > b.tagname ? 1 : -1)
 
-  // TODO - create an AccordionItem for agency tags
   return (
     <Accordion defaultIndex={[0]} allowMultiple>
       <AccordionItem border="none">
@@ -100,7 +101,12 @@ const TagPanel = (): ReactElement => {
             </Text>
           </Flex>
         </AccordionButton>
-        <AccordionPanel p={0} shadow="md">
+        {/* Accordion for mobile */}
+        <AccordionPanel
+          p={0}
+          shadow="md"
+          display={{ base: 'block', sm: 'none' }}
+        >
           {isLoading && <Spinner />}
           {tags && (
             <VStack align="left" spacing={0}>
@@ -134,6 +140,58 @@ const TagPanel = (): ReactElement => {
                   )
                 })}
             </VStack>
+          )}
+        </AccordionPanel>
+        {/* Accordion cards view for tablet and desktop */}
+        <AccordionPanel
+          p={0}
+          shadow="md"
+          display={{ base: 'none', sm: 'block' }}
+        >
+          {isLoading && <Spinner />}
+          {tags && (
+            <SimpleGrid
+              templateColumns="repeat(2, 1fr)"
+              maxW="620px"
+              m="auto"
+              spacingX="16px"
+              spacingY="16px"
+              py="48px"
+            >
+              {tags
+                .filter(({ tagType }) => tagType === TagType.Topic)
+                .sort(bySpecifiedOrder)
+                .map((tag) => {
+                  const { tagType, tagname } = tag
+                  return (
+                    <Box
+                      py="24px"
+                      h="72px"
+                      w="100%"
+                      textAlign="left"
+                      textStyle="h4"
+                      boxShadow="base"
+                      role="group"
+                      _hover={{ bg: 'primary.100', boxShadow: 'lg' }}
+                      _focus={{
+                        color: 'primary.600',
+                      }}
+                      as={RouterLink}
+                      key={tag.id}
+                      to={getRedirectURL(tagType, tagname, agency)}
+                      onClick={() => sendClickTagEventToAnalytics(tagname)}
+                    >
+                      <Flex m="auto" w="100%" px={8}>
+                        <Text _groupHover={{ color: 'primary.600' }}>
+                          {tag.tagname}
+                        </Text>
+                        <Spacer />
+                        <BiRightArrowAlt />
+                      </Flex>
+                    </Box>
+                  )
+                })}
+            </SimpleGrid>
           )}
         </AccordionPanel>
       </AccordionItem>

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -90,16 +90,14 @@ const TagPanel = (): ReactElement => {
 
   const isShowMobileVariant = useBreakpointValue({
     base: true,
-    xs: true,
     sm: false,
-    md: false,
-    lg: false,
-    xl: false,
   })
 
-  const TagMenuMobile = tags && (
+  const tagsToShow = tags || []
+
+  const TagMenuMobile = (
     <VStack align="left" spacing={0}>
-      {tags
+      {tagsToShow
         .filter(({ tagType }) => tagType === TagType.Topic)
         .sort(bySpecifiedOrder)
         .map((tag) => {
@@ -131,7 +129,7 @@ const TagPanel = (): ReactElement => {
     </VStack>
   )
 
-  const TagMenuDesktop = tags && (
+  const TagMenuDesktop = (
     <SimpleGrid
       templateColumns="repeat(2, 1fr)"
       maxW="620px"
@@ -140,11 +138,10 @@ const TagPanel = (): ReactElement => {
       spacingY="16px"
       py="48px"
     >
-      {tags
+      {tagsToShow
         .filter(({ tagType }) => tagType === TagType.Topic)
         .sort(bySpecifiedOrder)
-        .map((tag) => {
-          const { tagType, tagname } = tag
+        .map(({ id, tagType, tagname }) => {
           return (
             <Box
               py="24px"
@@ -159,14 +156,12 @@ const TagPanel = (): ReactElement => {
                 color: 'primary.600',
               }}
               as={RouterLink}
-              key={tag.id}
+              key={id}
               to={getRedirectURL(tagType, tagname, agency)}
               onClick={() => sendClickTagEventToAnalytics(tagname)}
             >
               <Flex m="auto" w="100%" px={8}>
-                <Text _groupHover={{ color: 'primary.600' }}>
-                  {tag.tagname}
-                </Text>
+                <Text _groupHover={{ color: 'primary.600' }}>{tagname}</Text>
                 <Spacer />
                 <BiRightArrowAlt />
               </Flex>


### PR DESCRIPTION
## Problem

The views for topic selection are the same across all devices. On larger screens, this results in wasted space.

Closes #550 

## Solution

For tablets and desktops, use grids to display topics in individual boxes ([figma reference](https://www.figma.com/file/O6lxjjfn04Ow6nn2TMStpk/AskGov-Design-Master-v2?node-id=6003%3A70135))


## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/56983748/138998969-42407adc-e5f4-4bd0-8a63-25bf369f9725.mov


**AFTER**:

https://user-images.githubusercontent.com/56983748/138998873-c52d3903-1faa-44bb-a06c-3fb37302acf5.mov


## Tests

- Click around and check that navigation to topics still works