### PR TITLE
feat(topics): replace tags in frontend

### DIFF
--- a/client/src/api/types/index.ts
+++ b/client/src/api/types/index.ts
@@ -1,2 +1,3 @@
 export * from './post'
 export * from './answer'
+export * from './topic'

--- a/client/src/api/types/post.ts
+++ b/client/src/api/types/post.ts
@@ -23,9 +23,11 @@ export type GetPostsDto = {
   totalItems: number
 }
 
-export type CreatePostReqDto = Pick<BasePostDto, 'title' | 'description'> & {
+export type CreatePostReqDto = Pick<
+  BasePostDto,
+  'title' | 'description' | 'agencyId' | 'topicId'
+> & {
   tagname: string[] | null
-  topicId: number | null
 }
 
 export type CreatePostResDto = MessageResponse & { data: number }

--- a/client/src/api/types/topic.ts
+++ b/client/src/api/types/topic.ts
@@ -1,0 +1,8 @@
+import { MessageResponse } from './common'
+import { Topic } from '~shared/types/base'
+
+export type GetTopicsDto = Topic & {
+  children?: GetTopicsDto[]
+}
+
+export type CreateTopicResDto = MessageResponse & { data: number }

--- a/client/src/pages/EditForm/EditForm.component.tsx
+++ b/client/src/pages/EditForm/EditForm.component.tsx
@@ -17,9 +17,11 @@ import {
   LIST_POSTS_QUERY_KEY,
 } from '../../services/PostService'
 import {
-  getTagsByUser,
-  GET_TAGS_BY_USER_QUERY_KEY,
-} from '../../services/TagService'
+  getTopicById,
+  GET_TOPIC_BY_ID_QUERY_KEY,
+  getTopicsUsedByAgency,
+  GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
+} from '../../services/TopicService'
 import AskForm, {
   AskFormSubmission,
 } from '../PostForm/AskForm/AskForm.component'
