### PR TITLE
refactor(answers): simplify AnswerService

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -123,7 +123,7 @@ const postService = new PostService({
 })
 const enquiryService = new EnquiryService({ Agency, mailService })
 const recaptchaService = new RecaptchaService({ axios, ...recaptchaConfig })
-const answersService = new AnswersService()
+const answersService = new AnswersService({ Post, Answer })
 const topicsService = new TopicsService({ Topic })
 const userService = new UserService({ User, Tag, Agency })
 

--- a/server/src/modules/answers/answers.controller.ts
+++ b/server/src/modules/answers/answers.controller.ts
@@ -5,6 +5,7 @@ import { createLogger } from '../../bootstrap/logging'
 import { StatusCodes } from 'http-status-codes'
 import { ControllerHandler } from '../../types/response-handler'
 import { Message } from '../../types/message-type'
+import { Answer } from '~shared/types/base'
 
 const logger = createLogger(module)
 
@@ -29,16 +30,10 @@ export class AnswersController {
    * @returns 200 with array of answers
    * @returns 500 if database error occurs
    */
-  listAnswers: ControllerHandler<
-    { id: string },
-    | {
-        body: string
-        username: string
-        userId: number
-        agencyLogo: string
-      }[]
-    | Message
-  > = async (req, res) => {
+  listAnswers: ControllerHandler<{ id: string }, Answer[] | Message> = async (
+    req,
+    res,
+  ) => {
     try {
       const answers = await this.answersService.listAnswers(
         Number(req.params.id),

--- a/shared/src/types/base/answer.ts
+++ b/shared/src/types/base/answer.ts
@@ -3,6 +3,8 @@ import { BaseModel } from './common'
 
 export const Answer = BaseModel.extend({
   body: z.string(),
+  userId: z.number().nonnegative(),
+  postId: z.number().nonnegative(),
 })
 
 export type Answer = z.infer<typeof Answer>


### PR DESCRIPTION

## Problem

Closes #646 

## Solution

- Drop query joins no longer used in `AnswerService.listAnswers()`;
  frontend no longer queries for user/agency information for each
  answer as we've changed approach from submitted question ->
  multiple answers to agency-created question and answer

- Rework to use dependency injection and shared types

## Tests

- Ensure that answers continue to be fetched normally