### PR TITLE
Revert "build(deps): bump react-router-dom from 5.3.0 to 6.0.0 in /client"

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -33,7 +33,7 @@
         "react-hook-form": "^7.18.1",
         "react-icons": "^4.3.1",
         "react-query": "^3.31.0",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "^5.3.0",
         "react-scripts": "^4.0.3",
         "react-select": "^5.2.0",
         "react-tabs": "^3.2.3",
@@ -12229,11 +12229,16 @@
       "peer": true
     },
     "node_modules/history": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "dependencies": {
-        "@babel/runtime": "^7.7.6"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "node_modules/hmac-drbg": {
@@ -13349,6 +13354,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -17765,6 +17775,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -18820,6 +18843,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -21034,26 +21065,40 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/react-router": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.0.tgz",
-      "integrity": "sha512-FcTRCihYZvERMNbG54D9+Wkv2cj/OtoxNlA/87D7vxKYlmSmbF9J9XChI9Is44j/behEiOhbovgVZBhKQn+wgA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
       "dependencies": {
-        "history": "^5.0.3"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=15"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.0.tgz",
-      "integrity": "sha512-bPXyYipf0zu6K7mHSEmNO5YqLKq2q9N+Dsahw9Xh3oq1IirsI3vbnIYcVWin6A0zWyHmKhMGoV7Gr0j0kcuVFg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "dependencies": {
-        "react-router": "6.0.0"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=15"
       }
     },
     "node_modules/react-scripts": {
@@ -21594,6 +21639,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -23784,6 +23834,11 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -24445,6 +24500,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -35258,11 +35318,16 @@
       "peer": true
     },
     "history": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
-        "@babel/runtime": "^7.7.6"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -36089,6 +36154,11 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -39440,6 +39510,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -40262,6 +40341,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -42018,19 +42105,34 @@
       }
     },
     "react-router": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.0.tgz",
