### PR TITLE
feat(search): add elasticsearch to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,13 @@ services:
     environment:
       - MYSQL_DATABASE=$DB_NAME
       - MYSQL_ROOT_PASSWORD=$DB_PASSWORD
+
+  opensearch:
+    image: opensearchproject/opensearch:1.1.0
+    container_name: askgovsg_os_1
+    environment:
+      - "discovery.type=single-node"
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer


### PR DESCRIPTION
Add Opensearch service with default configurations to `docker-compose.yml`.

- OpenSearch chosen in favour of Elasticsearch due to free security features and AWS as vendor

Closes #683

## Tests

1. Start docker container either through Docker Desktop or through `docker-compose up`. 
2. Wait for docker to spin up the service, which can be determined when Docker logs print: "Node '<node_id>' initialized".
2. In a terminal, run a `curl` command to query the elastic search engine, such as the following: `curl -XGET https://localhost:9200 -u 'admin:admin' --insecure`. The output for the example command should be something like the following:

```json
{
  "name" : "4a44a7d1ec7e",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "Enxxlh4hSg-8bt5_8VQQTA",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.1.0",
    "build_type" : "tar",
    "build_hash" : "15e9f137622d878b79103df8f82d78d782b686a1",
    "build_date" : "2021-10-04T21:29:03.079792Z",
    "build_snapshot" : false,
    "lucene_version" : "8.9.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

3. Other simple queries can be found in the [Docker quickstart](https://opensearch.org/docs/latest).