### PR TITLE
test(post): add unit tests for post module

### DIFF
--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -48,14 +48,6 @@ describe('PostController', () => {
     next()
   }
 
-  const app = express()
-  app.use(express.json())
-  app.use(middleware)
-  app.get(path, controller.listPosts)
-  app.get(path + '/answerable', controller.listAnswerablePosts)
-  app.post(path, controller.createPost)
-  const request = supertest(app)
-
   beforeEach(() => {
     user = { id: 1 }
   })
@@ -64,10 +56,19 @@ describe('PostController', () => {
   })
 
   describe('listPosts', () => {
+    beforeEach(() => {
+      postService.listPosts.mockReset()
+    })
     it('should return 200 on successful data retrieval', async () => {
       // Arrange
       const data = { rows: ['1', '2'], totalItems: 5 }
       postService.listPosts.mockReturnValue(data)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path, controller.listPosts)
+      const request = supertest(app)
 
       // Act
       const response = await request.get(path)
@@ -84,6 +85,12 @@ describe('PostController', () => {
         throw error
       })
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path, controller.listPosts)
+      const request = supertest(app)
+
       // Act
       const response = await request.get(path)
 
@@ -99,6 +106,11 @@ describe('PostController', () => {
         throw error
       })
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path, controller.listPosts)
+      const request = supertest(app)
       // Act
       const response = await request.get(path)
 
@@ -114,6 +126,12 @@ describe('PostController', () => {
         throw error
       })
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path, controller.listPosts)
+      const request = supertest(app)
+
       // Act
       const response = await request.get(path)
 
@@ -122,12 +140,21 @@ describe('PostController', () => {
       expect(response.body).toStrictEqual({ message: 'Server Error' })
     })
   })
+
   describe('listAnswerablePosts', () => {
+    beforeEach(() => {
+      postService.listAnswerablePosts.mockReset()
+    })
     it('should return 200 on successful data retrieval', async () => {
       // Arrange
       const data = { rows: ['1', '2'], totalItems: 5 }
       postService.listAnswerablePosts.mockReturnValue(data)
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path + '/answerable', controller.listAnswerablePosts)
+      const request = supertest(app)
       // Act
       const response = await request.get(path + '/answerable')
 
@@ -140,14 +167,61 @@ describe('PostController', () => {
       // Arrange
       user = undefined
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path + '/answerable', controller.listAnswerablePosts)
+      const request = supertest(app)
+
       // Act
       const response = await request.get(path + '/answerable')
 
       // Assert
-      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
       expect(response.body).toStrictEqual({
-        message: 'Something went wrong, please try again.',
+        message: 'User not signed in.',
       })
+    })
+
+    it('should return 422 on invalid tags used in request', async () => {
+      // Arrange
+      const error = new Error('Invalid tags used in request')
+      postService.listAnswerablePosts.mockImplementation(() => {
+        throw error
+      })
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path + '/answerable', controller.listAnswerablePosts)
+      const request = supertest(app)
+      // Act
+      const response = await request.get(path + '/answerable')
+
+      // Assert
+      expect(response.status).toEqual(422)
+      expect(response.body).toStrictEqual({ message: error.message })
+    })
+
+    it('should return 422 on invalid topics used in request', async () => {
+      // Arrange
+      const error = new Error('Invalid topics used in request')
+      postService.listAnswerablePosts.mockImplementation(() => {
+        throw error
+      })
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path + '/answerable', controller.listAnswerablePosts)
+      const request = supertest(app)
+
+      // Act
+      const response = await request.get(path + '/answerable')
+
+      // Assert
+      expect(response.status).toEqual(422)
+      expect(response.body).toStrictEqual({ message: error.message })
     })
 
     it('should return 500 on any other errors', async () => {
@@ -156,6 +230,12 @@ describe('PostController', () => {
       postService.listAnswerablePosts.mockImplementation(() => {
         throw error
       })
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.get(path + '/answerable', controller.listAnswerablePosts)
+      const request = supertest(app)
 
       // Act
       const response = await request.get(path + '/answerable')
@@ -167,15 +247,23 @@ describe('PostController', () => {
       })
     })
   })