-      "integrity": "sha512-FcTRCihYZvERMNbG54D9+Wkv2cj/OtoxNlA/87D7vxKYlmSmbF9J9XChI9Is44j/behEiOhbovgVZBhKQn+wgA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
       "requires": {
-        "history": "^5.0.3"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-router-dom": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.0.tgz",
-      "integrity": "sha512-bPXyYipf0zu6K7mHSEmNO5YqLKq2q9N+Dsahw9Xh3oq1IirsI3vbnIYcVWin6A0zWyHmKhMGoV7Gr0j0kcuVFg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "requires": {
-        "react-router": "6.0.0"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-scripts": {
@@ -42441,6 +42543,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -44198,6 +44305,11 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -44700,6 +44812,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "react-hook-form": "^7.18.1",
     "react-icons": "^4.3.1",
     "react-query": "^3.31.0",
-    "react-router-dom": "^6.0.0",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "^4.0.3",
     "react-select": "^5.2.0",
     "react-tabs": "^3.2.3",

--- a/client/src/components/EditButton/EditButton.component.tsx
+++ b/client/src/components/EditButton/EditButton.component.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react'
 import { BiChevronDown, BiTrash } from 'react-icons/bi'
 import { useMutation, useQueryClient } from 'react-query'
-import { Link as RouterLink, useNavigate } from 'react-router-dom'
+import { Link as RouterLink, useHistory } from 'react-router-dom'
 import { getApiErrorMessage } from '../../api'
 import {
   deletePost,
@@ -32,7 +32,7 @@ const EditButton = ({ postId, onDeleteLink }: EditButtonProps): JSX.Element => {
     isOpen: isDeleteDialogOpen,
   } = useDisclosure()
 
-  const navigate = useNavigate()
+  const history = useHistory()
   const toast = useStyledToast()
 
   const queryClient = useQueryClient()
@@ -47,7 +47,7 @@ const EditButton = ({ postId, onDeleteLink }: EditButtonProps): JSX.Element => {
         description: `Post has been deleted`,
       })
       if (onDeleteLink !== undefined) {
-        navigate(onDeleteLink)
+        history.push(onDeleteLink)
       }
     },
     onError: (err) => {

--- a/client/src/components/OptionsMenu/OptionsMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsMenu.component.tsx
@@ -36,10 +36,10 @@ import { getRedirectURL, getRedirectURLAgency } from '../../util/urlparser'
 
 const OptionsMenu = (): ReactElement => {
   const [hasTagsKey, setHasTagsKey] = useState(false)
-  const { agency: agencyShortName } = useParams()
+  const { agency: agencyShortName } = useParams<{ agency: string }>()
   const { data: agency } = useQuery<Agency>(
     [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
-    () => getAgencyByShortName({ shortname: `${agencyShortName}` }),
+    () => getAgencyByShortName({ shortname: agencyShortName }),
     // Only getAgencyByShortName if agency param is present in URL
     // If agency URL param is not present, agencyShortName is undefined
     { enabled: agencyShortName !== undefined },

--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -4,7 +4,7 @@ import Downshift from 'downshift'
 import Fuse from 'fuse.js'
 import { BiSearch } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import {
   getAgencyById,
   GET_AGENCY_BY_ID_QUERY_KEY,
@@ -45,7 +45,7 @@ const SearchBox = ({
     { enabled: !!agencyId },
   )
 
-  const navigate = useNavigate()
+  const history = useHistory()
   const name = 'search'
 
   const googleAnalytics = useGoogleAnalytics()
@@ -86,7 +86,7 @@ const SearchBox = ({
   value = value ?? ''
   if (!handleSubmit) {
     handleSubmit = (inputValue) =>
-      navigate(
+      history.push(
         `/questions?search=${inputValue}` +
           (agency ? `&agency=${agency.shortname}` : ''),
       )
@@ -117,7 +117,7 @@ const SearchBox = ({
     <div className="search-container">
       <div className="search-form">
         <Downshift
-          onChange={(selection) => navigate(`/questions/${selection.id}`)}
+          onChange={(selection) => history.push(`/questions/${selection.id}`)}
           stateReducer={stateReducer}
           itemToString={itemToString}
           initialInputValue={value}

--- a/client/src/pages/EditForm/EditForm.component.tsx
+++ b/client/src/pages/EditForm/EditForm.component.tsx
@@ -1,7 +1,7 @@
 import { Spacer } from '@chakra-ui/react'
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient } from 'react-query'
-import { Navigate, useParams, useNavigate } from 'react-router-dom'
+import { Redirect, RouteComponentProps, useHistory } from 'react-router-dom'
 import { getApiErrorMessage } from '../../api'
 import Spinner from '../../components/Spinner/Spinner.component'
 import { useAuth } from '../../contexts/AuthContext'
@@ -26,12 +26,13 @@ import AskForm, {
 import { useStyledToast } from '../../components/StyledToast/StyledToast'
 import './EditForm.styles.scss'
 
-const EditForm = (): JSX.Element => {
+type EditFormProps = RouteComponentProps<{ id: string }>
+
+const EditForm = ({ match }: EditFormProps): JSX.Element => {
   const auth = useAuth()
   const queryclient = useQueryClient()
-  const navigate = useNavigate()
-  const { id } = useParams()
-  const postId = Number(id)
+  const history = useHistory()
+  const postId = Number(match.params.id)
   const getPostQueryKey = useMemo(
     () => [GET_POST_BY_ID_QUERY_KEY, postId],
     [postId],
@@ -90,7 +91,7 @@ const EditForm = (): JSX.Element => {
         status: 'success',
         description: 'Your post has been updated.',
       })
-      navigate(`/questions/${postId}`, { replace: true })
+      history.replace(`/questions/${postId}`)
     } catch (err) {
       toast({
         status: 'error',
@@ -100,7 +101,7 @@ const EditForm = (): JSX.Element => {
   }
 
   if (!auth.user) {
-    return <Navigate replace to="/login" />
+    return <Redirect to="/login" />
   }
 
   const isLoading = isPostLoading || isAnswerLoading || isTagLoading

--- a/client/src/pages/HomePage/HomePage.component.jsx
+++ b/client/src/pages/HomePage/HomePage.component.jsx
@@ -13,7 +13,7 @@ import {
 import { useEffect, useState } from 'react'
 import { BiSortAlt2 } from 'react-icons/bi'
 import { useQuery } from 'react-query'
-import { useNavigate, useLocation, useParams } from 'react-router-dom'
+import { useHistory, useLocation, useParams } from 'react-router-dom'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostQuestionButton from '../../components/PostQuestionButton/PostQuestionButton.component'
@@ -35,7 +35,7 @@ import { getTagsQuery, isSpecified } from '../../util/urlparser'
 
 const HomePage = ({ match }) => {
   const [hasTagsKey, setHasTagsKey] = useState(false)
-  const navigate = useNavigate()
+  const history = useHistory()
   // check URL
   const location = useLocation()
   // TODO (#259): make into custom hook
@@ -206,7 +206,7 @@ const HomePage = ({ match }) => {
                   borderColor="secondary.700"
                   onClick={() => {
                     window.scrollTo(0, 0)
-                    navigate('?tags=')
+                    history.push('?tags=')
                   }}
                 >
                   <Text textStyle="subhead-1">View all questions</Text>

--- a/client/src/pages/Login/Login.component.jsx
+++ b/client/src/pages/Login/Login.component.jsx
@@ -8,7 +8,7 @@ const Login = () => {
   const { user } = useAuth()
 
   if (user) {
-    return <Navigate replace to={`/agency/${user.agency.shortname}`} />
+    return <Redirect to={`/agency/${user.agency.shortname}`} />
   } else {
     return (
       <div className="login-page">

--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -1,7 +1,7 @@
 import { Alert, AlertIcon, Switch } from '@chakra-ui/react'
 import { useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import Select from 'react-select'
 import { Tag, TagType } from '~shared/types/base'
 import { RichTextEditor } from '../../../components/RichText/RichTextEditor.component'
@@ -60,7 +60,7 @@ const AskForm = ({
       })),
     [inputTags],
   )
-  const navigate = useNavigate()
+  const history = useHistory()
   const { register, control, handleSubmit, watch, formState } =
     useForm<AskFormInput>({
       defaultValues: {
@@ -238,7 +238,7 @@ const AskForm = ({
           value={submitButtonText}
           type="submit"
         />
-        <div className="cancel-text" onClick={() => navigate(-1)}>
+        <div className="cancel-text" onClick={() => history.goBack()}>
           Cancel
         </div>
       </div>

--- a/client/src/pages/PostForm/PostForm.component.tsx
+++ b/client/src/pages/PostForm/PostForm.component.tsx
@@ -1,7 +1,7 @@
 import { Spacer } from '@chakra-ui/react'
-import { Fragment } from 'react'
+import React, { Fragment } from 'react'
 import { useQuery } from 'react-query'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Redirect, useHistory } from 'react-router-dom'
 import { getApiErrorMessage } from '../../api/ApiClient'
 import Spinner from '../../components/Spinner/Spinner.component'
 import { useStyledToast } from '../../components/StyledToast/StyledToast'
@@ -18,7 +18,7 @@ import './PostForm.styles.scss'
 const PostForm = (): JSX.Element => {
   const auth = useAuth()
   const toast = useStyledToast()
-  const navigate = useNavigate()
+  const history = useHistory()
   const { isLoading, data: tagData } = useQuery(
     GET_TAGS_BY_USER_QUERY_KEY,
     getTagsByUser,
@@ -27,7 +27,7 @@ const PostForm = (): JSX.Element => {
     },
   )
   if (!auth.user) {
-    return <Navigate replace to="/login" />
+    return <Redirect to="/login" />
   }
 
   const onSubmit = async (data: AskFormSubmission) => {
@@ -43,7 +43,7 @@ const PostForm = (): JSX.Element => {
         status: 'success',
         description: 'Your post has been created.',
       })
-      navigate(`/questions/${postId}`, { replace: true })
+      history.replace(`/questions/${postId}`)
     } catch (err) {
       toast({
         status: 'error',

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -1,4 +1,4 @@
-import { Route, Routes as ReactRoutes } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 import {
   AgencyPrivacy,
   AgencyTerms,
@@ -69,7 +69,7 @@ const AgencyPrivacyComponent = withPageTitle({
 
 const Routes = () => {
   return (
-    <ReactRoutes>
+    <Switch>
       <Route exact path="/" component={HomePageComponent} />
       <Route exact path="/agency/:agency" component={HomePageComponent} />
       <Route exact path="/questions" component={SearchResultsComponent} />
@@ -82,7 +82,7 @@ const Routes = () => {
       <Route exact path="/privacy" component={CitizenPrivacyComponent} />
       <Route exact path="/agency-privacy" component={AgencyPrivacyComponent} />
       <Route path="*" component={NotFoundComponent} />
-    </ReactRoutes>
+    </Switch>
   )
 }
 


### PR DESCRIPTION
We were naive to think that react-router would have well-written migration documentation from v5. Revert this for now.