@@ -27,119 +29,130 @@ import { useStyledToast } from '../../components/StyledToast/StyledToast'
 import './EditForm.styles.scss'
 
 const EditForm = (): JSX.Element => {
-  const auth = useAuth()
+  const { user } = useAuth()
   const queryclient = useQueryClient()
   const navigate = useNavigate()
   const { id } = useParams<'id'>()
   const postId = Number(id)
-  const getPostQueryKey = useMemo(
-    () => [GET_POST_BY_ID_QUERY_KEY, postId],
-    [postId],
-  )
-  const getAnswerQueryKey = useMemo(
-    () => [GET_ANSWERS_FOR_POST_QUERY_KEY, postId],
-    [postId],
-  )
-  const toast = useStyledToast()
-  const { isLoading: isPostLoading, data: postData } = useQuery(
-    getPostQueryKey,
-    () => PostService.getPostById(postId),
-  )
-  const { isLoading: isAnswerLoading, data: answerData } = useQuery(
-    getAnswerQueryKey,
-    () => getAnswersForPost(postId),
-  )
-  const { isLoading: isTagLoading, data: tagData } = useQuery(
-    GET_TAGS_BY_USER_QUERY_KEY,
-    getTagsByUser,
-    {
-      staleTime: Infinity,
-    },
-  )
-  const updatePostAndAnswer = async (data: AskFormSubmission) => {
-    if (!answerData) {
-      toast({
-        status: 'error',
-        description: getApiErrorMessage(),
-      })
-      return
-    }
-    await PostService.updatePost(postId, {
-      description: data.postData.description,
-      title: data.postData.title,
-      tagname: data.tags,
-      topicId: null, //TODO: update when topics selection is introduced in frontend
-    })
-    await updateAnswer(answerData[0].id, data.answerData)
-  }
-  const updatePostAndAnswerMutation = useMutation(updatePostAndAnswer, {
-    onSuccess: () => {
-      queryclient.invalidateQueries(getPostQueryKey)
-      queryclient.invalidateQueries(getAnswerQueryKey)
-      queryclient.invalidateQueries(LIST_POSTS_QUERY_KEY)
-      queryclient.invalidateQueries(
-        LIST_ANSWERABLE_POSTS_WITH_ANSWERS_QUERY_KEY,
-      )
-    },
-  })
 
-  const onSubmit = async (data: AskFormSubmission) => {
-    try {
-      await updatePostAndAnswerMutation.mutateAsync(data)
-      toast({
-        status: 'success',
-        description: 'Your post has been updated.',
-      })
-      navigate(`/questions/${postId}`, { replace: true })
-    } catch (err) {
-      toast({
-        status: 'error',
-        description: getApiErrorMessage(err),
-      })
-    }
-  }
-
-  if (!auth.user) {
+  if (!user) {
     return <Navigate replace to="/login" />
-  }
+  } else {
+    const getPostQueryKey = useMemo(
+      () => [GET_POST_BY_ID_QUERY_KEY, postId],
+      [postId],
+    )
+    const getAnswerQueryKey = useMemo(
+      () => [GET_ANSWERS_FOR_POST_QUERY_KEY, postId],
+      [postId],
+    )
+    const toast = useStyledToast()
+    const { isLoading: isPostLoading, data: postData } = useQuery(
+      getPostQueryKey,
+      () => PostService.getPostById(postId),
+    )
+    const { isLoading: isAnswerLoading, data: answerData } = useQuery(
+      getAnswerQueryKey,
+      () => getAnswersForPost(postId),
+    )
+    const { isLoading: isTopicLoading, data: topicData } = useQuery(
+      GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
+      () => getTopicsUsedByAgency(user.agencyId),
+      {
+        staleTime: Infinity,
+      },
+    )
+    const topicId = Number(postData?.topicId)
+    const { isLoading: isPostTopicLoading, data: postTopic } = useQuery(
+      GET_TOPIC_BY_ID_QUERY_KEY,
+      () => getTopicById(topicId),
+      { enabled: !!topicId },
+    )
+    const updatePostAndAnswer = async (data: AskFormSubmission) => {
+      if (!answerData) {
+        toast({
+          status: 'error',
+          description: getApiErrorMessage(),
+        })
+        return
+      }
 
-  const isLoading = isPostLoading || isAnswerLoading || isTagLoading
+      await PostService.updatePost(postId, {
+        description: data.postData.description,
+        title: data.postData.title,
+        agencyId: user.agencyId,
+        tagname: null, //TODO: Update when tags are re-introduced
+        topicId: data.topic,
+      })
 
-  return isLoading ? (
-    <Spinner centerHeight="200px" />
-  ) : (
-    <>
-      <div className="edit-form-container">
-        <div className="edit-form-content">
-          <Spacer h={['64px', '64px', '84px']} />
-          <div className="edit-form-header">
-            <div className="edit-form-headline fc-black-800">
-              Edit a Question
+      await updateAnswer(answerData[0].id, data.answerData)
+    }
+    const updatePostAndAnswerMutation = useMutation(updatePostAndAnswer, {
+      onSuccess: () => {
+        queryclient.invalidateQueries(getPostQueryKey)
+        queryclient.invalidateQueries(getAnswerQueryKey)
+        queryclient.invalidateQueries(LIST_POSTS_QUERY_KEY)
+        queryclient.invalidateQueries(
+          LIST_ANSWERABLE_POSTS_WITH_ANSWERS_QUERY_KEY,
+        )
+      },
+    })
+
+    const onSubmit = async (data: AskFormSubmission) => {
+      try {
+        await updatePostAndAnswerMutation.mutateAsync(data)
+        toast({
+          status: 'success',
+          description: 'Your post has been updated.',
+        })
+        navigate(`/questions/${postId}`, { replace: true })
+      } catch (err) {
+        toast({
+          status: 'error',
+          description: getApiErrorMessage(err),
+        })
+      }
+    }
+
+    const isLoading =
+      isPostLoading || isAnswerLoading || isTopicLoading || isPostTopicLoading
+
+    return isLoading ? (
+      <Spinner centerHeight="200px" />
+    ) : (
+      <>
+        <div className="edit-form-container">
+          <div className="edit-form-content">
+            <Spacer h={['64px', '64px', '84px']} />
+            <div className="edit-form-header">
+              <div className="edit-form-headline fc-black-800">
+                Edit a Question
+              </div>
             </div>
-          </div>
-          <div className="edit-form-section">
-            <div className="editform" style={{ width: '100%' }}>
-              {/* Undefined checks to coerce types. In reality all data should have loaded. */}
-              <AskForm
-                inputPostData={{
-                  title: postData?.title ?? '',
-                  description: postData?.description ?? '',
-                }}
-                inputAnswerData={{
-                  text: answerData ? answerData[0].body : '',
-                }}
-                tagOptions={tagData ?? []}
-                inputTags={postData?.tags.map((t) => t.tagname)}
-                submitButtonText="Confirm changes"
-                onSubmit={onSubmit}
-              />
+            <div className="edit-form-section">
+              <div className="editform" style={{ width: '100%' }}>
+                {/* Undefined checks to coerce types. In reality all data should have loaded. */}
+                <AskForm
+                  inputPostData={{
+                    title: postData?.title ?? '',
+                    description: postData?.description ?? '',
+                  }}
+                  inputAnswerData={{
+                    text: answerData ? answerData[0].body : '',
+                  }}
+                  topicOptions={topicData ?? []}
+                  inputTopic={postTopic}
+                  submitButtonText="Confirm changes"
+                  onSubmit={onSubmit}
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <Spacer minH={20} />
-    </>
-  )
+        <Spacer minH={20} />
+      </>
+    )
+  }
 }
 
 export default EditForm

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -45,12 +45,7 @@ const HomePage = () => {
   const navigate = useNavigate()
   // check URL
   const location = useLocation()
-  // TODO (#259): make into custom hook
-  // useEffect(() => {
-  //   setQueryState(getTagsQuery(location.search))
-  //   const tagsSpecified = isSpecified(location.search, 'tags')
-  //   setHasTagsKey(tagsSpecified)
-  // }, [location, hasTagsKey])
+
   useEffect(() => {
     setQueryState(getTopicsQuery(location.search))
     const topicsSpecified = isSpecified(location.search, 'topics')
@@ -211,7 +206,6 @@ const HomePage = () => {
           <QuestionsListComponent
             sort={sortState.value}
             agencyId={agency?.id}
-            // tags={queryState}
             topics={queryState}
             pageSize={isAuthenticatedOfficer ? 50 : hasTopicsKey ? 30 : 10}
             listAnswerable={isAuthenticatedOfficer}

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -30,20 +30,32 @@ import {
   getTagsUsedByAgency,
   GET_TAGS_USED_BY_AGENCY_QUERY_KEY,
 } from '../../services/TagService'
+import {
+  fetchTopics,
+  FETCH_TOPICS_QUERY_KEY,
+  getTopicsUsedByAgency,
+  GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
+} from '../../services/TopicService'
 import { isUserPublicOfficer } from '../../services/user.service'
-import { getTagsQuery, isSpecified } from '../../util/urlparser'
+import { getTagsQuery, getTopicsQuery, isSpecified } from '../../util/urlparser'
 
 const HomePage = () => {
   const [hasTagsKey, setHasTagsKey] = useState(false)
+  const [hasTopicsKey, setHasTopicsKey] = useState(false)
   const navigate = useNavigate()
   // check URL
   const location = useLocation()
   // TODO (#259): make into custom hook
+  // useEffect(() => {
+  //   setQueryState(getTagsQuery(location.search))
+  //   const tagsSpecified = isSpecified(location.search, 'tags')
+  //   setHasTagsKey(tagsSpecified)
+  // }, [location, hasTagsKey])
   useEffect(() => {
-    setQueryState(getTagsQuery(location.search))
-    const tagsSpecified = isSpecified(location.search, 'tags')
-    setHasTagsKey(tagsSpecified)
-  }, [location, hasTagsKey])
+    setQueryState(getTopicsQuery(location.search))
+    const topicsSpecified = isSpecified(location.search, 'topics')
+    setHasTopicsKey(topicsSpecified)
+  }, [location, hasTopicsKey])
 
   const { user } = useAuth()
 
@@ -59,6 +71,11 @@ const HomePage = () => {
       )
     : useQuery(FETCH_TAGS_QUERY_KEY, () => fetchTags())
 
+  const { data: topics } = agency
+    ? useQuery(GET_TOPICS_USED_BY_AGENCY_QUERY_KEY, () =>
+        getTopicsUsedByAgency(agency.id),
+      )
+    : useQuery(FETCH_TOPICS_QUERY_KEY, () => fetchTopics())
   // dropdown options
   const options = [
     { value: 'basic', label: 'Most recent' },
@@ -96,12 +113,12 @@ const HomePage = () => {
         direction={{ base: 'column', lg: 'row' }}
       >
         <Box flex="5">
-          {(tags ?? [])
-            .filter(({ tagname }) => tagname === queryState)
-            .map((tag) => {
-              return tag.description ? (
+          {(topics ?? [])
+            .filter(({ name }) => name === queryState)
+            .map((topic) => {
+              return topic.description ? (
                 <Text textStyle="body-1" color="neutral.900" mb="50px">
-                  {tag.description}
+                  {topic.description}
                 </Text>
               ) : null
             })}
@@ -117,7 +134,7 @@ const HomePage = () => {
               mb={{ sm: '20px' }}
               d="block"
             >
-              {hasTagsKey
+              {hasTopicsKey
                 ? queryState
                   ? 'QUESTIONS ON THIS TOPIC'
                   : 'ALL QUESTIONS'
@@ -143,7 +160,7 @@ const HomePage = () => {
                       w={{ base: '100%', sm: '171px' }}
                       textStyle="body-1"
                       textAlign="left"
-                      d={{ base: hasTagsKey ? 'block' : 'none' }}
+                      d={{ base: hasTopicsKey ? 'block' : 'none' }}
                     >
                       <Flex justifyContent="space-between" alignItems="center">
                         <Text textStyle="body-1">{sortState.label}</Text>
@@ -194,11 +211,12 @@ const HomePage = () => {
           <QuestionsListComponent
             sort={sortState.value}
             agencyId={agency?.id}
-            tags={queryState}
-            pageSize={isAuthenticatedOfficer ? 50 : hasTagsKey ? 30 : 10}
+            // tags={queryState}
+            topics={queryState}
+            pageSize={isAuthenticatedOfficer ? 50 : hasTopicsKey ? 30 : 10}
             listAnswerable={isAuthenticatedOfficer}
             footerControl={
-              isAuthenticatedOfficer || hasTagsKey ? undefined : (
+              isAuthenticatedOfficer || hasTopicsKey ? undefined : (
                 <Button
                   mt={{ base: '40px', sm: '48px', xl: '58px' }}
                   variant="outline"
@@ -206,7 +224,7 @@ const HomePage = () => {
                   borderColor="secondary.700"
                   onClick={() => {
                     window.scrollTo(0, 0)
-                    navigate('?tags=')
+                    navigate('?topics=')
                   }}
                 >
                   <Text textStyle="subhead-1">View all questions</Text>

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -25,22 +25,15 @@ import {
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
 } from '../../services/AgencyService'
 import {
-  fetchTags,
-  FETCH_TAGS_QUERY_KEY,
-  getTagsUsedByAgency,
-  GET_TAGS_USED_BY_AGENCY_QUERY_KEY,
-} from '../../services/TagService'
-import {
   fetchTopics,
   FETCH_TOPICS_QUERY_KEY,
   getTopicsUsedByAgency,
   GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
 } from '../../services/TopicService'
 import { isUserPublicOfficer } from '../../services/user.service'
-import { getTagsQuery, getTopicsQuery, isSpecified } from '../../util/urlparser'
+import { getTopicsQuery, isSpecified } from '../../util/urlparser'
 
 const HomePage = () => {
-  const [hasTagsKey, setHasTagsKey] = useState(false)
   const [hasTopicsKey, setHasTopicsKey] = useState(false)
   const navigate = useNavigate()
   // check URL
@@ -60,11 +53,6 @@ const HomePage = () => {
     () => getAgencyByShortName({ shortname: agencyShortName }),
     { enabled: !!agencyShortName },
   )
-  const { data: tags } = agency
-    ? useQuery(GET_TAGS_USED_BY_AGENCY_QUERY_KEY, () =>
-        getTagsUsedByAgency(agency.id),
-      )
-    : useQuery(FETCH_TAGS_QUERY_KEY, () => fetchTags())
 
   const { data: topics } = agency
     ? useQuery(GET_TOPICS_USED_BY_AGENCY_QUERY_KEY, () =>

--- a/client/src/pages/PostForm/PostForm.component.tsx
+++ b/client/src/pages/PostForm/PostForm.component.tsx
@@ -9,79 +9,77 @@ import { useAuth } from '../../contexts/AuthContext'
 import * as AnswerService from '../../services/AnswerService'
 import * as PostService from '../../services/PostService'
 import {
-  getTagsByUser,
-  GET_TAGS_BY_USER_QUERY_KEY,
-} from '../../services/TagService'
+  getTopicsUsedByAgency,
+  GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
+} from '../../services/TopicService'
 import AskForm, { AskFormSubmission } from './AskForm/AskForm.component'
 import './PostForm.styles.scss'
 
 const PostForm = (): JSX.Element => {
-  const auth = useAuth()
+  const { user } = useAuth()
   const toast = useStyledToast()
   const navigate = useNavigate()
-  const { isLoading, data: tagData } = useQuery(
-    GET_TAGS_BY_USER_QUERY_KEY,
-    getTagsByUser,
-    {
-      staleTime: Infinity,
-    },
-  )
-  if (!auth.user) {
+  if (!user) {
     return <Navigate replace to="/login" />
-  }
-
-  const onSubmit = async (data: AskFormSubmission) => {
-    try {
-      const { data: postId } = await PostService.createPost({
-        description: data.postData.description,
-        title: data.postData.title,
-        tagname: data.tags,
-        topicId: null, //TODO: update when topics selection is introduced in frontend
-      })
-      await AnswerService.createAnswer(postId, data.answerData)
-      toast({
-        status: 'success',
-        description: 'Your post has been created.',
-      })
-      navigate(`/questions/${postId}`, { replace: true })
-    } catch (err) {
-      toast({
-        status: 'error',
-        description: getApiErrorMessage(err),
-      })
+  } else {
+    const { isLoading, data: topicData } = useQuery(
+      GET_TOPICS_USED_BY_AGENCY_QUERY_KEY,
+      () => getTopicsUsedByAgency(user.agencyId),
+      {
+        staleTime: Infinity,
+      },
+    )
+    const onSubmit = async (data: AskFormSubmission) => {
+      try {
+        const { data: postId } = await PostService.createPost({
+          description: data.postData.description,
+          title: data.postData.title,
+          agencyId: user.agencyId,
+          tagname: null, //TODO: Update when tags are re-introduced
+          topicId: data.topic,
+        })
+        await AnswerService.createAnswer(postId, data.answerData)
+        toast({
+          status: 'success',
+          description: 'Your post has been created.',
+        })
+        navigate(`/questions/${postId}`, { replace: true })
+      } catch (err) {
+        toast({
+          status: 'error',
+          description: getApiErrorMessage(err),
+        })
+      }
     }
-  }
 
-  return isLoading ? (
-    <Spinner centerHeight="200px" />
-  ) : (
-    <Fragment>
-      <div className="post-form-container">
-        <div className="post-form-content">
-          <Spacer h={['64px', '64px', '84px']} />
-          <div className="post-form-header">
-            <div className="post-form-headline fc-black-800">
-              Post a Question
+    return isLoading ? (
+      <Spinner centerHeight="200px" />
+    ) : (
+      <Fragment>
+        <div className="post-form-container">
+          <div className="post-form-content">
+            <Spacer h={['64px', '64px', '84px']} />
+            <div className="post-form-header">
+              <div className="post-form-headline fc-black-800">
+                Post a Question
+              </div>
             </div>
-          </div>
-          <div className="post-form-section">
-            <div className="postform" style={{ width: '100%' }}>
-              {/* Undefined checks to coerce types. In reality all data should have loaded. */}
-              <AskForm
-                inputTags={tagData
-                  ?.filter((t) => t.tagType === 'AGENCY')
-                  .map((t) => t.tagname)}
-                tagOptions={tagData ?? []}
-                onSubmit={onSubmit}
-                submitButtonText="Post your question"
-              />
+            <div className="post-form-section">
+              <div className="postform" style={{ width: '100%' }}>
+                {/* Undefined checks to coerce types. In reality all data should have loaded. */}
+                <AskForm
+                  topicOptions={topicData ?? []}
+                  onSubmit={onSubmit}
+                  submitButtonText="Post your question"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <Spacer minH={20} />
-    </Fragment>
-  )
+        <Spacer minH={20} />
+      </Fragment>
+    )
+  }
 }
 
 export default PostForm

--- a/client/src/services/TopicService.ts
+++ b/client/src/services/TopicService.ts
@@ -1,0 +1,14 @@
+import { ApiClient, GetTopicsDto } from '../api'
+
+export const fetchTopics = (): Promise<GetTopicsDto[]> =>
+  ApiClient.get<GetTopicsDto[]>('/topics').then(({ data }) => data)
+export const FETCH_TOPICS_QUERY_KEY = 'fetchTopics'
+
+export const getTopicsUsedByAgency = (
+  agencyId: number,
+): Promise<GetTopicsDto[]> =>
+  ApiClient.get<GetTopicsDto[]>(`/agencies/${agencyId}/topics`).then(
+    ({ data }) => data,
+  )
+
+export const GET_TOPICS_USED_BY_AGENCY_QUERY_KEY = 'getTopicsUsedByAgency'

--- a/client/src/services/TopicService.ts
+++ b/client/src/services/TopicService.ts
@@ -1,14 +1,23 @@
 import { ApiClient, GetTopicsDto } from '../api'
+import { Topic } from '~shared/types/base'
 
-export const fetchTopics = (): Promise<GetTopicsDto[]> =>
-  ApiClient.get<GetTopicsDto[]>('/topics').then(({ data }) => data)
+export const fetchTopics = (): Promise<GetTopicsDto[]> => {
+  return ApiClient.get<GetTopicsDto[]>('/topics').then(({ data }) => data)
+}
 export const FETCH_TOPICS_QUERY_KEY = 'fetchTopics'
 
 export const getTopicsUsedByAgency = (
   agencyId: number,
-): Promise<GetTopicsDto[]> =>
-  ApiClient.get<GetTopicsDto[]>(`/agencies/${agencyId}/topics`).then(
+): Promise<GetTopicsDto[]> => {
+  return ApiClient.get<GetTopicsDto[]>(`/agencies/${agencyId}/topics`).then(
     ({ data }) => data,
   )
+}
 
 export const GET_TOPICS_USED_BY_AGENCY_QUERY_KEY = 'getTopicsUsedByAgency'
+
+export const getTopicById = (id: number): Promise<Topic> => {
+  return ApiClient.get<Topic>(`/topics/${id}`).then(({ data }) => data)
+}
+
+export const GET_TOPIC_BY_ID_QUERY_KEY = 'getTopicById'

--- a/client/src/services/googleAnalytics.tsx
+++ b/client/src/services/googleAnalytics.tsx
@@ -7,6 +7,7 @@ const GA_USER_EVENTS = {
   OPEN_ENQUIRY: 'Open Enquiry',
   CLICK_TAG: 'Click Tag',
   BROWSE: 'Browse',
+  CLICK_TOPIC: 'Click Topic',
 }
 
 const initializeGA = (trackingId: string): void => {

--- a/client/src/util/urlparser.ts
+++ b/client/src/util/urlparser.ts
@@ -1,4 +1,3 @@
-import { TagType } from '~shared/types/base'
 import queryString from 'query-string'
 import { Agency } from '../services/AgencyService'
 
@@ -12,23 +11,25 @@ export const getTagsQuery = (search: string): string => {
   return ''
 }
 
+export const getTopicsQuery = (search: string): string => {
+  const query = queryString.parse(search)
+  if (query.topics) {
+    return Array.isArray(query.topics) ? query.topics.join(',') : query.topics
+  }
+
+  // if nothing is valid return empty str; no filter on front-end
+  return ''
+}
+
 export const isSpecified = (search: string, key: string): boolean =>
   key in queryString.parse(search)
 
-export const getRedirectURL = (
-  tagType: string,
-  tagName: string,
-  agency?: Agency,
-): string => {
-  if (tagType === TagType.Agency) {
-    return `/agency/${encodeURIComponent(tagName)}`
-  } else {
-    return agency
-      ? `/agency/${encodeURIComponent(
-          agency.shortname,
-        )}?tags=${encodeURIComponent(tagName)}`
-      : `/?tags=${encodeURIComponent(tagName)}`
-  }
+export const getRedirectURLTopics = (name: string, agency?: Agency): string => {
+  return agency
+    ? `/agency/${encodeURIComponent(
+        agency.shortname,
+      )}?topics=${encodeURIComponent(name)}`
+    : `/?topics=${encodeURIComponent(name)}`
 }
 
 export const getRedirectURLAgency = (agencyShortName: string): string => {

--- a/server/seeders/20210826064325-was.js
+++ b/server/seeders/20210826064325-was.js
@@ -90,6 +90,57 @@ module.exports = {
       {},
     )
     await queryInterface.bulkInsert(
+      'topics',
+      [
+        {
+          id: 1,
+          name: 'financial support',
+          description: 'Financial Support topic description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          agencyId: 4,
+          parentId: null,
+        },
+        {
+          id: 2,
+          name: 'apprenticeships',
+          description: 'Apprenticeships topic description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          agencyId: 4,
+          parentId: null,
+        },
+        {
+          id: 3,
+          name: 'employers',
+          description: 'Employers topic description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          agencyId: 4,
+          parentId: null,
+        },
+        {
+          id: 4,
+          name: 'awards',
+          description: 'Awards topic description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          agencyId: 4,
+          parentId: null,
+        },
+        {
+          id: 5,
+          name: 'application',
+          description: 'financial support - application topic description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          agencyId: 4,
+          parentId: 1,
+        },
+      ],
+      {},
+    )
+    await queryInterface.bulkInsert(
       'posts',
       [
         {
@@ -101,6 +152,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
         {
           id: 15,
@@ -111,6 +163,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
         {
           id: 16,
@@ -122,6 +175,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
         {
           id: 17,
@@ -132,6 +186,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
         {
           id: 18,
@@ -143,6 +198,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
 
         {
@@ -154,6 +210,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
 
         {
@@ -167,6 +224,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 1,
         },
 
         {
@@ -179,6 +237,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 22,
@@ -190,6 +249,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 23,
@@ -200,6 +260,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 24,
@@ -210,6 +271,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 25,
@@ -222,6 +284,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
 
         {
@@ -235,6 +298,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 27,
@@ -246,6 +310,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 2,
         },
         {
           id: 28,
@@ -257,6 +322,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 3,
         },
         {
           id: 29,
@@ -267,6 +333,7 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 3,
         },
         {
           id: 30,
@@ -278,6 +345,19 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
           agencyId: 4,
+          topicId: 4,
+        },
+        {
+          id: 31,
+          title:
+            'What is the status of my financial support scheme application?',
+          description: '',
+          status: 'PUBLIC',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 4,
+          agencyId: 4,
+          topicId: 5,
         },
       ],
       {},
@@ -408,6 +488,13 @@ module.exports = {
           updatedAt: new Date(),
           userId: 4,
         },
+        {
+          postId: 31,
+          body: 'To check for your application status, please visit the application portal',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 4,
+        },
       ],
       {},
     )
@@ -504,6 +591,7 @@ module.exports = {
     await queryInterface.bulkDelete('permissions', null, {})
     await queryInterface.bulkDelete('answers', null, {})
     await queryInterface.bulkDelete('posts', null, {})
+    await queryInterface.bulkDelete('topics', null, {})
     await queryInterface.bulkDelete('users', null, {})
     await queryInterface.bulkDelete('agencies', null, {})
     await queryInterface.bulkDelete('tags', null, {})

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -345,7 +345,7 @@ export class PostService {
       include: [
         {
           model: this.Tag,
-          required: true,
+          required: false,
           attributes: ['tagname', 'description', 'tagType'],
         },
         { model: this.User, required: true, attributes: ['username'] },
@@ -458,7 +458,7 @@ export class PostService {
       include: [
         {
           model: this.Tag,
-          required: true,
+          required: false,
           attributes: ['tagname', 'description', 'tagType'],
         },
         { model: this.User, required: true, attributes: ['username'] },
@@ -587,7 +587,7 @@ export class PostService {
     if (!topicValid && tagList.length === 0) {
       throw new InvalidTagsAndTopicsError()
     } else {
-      if (newPost.tagname?.length !== tagList.length) {
+      if (newPost.tagname && newPost.tagname.length !== tagList.length) {
         throw new TagDoesNotExistError()
       }
       if (!topicValid && newPost.topicId) {

--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -38,6 +38,7 @@ describe('TopicsController', () => {
     createTopic: jest.fn(),
     deleteTopicById: jest.fn(),
     updateTopicById: jest.fn(),
+    listTopics: jest.fn(),
   }
   const topicsController = new TopicsController({
     authService,

--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -39,6 +39,7 @@ describe('TopicsController', () => {
     deleteTopicById: jest.fn(),
     updateTopicById: jest.fn(),
     listTopics: jest.fn(),
+    getTopicById: jest.fn(),
   }
   const topicsController = new TopicsController({
     authService,
@@ -55,6 +56,8 @@ describe('TopicsController', () => {
     topicsService.createTopic.mockReset()
     topicsService.deleteTopicById.mockReset()
     topicsService.updateTopicById.mockReset()
+    topicsService.listTopics.mockReset()
+    topicsService.getTopicById.mockReset()
     topicsService.listTopicsUsedByAgency.mockReturnValue(okAsync(mockTopic))
   })
 

--- a/server/src/modules/topics/__tests__/topics.service.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.service.spec.ts
@@ -77,13 +77,11 @@ describe('TopicsService', () => {
     mockTopics: TopicWithChildRelations[],
   ) => {
     expect(actualTopics.length).toStrictEqual(mockTopics.length)
-    expect(actualTopics[0].id).toStrictEqual(mockTopics[0].id)
-    expect(actualTopics[0].name).toStrictEqual(mockTopics[0].name)
-    expect(actualTopics[0].description).toStrictEqual(mockTopics[0].description)
-    expect(actualTopics[0].parentId).toStrictEqual(mockTopics[0].parentId)
-    expect(actualTopics[0].children?.[0].id).toStrictEqual(
-      mockTopics[0].children?.[0].id,
-    )
+    expect(actualTopics[0].id).toStrictEqual(mockTopic1.id)
+    expect(actualTopics[0].name).toStrictEqual(mockTopic1.name)
+    expect(actualTopics[0].description).toStrictEqual(mockTopic1.description)
+    expect(actualTopics[0].parentId).toStrictEqual(mockTopic1.parentId)
+    expect(actualTopics[0].children?.[0].id).toStrictEqual(mockTopic2.id)
   }
 
   describe('listTopicsUsedByAgency', () => {

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -24,6 +24,25 @@ export class TopicsController {
   }
 
   /**
+   * Lists all topics
+   * @returns 200 with topics
+   * @returns 404 if topics are not found
+   * @returns 500 if database error
+   */
+
+  listTopics: ControllerHandler<
+    undefined,
+    TopicWithChildRelations[] | Message
+  > = async (req, res) => {
+    return this.topicsService
+      .listTopics()
+      .map((data) => res.status(StatusCodes.OK).json(data))
+      .mapErr((error) => {
+        return res.status(error.statusCode).json({ message: error.message })
+      })
+  }
+
+  /**
    * Lists all topics in an agency
    * @param agencyId agencyId
    * @returns 200 with topics

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -24,6 +24,23 @@ export class TopicsController {
   }
 
   /**
+   * Find a topic by their id
+   * @returns 200 with topic
+   * @returns 404 if topics are not found
+   * @returns 500 if database error
+   */
+
+  getTopicById: ControllerHandler<{ topicId: number }, Topic | Message> =
+    async (req, res) => {
+      const topicId = Number(req.params.topicId)
+      return this.topicsService
+        .getTopicById(topicId)
+        .map((data) => res.status(StatusCodes.OK).json(data))
+        .mapErr((error) => {
+          return res.status(error.statusCode).json({ message: error.message })
+        })
+    }
+  /**
    * Lists all topics
    * @returns 200 with topics
    * @returns 404 if topics are not found

--- a/server/src/modules/topics/topics.routes.ts
+++ b/server/src/modules/topics/topics.routes.ts
@@ -13,6 +13,19 @@ export const routeTopics = ({
   const router = express.Router()
 
   /**
+   * Find a topic by its id
+   * @route GET /api/topics/:topicId
+   * @return 200 with topic
+   * @return 404 if topic not found
+   * @return 500 if database error
+   */
+  router.get(
+    '/:topicId',
+    param('topicId').isInt().toInt(),
+    controller.getTopicById,
+  )
+
+  /**
    * List all topics
    * @return 200 with topics
    * @return 400 with database error

--- a/server/src/modules/topics/topics.routes.ts
+++ b/server/src/modules/topics/topics.routes.ts
@@ -39,9 +39,9 @@ export const routeTopics = ({
         min: 1,
         max: 30,
       }),
-      check('description', 'Enter a description with minimum 30 characters')
+      check('description', 'Enter a description with minimum 10 characters')
         .isLength({
-          min: 30,
+          min: 10,
         })
         .optional({ nullable: true, checkFalsy: true }),
     ],

--- a/server/src/modules/topics/topics.routes.ts
+++ b/server/src/modules/topics/topics.routes.ts
@@ -13,6 +13,13 @@ export const routeTopics = ({
   const router = express.Router()
 
   /**
+   * List all topics
+   * @return 200 with topics
+   * @return 400 with database error
+   */
+  router.get('/', controller.listTopics)
+
+  /**
    * Create a new topic
    * @route  POST /api/topics
    * @return 200 if topic is created

--- a/server/src/modules/topics/topics.service.ts
+++ b/server/src/modules/topics/topics.service.ts
@@ -7,10 +7,6 @@ import { DatabaseError } from '../core/core.errors'
 
 const logger = createLogger(module)
 
-// export type TopicWithChildRelations = Topic & {
-//   children: Topic[]
-// }
-
 export type TopicWithChildRelations = Topic & {
   children?: TopicWithChildRelations[]
 }
@@ -63,16 +59,19 @@ export class TopicsService {
     TopicWithChildRelations[],
     DatabaseError | MissingTopicError
   > => {
-    return ResultAsync.fromPromise(this.Topic.findAll(), (error) => {
-      logger.error({
-        message: 'Database error while retrieving topics',
-        meta: {
-          function: 'listTopics',
-        },
-        error,
-      })
-      return new DatabaseError()
-    }).andThen((topics) => {
+    return ResultAsync.fromPromise(
+      this.Topic.findAll({ raw: true }),
+      (error) => {
+        logger.error({
+          message: 'Database error while retrieving topics',
+          meta: {
+            function: 'listTopics',
+          },
+          error,
+        })
+        return new DatabaseError()
+      },
+    ).andThen((topics) => {
       if (topics.length === 0) {
         return errAsync(new MissingTopicError())
       }
@@ -109,6 +108,7 @@ export class TopicsService {
         where: {
           agencyId: agencyId,
         },
+        raw: true,
       }),
       (error) => {
         logger.error({

--- a/server/src/modules/topics/topics.service.ts
+++ b/server/src/modules/topics/topics.service.ts
@@ -25,25 +25,20 @@ export class TopicsService {
    * @returns err(DatabaseError) if database errors occur while retrieving topic
    * @returns err(MissingTopicError) if topic does not exist in the database
    */
-  findOneById = (
+  getTopicById = (
     id: number,
   ): ResultAsync<Topic, DatabaseError | MissingTopicError> => {
-    return ResultAsync.fromPromise(
-      this.Topic.findOne({
-        where: { id: id },
-      }),
-      (error) => {
-        logger.error({
-          message: 'Database error while retrieving single topic by id',
-          meta: {
-            function: 'findOneById',
-            id,
-          },
-          error,
-        })
-        return new DatabaseError()
-      },
-    ).andThen((topic) => {
+    return ResultAsync.fromPromise(this.Topic.findByPk(id), (error) => {
+      logger.error({
+        message: 'Database error while retrieving single topic by id',
+        meta: {
+          function: 'getTopicById',
+          id,
+        },
+        error,
+      })
+      return new DatabaseError()
+    }).andThen((topic) => {
       if (!topic) {
         return errAsync(new MissingTopicError())
       }


### PR DESCRIPTION
## Problem

Tags are being used to categorise posts instead of Topics. We wish to switch to the latter as it allows for hierarchical categorisation.

Closes #695 

## Solution

**Features**:

- Use topics instead of tags in OptionsMenu. Clicking on a topic will display all posts belonging to that topic + its subtopics
- Use `agencyShortName` and `topic.name` for post breadcrumbs instead of tags
- Require selection of a topic in Create and Edit post
- Update WAS seed script with topics linked to posts (names derived from existing tags)

**Improvements**:

- Make tags optional in QuestionsList component, listPosts and listAnswerablePosts endpoints

**Bug Fixes**:

- remove redundant toggle switch in AskForm component


## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/56983748/140671918-db65099a-7a72-4f48-ac85-a72a27db9a85.png)

**AFTER**:
Edit a post

https://user-images.githubusercontent.com/56983748/140672044-b5a85ec7-2e59-4735-be60-526e9dd8059d.mov




Post a question

https://user-images.githubusercontent.com/56983748/140672267-8772e586-3a28-4d68-964c-86c20d7e633f.mov



## Tests

- Create a new post - alert message should pop up if a topic has not been selected
- Create a new post - check that post is listed in the landing page
- Edit a post - change its topic, check that post is listed under the new topic
- Filter for different topics - check that the posts displayed belong to the appropriate topic filter
- Check that a post's breadcrumbs reflect the correct agency and topic

## Deploy Notes

**Updated scripts**:

- `script` : `20210826064325-was.js`