+
   describe('createPost', () => {
     const agencyId = 21
     const postId = 13
+
     beforeEach(() => {
       userService.loadUser.mockResolvedValue({ agencyId })
       postService.createPost.mockResolvedValue(postId)
     })
     it('returns 401 on no user', async () => {
       user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.post(path, controller.createPost)
+      const request = supertest(app)
 
       const response = await request.post(path)
 
@@ -188,6 +276,12 @@ describe('PostController', () => {
     it('returns 500 on user with no agency', async () => {
       userService.loadUser.mockReturnValue({})
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.post(path, controller.createPost)
+      const request = supertest(app)
+
       const response = await request.post(path)
 
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
@@ -198,6 +292,12 @@ describe('PostController', () => {
     })
     it('returns 500 on userService problem', async () => {
       userService.loadUser.mockRejectedValue(new Error('bad user'))
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.post(path, controller.createPost)
+      const request = supertest(app)
 
       const response = await request.post(path)
 
@@ -210,6 +310,12 @@ describe('PostController', () => {
     it('returns 500 on postService problem', async () => {
       const body = { title: 'Title', description: null, tagname: [] }
       postService.createPost.mockRejectedValue(new Error('bad post'))
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.post(path, controller.createPost)
+      const request = supertest(app)
 
       const response = await request.post(path).send(body)
 
@@ -226,6 +332,12 @@ describe('PostController', () => {
     it('returns 200 on successful creation', async () => {
       const body = { title: 'Title', description: null, tagname: [] }
 
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.post(path, controller.createPost)
+      const request = supertest(app)
+
       const response = await request.post(path).send(body)
 
       expect(response.status).toEqual(StatusCodes.OK)
@@ -234,6 +346,217 @@ describe('PostController', () => {
         ...body,
         userId: user?.id,
         agencyId,
+      })
+    })
+  })
+
+  describe('deletePost', () => {
+    const postId = 1
+
+    beforeEach(() => {
+      authService.hasPermissionToAnswer.mockReset()
+      postService.deletePost.mockReset()
+    })
+
+    it('returns 200 on successful deletion', async () => {
+      authService.hasPermissionToAnswer.mockResolvedValue(true)
+      postService.deletePost.mockImplementation(() => Promise.resolve())
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.delete(path + '/:id([0-9]+$)', controller.deletePost)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        message: 'OK',
+      })
+      expect(postService.deletePost).toHaveBeenCalledWith(postId)
+    })
+
+    it('returns 401 on no user', async () => {
+      user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.delete(path + '/:id([0-9]+$)', controller.deletePost)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
+      expect(response.body).toStrictEqual({
+        message: 'You must be logged in to delete posts.',
+      })
+      expect(postService.deletePost).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 if user does not have permission to delete post', async () => {
+      authService.hasPermissionToAnswer.mockResolvedValue(false)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.delete(path + '/:id([0-9]+$)', controller.deletePost)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.FORBIDDEN)
+      expect(response.body).toStrictEqual({
+        message: 'You do not have permission to delete this post.',
+      })
+      expect(postService.deletePost).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 on database error', async () => {
+      authService.hasPermissionToAnswer.mockRejectedValue(
+        new Error('Error while deleting post'),
+      )
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.delete(path + '/:id([0-9]+$)', controller.deletePost)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(response.body).toStrictEqual({
+        message: 'Server error',
+      })
+      expect(postService.deletePost).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updatePost', () => {
+    const userId = 1
+    const postId = 1
+    beforeEach(() => {
+      authService.hasPermissionToAnswer.mockReset()
+      postService.updatePost.mockReset()
+    })
+
+    it('returns 200 on successful update', async () => {
+      authService.hasPermissionToAnswer.mockResolvedValue(true)
+      postService.updatePost.mockResolvedValue(true)
+
+      const body = {
+        title: 'Title',
+        description: '',
+        tagname: [],
+        topicId: null,
+      }
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.put(path + '/:id([0-9]+$)', controller.updatePost)
+      const request = supertest(app)
+
+      const response = await request.put(path + `/${postId}`).send(body)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        message: 'Answer updated',
+      })
+      expect(postService.updatePost).toHaveBeenCalledWith({
+        ...body,
+        id: postId,
+        userid: userId,
+      })
+    })
+
+    it('returns 401 on no user', async () => {
+      user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.put(path + '/:id([0-9]+$)', controller.updatePost)
+      const request = supertest(app)
+
+      const response = await request.put(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
+      expect(response.body).toStrictEqual({
+        message: 'You must be logged in to update posts.',
+      })
+      expect(postService.updatePost).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 if user does not have permission to update post', async () => {
+      authService.hasPermissionToAnswer.mockResolvedValue(false)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.put(path + '/:id([0-9]+$)', controller.updatePost)
+      const request = supertest(app)
+
+      const response = await request.put(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.FORBIDDEN)
+      expect(response.body).toStrictEqual({
+        message: 'You do not have permission to update this post.',
+      })
+      expect(postService.updatePost).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 on database error while determining permissions', async () => {
+      authService.hasPermissionToAnswer.mockRejectedValue(
+        new Error('Error while determining permissions to update post'),
+      )
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.put(path + '/:id([0-9]+$)', controller.updatePost)
+      const request = supertest(app)
+
+      const response = await request.put(path + `/${postId}`)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(response.body).toStrictEqual({
+        message: 'Something went wrong, please try again.',
+      })
+      expect(postService.updatePost).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 on database error while updating post', async () => {
+      authService.hasPermissionToAnswer.mockResolvedValue(true)
+      postService.updatePost.mockRejectedValue(
+        new Error('Answer failed to update'),
+      )
+
+      const body = {
+        title: 'Title',
+        description: '',
+        tagname: [],
+        topicId: null,
+      }
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.put(path + '/:id([0-9]+$)', controller.updatePost)
+      const request = supertest(app)
+
+      const response = await request.put(path + `/${postId}`).send(body)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(response.body).toStrictEqual({
+        message: 'Answer failed to update',
+      })
+      expect(postService.updatePost).toHaveBeenCalledWith({
+        ...body,
+        id: postId,
+        userid: userId,
       })
     })
   })

--- a/server/src/modules/post/post.errors.ts
+++ b/server/src/modules/post/post.errors.ts
@@ -19,9 +19,36 @@ export class TagDoesNotExistError extends ApplicationError {
   }
 }
 
+export class TopicDoesNotExistError extends ApplicationError {
+  constructor(
+    message = 'Topic does not exist',
+    statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
+  ) {
+    super(message, statusCode)
+  }
+}
+
+export class InvalidTagsAndTopicsError extends ApplicationError {
+  constructor(
+    message = 'At least one valid tag or topic is required',
+    statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
+  ) {
+    super(message, statusCode)
+  }
+}
+
 export class InvalidTagsError extends ApplicationError {
   constructor(
     message = 'Invalid tags used in request',
+    statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
+  ) {
+    super(message, statusCode)
+  }
+}
+
+export class InvalidTopicsError extends ApplicationError {
+  constructor(
+    message = 'Invalid topics used in request',
     statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
   ) {
     super(message, statusCode)

--- a/server/src/modules/post/post.routes.ts
+++ b/server/src/modules/post/post.routes.ts
@@ -137,7 +137,11 @@ export const routePosts = ({
    * @return 500 if database error
    * @access Private
    */
-  router.delete('/:id([0-9]+$)', controller.deletePost)
+  router.delete(
+    '/:id([0-9]+$)',
+    [authMiddleware.authenticate],
+    controller.deletePost,
+  )
 
   /**
    * Update a post
@@ -149,7 +153,25 @@ export const routePosts = ({
    * @return 500 if database error
    * @access Private
    */
-  router.put('/:id([0-9]+$)', controller.updatePost)
+  router.put(
+    '/:id([0-9]+$)',
+    [
+      authMiddleware.authenticate,
+      check(
+        'title',
+        'Enter a title with minimum 15 characters and maximum 150 characters',
+      ).isLength({
+        min: 15,
+        max: 150,
+      }),
+      check('description', 'Enter a description with minimum 30 characters')
+        .isLength({
+          min: 30,
+        })
+        .optional({ nullable: true, checkFalsy: true }),
+    ],
+    controller.updatePost,
+  )
 
   return router
 }


### PR DESCRIPTION
## Problem

Tests for `post` module are not comprehensive and do not fully account for the addition of Topics.

Closes #653 

## Solution

Add unit tests for post module

**Features**:

- Tests for post service
- Tests for post controller
- Tests for post routes

Note: migration to `neverthrow` to be undertaken in a separate PR

**Improvements**:
- Initialise a new express app in each test
- Replace `bodyParser.json()` with [`express.json()`](https://expressjs.com/en/4x/api.html#express.json)

