### PR TITLE
fix(tags): centralise text in TagPanel and TagMenu

### DIFF
--- a/client/src/components/TagMenu/TagMenu.component.tsx
+++ b/client/src/components/TagMenu/TagMenu.component.tsx
@@ -10,7 +10,6 @@ import {
   Spacer,
   Stack,
   SimpleGrid,
-  Box,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -114,10 +113,10 @@ const TagMenu = (): ReactElement => {
     >
       {tagsToShow.map(({ id, tagType, tagname }) => {
         return (
-          <Box
-            py="24px"
+          <Flex
             h="72px"
             w="100%"
+            alignItems="center"
             textAlign="left"
             textStyle="h4"
             boxShadow="base"
@@ -139,9 +138,11 @@ const TagMenu = (): ReactElement => {
             <Flex m="auto" w="100%" px={8}>
               <Text>{tagname}</Text>
               <Spacer />
-              <BiRightArrowAlt />
+              <Flex alignItems="center">
+                <BiRightArrowAlt />
+              </Flex>
             </Flex>
-          </Box>
+          </Flex>
         )
       })}
     </SimpleGrid>

--- a/client/src/components/TagPanel/TagPanel.component.tsx
+++ b/client/src/components/TagPanel/TagPanel.component.tsx
@@ -8,7 +8,6 @@ import {
   Flex,
   Spacer,
   SimpleGrid,
-  Box,
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
@@ -100,9 +99,9 @@ const TagPanel = (): ReactElement => {
     >
       {tagsToShow.map(({ id, tagType, tagname }) => {
         return (
-          <Box
-            py="24px"
+          <Flex
             h="72px"
+            alignItems="center"
             w={{ base: '87%', sm: '100%' }}
             mx={{ base: 'auto', md: undefined }}
             textAlign="left"
@@ -120,9 +119,11 @@ const TagPanel = (): ReactElement => {
             <Flex m="auto" w="100%" px={8}>
               <Text>{tagname}</Text>
               <Spacer />
-              <BiRightArrowAlt />
+              <Flex alignItems="center">
+                <BiRightArrowAlt />
+              </Flex>
             </Flex>
-          </Box>
+          </Flex>
         )
       })}
     </SimpleGrid>


### PR DESCRIPTION
## Problem

Text in TagPanel and TagMenu is not centralised when it spans more than 1 line.

Closes #697 

## Solution

Use `alignItems` to center text and icon

## Before & After Screenshots

**BEFORE**:
Desktop:
![image](https://user-images.githubusercontent.com/56983748/139404684-319bc6ca-ea06-4062-8a6f-26ebf75a71d6.png)

Mobile:
![image](https://user-images.githubusercontent.com/56983748/139404756-ed3c0f0c-78db-4d99-b1ed-c60ec99ade74.png) ![image](https://user-images.githubusercontent.com/56983748/139405949-f25ccd4c-1f33-48d3-83ac-94d400660977.png)



**AFTER**:
Desktop:
![image](https://user-images.githubusercontent.com/56983748/139404904-a5133783-bc86-4675-9c30-ba4807def0cf.png)

Mobile:
![image](https://user-images.githubusercontent.com/56983748/139404962-79ce3177-6e98-47ae-8a85-9a66e41a2ff4.png) ![image](https://user-images.githubusercontent.com/56983748/139405017-a58d66fd-f270-4d33-8a02-bf89e00962d4.png)



## Tests

Topics navigation should work as normal
