### PR TITLE
Revert "build(deps): bump @chakra-ui/react from 1.6.10 to 1.6.12 in /client"

### DIFF
--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -5,10 +5,6 @@ const {
 
 module.exports = function override(config, _env) {
   aliasDangerous(configPaths('tsconfig.paths.json'))(config)
-  config.module.rules.push({
-    test: /\.mjs$/,
-    include: /node_modules/,
-    type: 'javascript/auto',
-  })
+
   return config
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
-        "@chakra-ui/react": "^1.6.12",
+        "@chakra-ui/react": "^1.6.10",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
         "@fullstory/browser": "^1.4.9",
@@ -1799,16 +1799,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@chakra-ui/accordion": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.3.10.tgz",
-      "integrity": "sha512-jlhxPRAA/nbuksIMpvNZjKLSm03fo8ljmWbJRqZC00ExFyLuBJ2olGVm3MTge1CCfJiOVQuiR6e7/k6fXHDvoA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.3.8.tgz",
+      "integrity": "sha512-LsdRGct1hLEDUyuZp6db2VOYCvBXN1rdJEmnqJWFp8ppePApdccwow74dDQRuZSwe3B/JLBUQ54Cdk4YUH2aAg==",
       "dependencies": {
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1816,13 +1816,13 @@
       }
     },
     "node_modules/@chakra-ui/alert": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.2.9.tgz",
-      "integrity": "sha512-3vH1mY2TKauTka57fWu4REIlD5QeBC+Sr88CQx7ErCQbg/Yh9YvBwIt/4Eiy6IeLF/DofHy8Pe2R+bwlUIXXTw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.2.8.tgz",
+      "integrity": "sha512-/91WfnGYGUDBeDlQ4I2ZAP+NHloAGPFsjNyw9if5dreeDA9zgOhUr2s4qj8uzZ9NtLurvWg7YMA8kqvmD/f7/w==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1830,21 +1830,21 @@
       }
     },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.1.0.tgz",
-      "integrity": "sha512-Q9v5tAqX4m2oVUyO0MJn/tq7PpuHe44pJizo6Imwmp7VMDxGJ8lNBkh1mLA17ZIXWpgMRysbREOU/QPaq6hDVg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.0.1.tgz",
+      "integrity": "sha512-eMmusEHhQJn465txOdEUM2yx2A2DoRfMQWwAxoW4GwwbJTD6q8fuGEIf6jaTQ7QtDLcJ9JOkYA7C0f3SKRTGGg==",
       "dependencies": {
-        "@chakra-ui/theme-tools": "^1.2.3"
+        "@chakra-ui/theme-tools": "^1.2.1"
       }
     },
     "node_modules/@chakra-ui/avatar": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.2.12.tgz",
-      "integrity": "sha512-sbteyANEaesY8HuFiRXX41tMS+IqiA77r2854ra+KIvBGz4yhSiHkMI0Di1yqG5vBaDJvST9ygVgU4kG++Ce4g==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.2.11.tgz",
+      "integrity": "sha512-h+Fo0bjRQTgDgga0n9RCQtJtRgUc2KowMhfajzjFyhtspSfhZauSjazKqDtiPkzD7alc+herEGEMi0RQRuQXig==",
       "dependencies": {
-        "@chakra-ui/image": "1.0.22",
+        "@chakra-ui/image": "1.0.21",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1852,12 +1852,12 @@
       }
     },
     "node_modules/@chakra-ui/breadcrumb": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.2.10.tgz",
-      "integrity": "sha512-2e3G9wLMCR9rf2j0eUuOL6uqmvhJe5r4hSITcDCM4cTuxfLnJPJcdDJ5Y2J+/eSDb2MUeXDozTzcSAnV/mZciw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.2.9.tgz",
+      "integrity": "sha512-MYyG6Flnw6TXTvX1fS88SZs6R4m8DMQHn67V+mypDN5htWVHku4d1P3jAhuHganu3ql+C0K2E2Qve78gWMbi/g==",
       "dependencies": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1865,14 +1865,14 @@
       }
     },
     "node_modules/@chakra-ui/button": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.4.6.tgz",
-      "integrity": "sha512-YcVZjM660LyfsGGZBPLtgaxFCEjZWin9lUAGME1iyAhVYGCj0nbNsXkClbGV/Q9EQhP7mPySm5N9GP9DzCaFzA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.4.5.tgz",
+      "integrity": "sha512-fWwSpgM0h0e+TcXEq6cCJhHSRxTsKDvaE2KJa9KJcqKSjad6p4SSQf1UEw0TstxhrqbgvjDlvYcUjJ4MH6u04Q==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/spinner": "1.1.14",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/spinner": "1.1.13",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1880,40 +1880,40 @@
       }
     },
     "node_modules/@chakra-ui/checkbox": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.5.10.tgz",
-      "integrity": "sha512-URS8wFK8DT6pk/KhdixlfDbyLYsLgEC9Iy4c53tOrcKEaSFf/hnyDIJ3w8xN0PxdO9F+UAhCbX4L6DGMgVD9ww==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.5.8.tgz",
+      "integrity": "sha512-eZK720TfnZ2aYs34MpfCyAou94TS5qjarAlE/UjkOH4XhZH49Pf6Ck6ai+7hrALn7yi61qVt0MoE5Dd2KsedYA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/clickable": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.1.9.tgz",
-      "integrity": "sha512-4uX1IRQbznPUAB3CeNZJK+wFNsGPdRt4NPz0GW7Mep6lw/A7rfyTBANBdM7hK2VMqBnIceS2goWbPftrrFIvhA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.1.8.tgz",
+      "integrity": "sha512-o17ljVD3qf2dsJqVhRX4V/xFtwJ9sAzCGcZrXV/O/dWAVDNuL8fGMdx5FileUVdFFi50w3tBuM4hxZRD5KNeGQ==",
       "dependencies": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/close-button": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.13.tgz",
-      "integrity": "sha512-YuTeZAJ7VyuxFlCSc7IXhC6HDSN77zWf1EKZDiFJWzpLDVVCpgf4bw7klBBWVbno2bVcHY7OPQeflcokFJ9Idg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.12.tgz",
+      "integrity": "sha512-ZuNNhkOfwFKdjUPHvwkRapCv8vto857wYYw/OtogDp6XcTYBPudeQl29nglhoI8fQAvEt7wmMZAZaTwAAW0dNQ==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1921,24 +1921,23 @@
       }
     },
     "node_modules/@chakra-ui/color-mode": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.2.0.tgz",
-      "integrity": "sha512-8oaFYqswjqfAKeMlK15q09tkB4ZDIlWpzUlSdh2jrJs3NCBacsSadH+y9lPexdfKfhCIn7jeHk2SDd8MYBgQHA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.1.13.tgz",
+      "integrity": "sha512-IYCOfeP+5a/OFmixNN2nkcZIRwC7qNb26I7zqZ/hEQYr4gZi7FKEthKjpvZWKCwLRSNiidhkaPLzAf+lhqM/Qg==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/control-box": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.17.tgz",
-      "integrity": "sha512-q2bkaw33KEamuSXSdNxjVCYHMY7Z3lrZppD7CB2bT77uIQCTldVHEX99Qf8clTqwXuPgXDc81+/WXDAXqm1v3A==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.16.tgz",
+      "integrity": "sha512-Smkk9Olr6mhkUEktgGLw1oc4fZr58U3Ts5bMKJsTSBIRdsol+Tm3oFUzLKADD7udhMaz+7+aEx4WiTrg5tWzzA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1946,12 +1945,12 @@
       }
     },
     "node_modules/@chakra-ui/counter": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.1.11.tgz",
-      "integrity": "sha512-Z3SCtvXfBdkWiRCtx8S+7URcayUY5IfYAuXQKRkpt/vNwYCGPFT5dMFy/wafHNXx0T4Oaga5qdGHqmt8BsLqBw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.1.10.tgz",
+      "integrity": "sha512-63LfIKK2duHyY9n8AfoXfwmQYkmNNaItAIB2ZNT230eTY0RwuKiAi+J4C/N9amxCB7EUw15gQphb2DjjL5D3GQ==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
@@ -1978,13 +1977,13 @@
       }
     },
     "node_modules/@chakra-ui/editable": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.2.11.tgz",
-      "integrity": "sha512-G8uVbtAACu11jSxoE2so2RNYyes5F0w9Yl6oqWjEKBvTJTO0lt588HduFp0uZ2ptagV/UEDiihWIr5M34orZrQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.2.10.tgz",
+      "integrity": "sha512-UYhg60F46Z4W85amYV3f4KTKjxfDL3GxcAN5d9r/E75jHrluwd4YGr/nlVhg57AhFhteiPpIdQx/NQ68KQ2KJA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1992,11 +1991,11 @@
       }
     },
     "node_modules/@chakra-ui/focus-lock": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.12.tgz",
-      "integrity": "sha512-NirFUA34xxsY7tioCfYW8PCk16figLyKlYwRtHhAKfN2zajWft1XqEmmM1cQGiTo7EpbxdD24mReU1Sym2vvfQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.11.tgz",
+      "integrity": "sha512-piJwxQCxPIx5d9jPNr4aQ0BoDU1+tNecNKAoUz+U0mXa334O3DSb84cbsOjBQn9VBLV82FtmtvrF8FwrT9cl9Q==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "react-focus-lock": "2.5.0"
       },
       "peerDependencies": {
@@ -2004,14 +2003,14 @@
       }
     },
     "node_modules/@chakra-ui/form-control": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.4.3.tgz",
-      "integrity": "sha512-uHulh477WgB5YYoamcNdQpH6/p+Gf2Nk1sC6YzqhG6brJAoXWRxa5oazgpUt0U/AAlA+W1rMTciUKidGxM4Hbw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.4.2.tgz",
+      "integrity": "sha512-VmoyNAh+bWj4p1ocMZDfrdJgo6pG+cgfJZ62YBSWZk7glK5ZsUNFZfd/TlxKkINKzDQyhBEEPzNjNV9TcVymmA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2019,12 +2018,12 @@
       }
     },
     "node_modules/@chakra-ui/hooks": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.6.2.tgz",
-      "integrity": "sha512-B4nAMFnwS7jamugVwl6JnALZJhxf4vxyZmwY1qjVSoe3lY8ZyqssI2TI6yla4WHa7gny2beG0SXS2+gCEGtwmA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.6.1.tgz",
+      "integrity": "sha512-377Wvrt2BxpEY+1dDMsvm3J/E4GTdrxJM4fju24iUg0iFv87jg+jf6GXPsrZfdN6a9XfCCmclcmLxEH/0Trwpg==",
       "dependencies": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "compute-scroll-into-view": "1.0.14",
         "copy-to-clipboard": "3.3.1"
       },
@@ -2033,11 +2032,11 @@
       }
     },
     "node_modules/@chakra-ui/icon": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.13.tgz",
-      "integrity": "sha512-yVZr1YMd3YEd0toHKmLxNH4LlLQ60vzuaKYVOmAO9c/gxxPMNYM4Il260Q5W2lxOOzoimfQnZlNfTUPCwHHfUg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.12.tgz",
+      "integrity": "sha512-MVzsW+IqAYUGPjxOiEWu9kU3kl3gQ8tNONN77EyDEEcbqPOCgPOomitQ4/scmgSWWWOrAL+SvjlbykXtH8g6+Q==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2045,12 +2044,12 @@
       }
     },
     "node_modules/@chakra-ui/image": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.22.tgz",
-      "integrity": "sha512-+WRYWhZU0izZehwX5x52snIALd61NEY/9mHM/xWMEPl8kTivBhC6VrLv5xuhv5vJc21Witu8zuSttqF3j0V1iw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.21.tgz",
+      "integrity": "sha512-efknvUiUPEarhOAivbel89RLlYR5sA2E5vvmmbPXp348TGBiVvpxrmtfuUKZjbaF6ZBkkZsVPk6zJFE1PgwJbA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2058,13 +2057,13 @@
       }
     },
     "node_modules/@chakra-ui/input": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.2.12.tgz",
-      "integrity": "sha512-eiYVXIDAWCzAUNaDfsbHcr3xLwyY3K8w1VIczjxlnEl/s9zPczKO44OuP3aM/zQ5JHio3YPkR2WLQ0/8jdBckw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.2.11.tgz",
+      "integrity": "sha512-/UaUcdSoVA2Bd9sdODnuNpK0+lI68fyigzHWe3z6lF1wmLZB546MxXxt70ZvZWsu+eJ41qBNpx81BZZ9zCJP8w==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.4.3",
+        "@chakra-ui/form-control": "1.4.2",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2072,13 +2071,13 @@
       }
     },
     "node_modules/@chakra-ui/layout": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.4.11.tgz",
-      "integrity": "sha512-Aj7W89wJjWH+LPIUO+2IIeam6x+fPWOWDFczzkDwGm/2T/qMy+UJ6sO2Vs00plEvCf1yQamrdR9W3F9o1QIEEA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.4.10.tgz",
+      "integrity": "sha512-KtJOKCYyCzUBRrBRNAr9SAhvC6KtSxzIM1NynA0dJSGEVHdkeVchfoZRSNfji60T0vNVA6hVGdgBi9DjZlh02Q==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2086,23 +2085,23 @@
       }
     },
     "node_modules/@chakra-ui/live-region": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.16.tgz",
-      "integrity": "sha512-U4fw8qgVfIq0xM6+LEARBlj0eiD7SY19f+/doeBaQTHwjVhQ4AflrQL6hm8jqpR7O9iHSUhW25S9yRRSfA+O9g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.15.tgz",
+      "integrity": "sha512-Gl9q2Cb7xY68LoEo1qXGUyQp4A01Dd62apJY3Ox2RorcE7DiCQXr1KVGefiRBbcny/borbgrNVL9VcTl24ZNrA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/media-query": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.1.5.tgz",
-      "integrity": "sha512-9Dk1oJVJT9nRB3aVx2bzUMmPwlqm9dAj0GY+L8twg8MgaebjtxXlz3xqitRfdP2Wd1M0yiK6/vyicn4qB7C6Kg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.1.3.tgz",
+      "integrity": "sha512-/LdpMTCW7PLR2uWRwTYrWK7TZZI6MmVVlCCXicqNTfx8Seu87F54pr7D/T/nkxYOM419KF/gQQjGDUxl2N6V6Q==",
       "dependencies": {
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2111,57 +2110,57 @@
       }
     },
     "node_modules/@chakra-ui/menu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.7.8.tgz",
-      "integrity": "sha512-ut4hWKjTkUfT/hew5tvx3fE1um447zLijPcrFDyUwX780/IQAGV31bcJcGSMarLbsAgBOAaVaoiwBQvL0QLe2g==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.7.6.tgz",
+      "integrity": "sha512-3O0zSvZrJmReM8iaeZ447KY4swMT/al0QJyloO7LNa3ex4uNQRw9ff5YXgKk+EURNvRwI75Lc2tEwpOHGNczWw==",
       "dependencies": {
-        "@chakra-ui/clickable": "1.1.9",
+        "@chakra-ui/clickable": "1.1.8",
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/modal": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.9.4.tgz",
-      "integrity": "sha512-TZ/XS/8uZwx7VCp1Lhf83U2BZNGj7djDbXJPeLp6VXZ1WYhwh1lF5A1H5RcH7WzN+kvrjv1rmSlTAXNlHTgDag==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.9.2.tgz",
+      "integrity": "sha512-5QPDca8q1YB0XgB6Whuj1B0dzRzSuYQS7demz3TOuEWHKcmNSz/hx3YprMFgEVEx0Awg3HaWomnyj7AG+m/2dQ==",
       "dependencies": {
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/focus-lock": "1.1.12",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/portal": "1.2.11",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/focus-lock": "1.1.11",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/portal": "1.2.10",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.4.1"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/number-input": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.2.12.tgz",
-      "integrity": "sha512-0gLII6l6Nee8BH4yBDm/P6u4DIPt/TfbnRnKhuX8iAaxfC7YdOaLJFShQpa5UkQ/56Me98nb78+Zli56cc8FYg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.2.11.tgz",
+      "integrity": "sha512-tB4+SFyZrsDW3rzKoW+Wy34dQEZhqP2EMOnTflxIWxF4A66hf3Sz/6av0b6CEhlSsOd59QQd8GaT1FvHWdhz7A==",
       "dependencies": {
-        "@chakra-ui/counter": "1.1.11",
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/counter": "1.1.10",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2169,14 +2168,14 @@
       }
     },
     "node_modules/@chakra-ui/pin-input": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.6.7.tgz",
-      "integrity": "sha512-lt45R03xM5cdKxG7l2uXVnxebxfFaGPxs3/Yj97lZ/yQaG8N7iYwIdPKDH26vAvBZFRZayQJTgtUcJpeK/dn0g==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.6.6.tgz",
+      "integrity": "sha512-c4C4IT+FVIVc8uX4HQLlGdWCE3WqwH5ZBv393ukd7VGOfn8G/jmgOCafn2VbW8TsAwqpvQ/IH3TUbcFI75Drkg==",
       "dependencies": {
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2184,26 +2183,26 @@
       }
     },
     "node_modules/@chakra-ui/popover": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.9.1.tgz",
-      "integrity": "sha512-MtKvtntLQ5v3N+FUa4cPjd8EVNbNCCeTd/rPDdcH7HBnPqyDndtagE+GQGjseHmXuSY3nr7X+FnSsYktD+wnBg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.8.5.tgz",
+      "integrity": "sha512-SM10pQEIRSM7Y0Ygnuv0Skzxm8NES/UP9qcrfrFLJOMjmVxf52NZBPcNA4pIMEM4ocSHq6AyCHzhTXHr8a7HpQ==",
       "dependencies": {
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/popper": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.3.1.tgz",
-      "integrity": "sha512-iRsJTWw27c7HN+304UxzT5tDssEsCKBsfXDL9cbgwyhs4D9GJQGqM3eJDHXvvd1DAf9WZuWzya3sjvl3YhPtPw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.3.0.tgz",
+      "integrity": "sha512-K3Bw4RqttnX6TegLCBcMIez3w8YJFhUyLIkGUH0g2OCGgOajwucryFjNpuWRwkH4xcQPHghS9OVPYxRYTB22xA==",
       "dependencies": {
         "@chakra-ui/react-utils": "1.1.2",
         "@popperjs/core": "2.4.4"
@@ -2213,13 +2212,13 @@
       }
     },
     "node_modules/@chakra-ui/portal": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.2.11.tgz",
-      "integrity": "sha512-APp7L0Ql4eCHY9OkcJevuzNj/I07hOsn3aHiJmfV3o2whEWd/0P1pkEG5eTb2Gul7WS9+fxaPUL5Zzl44jxkUQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.2.10.tgz",
+      "integrity": "sha512-fK5wyZcPZ9DIYsD2fzRWMHiaI2yal54BaojKmCKyBOzC3M1QLHwHF31qbyS7xbo0f2dtzsLPUz1bC0nsTwUXmA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6",
@@ -2227,12 +2226,12 @@
       }
     },
     "node_modules/@chakra-ui/progress": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.16.tgz",
-      "integrity": "sha512-zS1GcHAPvsoCRE7A/fM28ZxVVXo5Iymv0RqXEu2p4vs5HuZnRebB0elWiDNlkrnAPVPpN+qGVz5kVnnp9QsFIw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.15.tgz",
+      "integrity": "sha512-DFKAYUjkbsfFJ8T9B5fqGHyuHQeKrCaJgPQDRr9v9th8oRhuUGuKM2mHgCfkGbQwRWwF5ViWz38tSJLOcwPGng==",
       "dependencies": {
-        "@chakra-ui/theme-tools": "1.2.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/theme-tools": "1.2.2",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2240,16 +2239,16 @@
       }
     },
     "node_modules/@chakra-ui/provider": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.6.11.tgz",
-      "integrity": "sha512-yyH9yV/V7qV0hTaY5mV02cmWIK4ouV4gEbPabKsT+tkjxA/ygw98MZ8cjUptGv7u3OIRry/7AWgmT3IU8iKm8A==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.6.9.tgz",
+      "integrity": "sha512-NS60y6AYTjngk+tNuNCvgJUo5VVSJeyzmm+3Ujvl3nKwHnsUrwvvug5XhPrZI3b3K9910BG6xk0+ptWqaHCWvQ==",
       "dependencies": {
         "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/portal": "1.2.11",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/portal": "1.2.10",
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0",
@@ -2259,15 +2258,15 @@
       }
     },
     "node_modules/@chakra-ui/radio": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.3.13.tgz",
-      "integrity": "sha512-0bbnUYpA39WihLdYPb+xF/rDXiTvTiQCEVr75R0RTm19AmxvfnfJNdEzFb1nIfcu/uzlyFCSoe7OpPih1Pdquw==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.3.11.tgz",
+      "integrity": "sha512-pV7bIucW1N99DeNQLE54zRhgU6kD/vg7bAfNU3kHhg14xYmuB3F/4S9ad22V41nM1/g9S66kqUPmEadvhKWsXg==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2275,72 +2274,72 @@
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.6.12.tgz",
-      "integrity": "sha512-hlFZPU0ZApEbzdUoUyfr5PCX8UhO4qYmTrZRhWG4noQj/uQu5WkysSHW9k8dtBS2jGIctyY6BQjm7doaQv8Mqg==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.6.10.tgz",
+      "integrity": "sha512-eIPBRRssimuM+T1zIGtZ+2910BvjOirb85/iPfqJj2uQCCy/FGQvPUpU7QYJt30zsgyRzJGe/G7D8cJO0MFlzg==",
       "dependencies": {
-        "@chakra-ui/accordion": "1.3.10",
-        "@chakra-ui/alert": "1.2.9",
-        "@chakra-ui/avatar": "1.2.12",
-        "@chakra-ui/breadcrumb": "1.2.10",
-        "@chakra-ui/button": "1.4.6",
-        "@chakra-ui/checkbox": "1.5.10",
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/control-box": "1.0.17",
-        "@chakra-ui/counter": "1.1.11",
+        "@chakra-ui/accordion": "1.3.8",
+        "@chakra-ui/alert": "1.2.8",
+        "@chakra-ui/avatar": "1.2.11",
+        "@chakra-ui/breadcrumb": "1.2.9",
+        "@chakra-ui/button": "1.4.5",
+        "@chakra-ui/checkbox": "1.5.8",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/control-box": "1.0.16",
+        "@chakra-ui/counter": "1.1.10",
         "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/editable": "1.2.11",
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/image": "1.0.22",
-        "@chakra-ui/input": "1.2.12",
-        "@chakra-ui/layout": "1.4.11",
-        "@chakra-ui/live-region": "1.0.16",
-        "@chakra-ui/media-query": "1.1.5",
-        "@chakra-ui/menu": "1.7.8",
-        "@chakra-ui/modal": "1.9.4",
-        "@chakra-ui/number-input": "1.2.12",
-        "@chakra-ui/pin-input": "1.6.7",
-        "@chakra-ui/popover": "1.9.1",
-        "@chakra-ui/popper": "2.3.1",
-        "@chakra-ui/portal": "1.2.11",
-        "@chakra-ui/progress": "1.1.16",
-        "@chakra-ui/provider": "1.6.11",
-        "@chakra-ui/radio": "1.3.13",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/select": "1.1.17",
-        "@chakra-ui/skeleton": "1.1.21",
-        "@chakra-ui/slider": "1.4.2",
-        "@chakra-ui/spinner": "1.1.14",
-        "@chakra-ui/stat": "1.1.14",
-        "@chakra-ui/switch": "1.2.13",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/table": "1.2.8",
-        "@chakra-ui/tabs": "1.5.7",
-        "@chakra-ui/tag": "1.1.14",
-        "@chakra-ui/textarea": "1.1.16",
-        "@chakra-ui/theme": "1.11.1",
-        "@chakra-ui/toast": "1.3.4",
-        "@chakra-ui/tooltip": "1.3.14",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/editable": "1.2.10",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/image": "1.0.21",
+        "@chakra-ui/input": "1.2.11",
+        "@chakra-ui/layout": "1.4.10",
+        "@chakra-ui/live-region": "1.0.15",
+        "@chakra-ui/media-query": "1.1.3",
+        "@chakra-ui/menu": "1.7.6",
+        "@chakra-ui/modal": "1.9.2",
+        "@chakra-ui/number-input": "1.2.11",
+        "@chakra-ui/pin-input": "1.6.6",
+        "@chakra-ui/popover": "1.8.5",
+        "@chakra-ui/popper": "2.3.0",
+        "@chakra-ui/portal": "1.2.10",
+        "@chakra-ui/progress": "1.1.15",
+        "@chakra-ui/provider": "1.6.9",
+        "@chakra-ui/radio": "1.3.11",
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/select": "1.1.16",
+        "@chakra-ui/skeleton": "1.1.19",
+        "@chakra-ui/slider": "1.4.1",
+        "@chakra-ui/spinner": "1.1.13",
+        "@chakra-ui/stat": "1.1.13",
+        "@chakra-ui/switch": "1.2.11",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/table": "1.2.7",
+        "@chakra-ui/tabs": "1.5.6",
+        "@chakra-ui/tag": "1.1.13",
+        "@chakra-ui/textarea": "1.1.15",
+        "@chakra-ui/theme": "1.10.4",
+        "@chakra-ui/toast": "1.3.2",
+        "@chakra-ui/tooltip": "1.3.12",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/react-env": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.0.8.tgz",
-      "integrity": "sha512-iA5D1BgcrXrwf0XIBMdvWced+9nH312KLPeQMYHZx8i0n9YqwyJBxUhcruyaKQB+m+NRO2sjkKLLH4wnCG9dwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.0.7.tgz",
+      "integrity": "sha512-3ANGROM7wZL4lLiY5GCdslLhNv44xa4cykyBed9B/O0B0J4xqIbVCwLMV2aNSCXwwUChFgjmBsDvk0vnMvclmg==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
@@ -2358,12 +2357,12 @@
       }
     },
     "node_modules/@chakra-ui/select": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.17.tgz",
-      "integrity": "sha512-E+I6vZAxsmnzge8xxaj3AAuqhFEn3L3qVI/fAoA5xyjE0JgJwmrqVXYhDLBANTGnv1YoEohspEUPyc7U3LYabQ==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.16.tgz",
+      "integrity": "sha512-2Hoq5B4ukEKLOn2TEnw07EGrFLM9ZDOXQltQ4MKXmjkw0EWCE9mwGbW1FK4pp+CW0Qmp34qiYhV6mzaC09iMgQ==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2371,27 +2370,27 @@
       }
     },
     "node_modules/@chakra-ui/skeleton": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.21.tgz",
-      "integrity": "sha512-MQwitvzPk9JN9HgcM7Ggd4AX4j8T9GpMoNatGvjyPdcHW2hUa9wiLrblhoYGaM2pN/4ww4kUwRK5O3Nvame+fg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.19.tgz",
+      "integrity": "sha512-+JoJxs28PirYmTAaPKabEPcVUWKjFqVvmN8ygK+p3poZQ6J4csCWv7DHbh2dHcvTXJFckuGqmQYFcflW11OoPg==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/media-query": "1.1.5",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/media-query": "1.1.3",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/slider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.4.2.tgz",
-      "integrity": "sha512-L+rNPGlmjcC1AiZ/BAgMfv+44pZS8NoWEGBkIIV3jCmGy/XMl8dkAL3EbdPHs/favQICKGsEmTV33AeAy0bVAQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.4.1.tgz",
+      "integrity": "sha512-7RwnH0bSmZD8TQi7LcK3aszG80qzawE9i0OkIfiNODBOqY3ijI5mU6rFsXJ614gJTmNYD/1z08/E3SZYeBLZHQ==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2399,12 +2398,12 @@
       }
     },
     "node_modules/@chakra-ui/spinner": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.14.tgz",
-      "integrity": "sha512-767yIR+RrM9iPXB77EvCrwTtaWhvR3p+vWyfPnRVEQR7kd6NDO696altdQZyUO0hVLyhr3bBPCXofSEChinFHA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.13.tgz",
+      "integrity": "sha512-LpO24XfpkG6pAdcppayNjfdSX8pSHBoi1oxNKCI6JysNgBO+HCWdaz/LaJRB6WEIXZu764XtHEB/mTMdP7edyg==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2412,13 +2411,13 @@
       }
     },
     "node_modules/@chakra-ui/stat": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.14.tgz",
-      "integrity": "sha512-dhE8m0JeQcDouXEJiMTlXf8QkRhfozc3vfTcyBo4p+mZs4+QXOw1/jcxsPQBzJQ0kNYV8y7LDzJp+J62FoPX1g==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.13.tgz",
+      "integrity": "sha512-XV6AMKVj/iF3pmao4wK3gnW7meH0W9yfEREA5/8vif/9exvfX6KDz/04irjnFIO/cDu7QHQKQmXTnhe1zLwvMA==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2426,21 +2425,21 @@
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.13.0.tgz",
-      "integrity": "sha512-+pdJ2ZnIS2uqJhm2Lyi5asYGJnwrZcFH/4rje18e6wh39Y937EDr0XRuwqbqL9Lk2C4G1H/M1br0cAmO85kHIw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.12.3.tgz",
+      "integrity": "sha512-Rgan47tBgqvE6K6wKEMjRpK/pM+6aHvn18MoZFWcrMCMfd7QxGuhI9MHaQP8b20i11bjtTlUd6AGs3PEMl6ZyQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "csstype": "^3.0.6"
       }
     },
     "node_modules/@chakra-ui/switch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.2.13.tgz",
-      "integrity": "sha512-nD9Sm+d2NfI6sVA9Y14az3yHdCUMkk+h0n7pDughI2p3VMlG196li/bI8BSwnIa8y4XtpARSACo5dx8tWnOD1Q==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.2.11.tgz",
+      "integrity": "sha512-3cZmLR0dQLQSrGQ8lJgsdxUNrek8ZpMdA8pzFASKOhge3goeHsbiyxFutbYagBYLmS573kFVHu/o/RDVnP5xxA==",
       "dependencies": {
-        "@chakra-ui/checkbox": "1.5.10",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/checkbox": "1.5.8",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2448,14 +2447,14 @@
       }
     },
     "node_modules/@chakra-ui/system": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.7.6.tgz",
-      "integrity": "sha512-83h5Ky+Ks8ddeU77ozwZlyxU1+ESysmrJ0bGCohmD69LxUZHUrcK4csUOJl9AuZioufoQdYvR3xUJFEM8v0d2w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.7.4.tgz",
+      "integrity": "sha512-YZMPP+OCuV5edxXuwDPP7TEVl13Kziq0vf/GjgnCizcgUImSRL9eUaPcF4INvGbvS/rcAeG9mZn26DMpFwVV7g==",
       "dependencies": {
-        "@chakra-ui/color-mode": "1.2.0",
+        "@chakra-ui/color-mode": "1.1.13",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/styled-system": "1.13.0",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/styled-system": "1.12.3",
+        "@chakra-ui/utils": "1.8.3",
         "react-fast-compare": "3.2.0"
       },
       "peerDependencies": {
@@ -2465,11 +2464,11 @@
       }
     },
     "node_modules/@chakra-ui/table": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.2.8.tgz",
-      "integrity": "sha512-Ra6qM+8osM6EwGidn9jrzdIufo5tQ8WMJkuXyv9mByjJnzbr2EOQqexHHA8AwCMsxaFieWBG9QPuuDWavl8ptQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.2.7.tgz",
+      "integrity": "sha512-fx7Hl1I16DCCD/pPBtkH/gl6ielUkLg8qQfPJ+5nbE8xrRM5Nxp2RqFuuFrJ0qGLZ+OZrshPm9r86JVrS6ZmOw==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2477,15 +2476,15 @@
       }
     },
     "node_modules/@chakra-ui/tabs": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.5.7.tgz",
-      "integrity": "sha512-+z9FsdY9Qukp9nShgh+LR/cMJGzwhGdgmav/AX/P/f/C/32PFYhmBZrKobHJwozYZeDebBeb8zhxqV8VROrfRQ==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.5.6.tgz",
+      "integrity": "sha512-s83Bosv7aQkcE6ufaAx6yRur8bV2uIuVAaTczMv4oxH/5OU2wNwA4rGbdiPbrxDf9M8M0AuH/mqJ+2uSu7Vdxg==",
       "dependencies": {
-        "@chakra-ui/clickable": "1.1.9",
+        "@chakra-ui/clickable": "1.1.8",
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2493,12 +2492,12 @@
       }
     },
     "node_modules/@chakra-ui/tag": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.14.tgz",
-      "integrity": "sha512-FfROxP2WJIimYWr6IRuLnJlH6an4QoJvXMO98yQYSXqycsOcuVNA+XP3aRCa6+o9qcL95AqkAidkpXSd8+sHsw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.13.tgz",
+      "integrity": "sha512-p1BxgqFnDzVFQrBJ1EItM+BCNjfJ9vCjg5lQK13JeLWHa6kHR+2agzNgxH+F9jzhKGY17BHroc2YYW4yKzD61Q==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2506,12 +2505,12 @@
       }
     },
     "node_modules/@chakra-ui/textarea": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.16.tgz",
-      "integrity": "sha512-wXYmZSsoYspH3Rtzhb9joysIfzHlegds9ABlBeuothYqz6HEQg7+DiTIdVmqtMydExdU+fhxuhwQ/EIGXCronA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.15.tgz",
+      "integrity": "sha512-q6yvyEdZ+72Gq6eE76vJxCo5aZcYdiORJHTmELtJWo4h+a1ASd8OBdIkygbvqKnT/jssnH2b2S9kFf8EcEPkMg==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2519,24 +2518,24 @@
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.11.1.tgz",
-      "integrity": "sha512-0E4Vb6AP/W400nj9qDUhT+LPzpz2fi99lBCffIwR53m9t+xWjWWdB7saXJ2Np1xKdkhGbzSpcn3Fo8Q3CzVM7w==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.10.4.tgz",
+      "integrity": "sha512-FaO5Qr1oGP+1JoCIotoqWT9RF0aguXmKjgz+4xDM8E+Gct6juuj+td43NfzeXr/FJXiXjL8u1G4RWxAeR2FxZQ==",
       "dependencies": {
-        "@chakra-ui/anatomy": "1.1.0",
-        "@chakra-ui/theme-tools": "1.2.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/anatomy": "1.0.1",
+        "@chakra-ui/theme-tools": "1.2.2",
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.2.3.tgz",
-      "integrity": "sha512-4vYW5KiJHRpqiuAw6opDMdIOMywL47gCtFiOP1CwwObXxrHetEHyJvMt9qnx+AfSMyCFGyHz8sFjDmLc+v/jEA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.2.2.tgz",
+      "integrity": "sha512-+2xPTW7/rFr++Qu/ibZsM1dq5qmvvjg6+Af4SRZw1AvjGq4CTxuV7upXo5zJM3Q3OgzOtU9Q9RATap3fhEHkyA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "@ctrl/tinycolor": "^3.4.0"
       },
       "peerDependencies": {
@@ -2544,60 +2543,60 @@
       }
     },
     "node_modules/@chakra-ui/toast": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.3.4.tgz",
-      "integrity": "sha512-0RMMldpvtita0zfFE5Jwp9JphUVL2P8jDfoiPJrqKD6K/7vT4dj3PyWhiIedes4yv4SM/dI3dnXKA8fChQaotQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.3.2.tgz",
+      "integrity": "sha512-uREAV+UoPvbTktQXgGhaExOX4RIKAlj54K9yOojO2FOBDCywtq0TdlI4eMk/dZvlz2SIuTWveK/C4CHBBbcd4Q==",
       "dependencies": {
-        "@chakra-ui/alert": "1.2.9",
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/theme": "1.11.1",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/alert": "1.2.8",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/theme": "1.10.4",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
         "@reach/alert": "0.13.2"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/tooltip": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.3.14.tgz",
-      "integrity": "sha512-P7npmVnCcGdTxwbf8lIHcsvpPdLpQLgyOcdEykJd6iSEb33SquVK2RULrktawn/NqbAohulUrvVoIHDhY9j92A==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.3.12.tgz",
+      "integrity": "sha512-zF4pWU//9YSIR3D9cljO+BNlYettKXqgVermTg8z7KvKMmgH+Ni99OA7aWQ6g3vii9LzJryi5kUdxfApoLCm9Q==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
-        "@chakra-ui/portal": "1.2.11",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
+        "@chakra-ui/portal": "1.2.10",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/transition": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.3.8.tgz",
-      "integrity": "sha512-YvcHkazYUIBaew5dfrts9Wp6/LPhHgbJoRYrKHBcfsDU+a63g/HoN4SCB19B46+pV3L6Fg4VPnOIED7KL7uoXg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.3.6.tgz",
+      "integrity": "sha512-P6H88iHWwElGpqrH3RoEhWTZToFw3ZQx2XyJhVUHNroavkxQ48wyRcoFIQ/btKAInQ+5xyyKISRLZlvAuy6ONg==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/utils": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.8.4.tgz",
-      "integrity": "sha512-lMk+FD70zgI8Fn6Ee5h6T2FJdJLnYIYaRQI+Au5izjl8e3V2OZ/Tdi72LW9FnHlQyFZ5N24HGefZlNxOEDUjmw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.8.3.tgz",
+      "integrity": "sha512-v184c2TYwQYBEcDI/9C1DjN668jZVTJeb/DPtucAjEHNi4T0py3tjGDbUd05LoNoZ64uijtWYanfrr6Abe4m1Q==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
         "css-box-model": "1.2.1",
@@ -2606,11 +2605,11 @@
       }
     },
     "node_modules/@chakra-ui/visually-hidden": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.16.tgz",
-      "integrity": "sha512-UQfSepguq/A0OzhW6tzBspLim8nMlG4G1pFeQRyuGAqJnoh1fCk749jcv32+FDBaeI60JGMCap6LcYgarxpt3A==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.15.tgz",
+      "integrity": "sha512-/qGI47YamrgazFt9KS4YxIt5U2/RT6jxdjHj1Tn3D2clivB1n+H+v5fQC9xFfjm7ul0QZwEhBrYhynqr5ybZkg==",
       "dependencies": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -5099,9 +5098,9 @@
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.176",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
-      "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+      "version": "4.14.175",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
     },
     "node_modules/@types/lodash.mergewith": {
       "version": "4.6.6",
@@ -11726,15 +11725,15 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.2.0.tgz",
-      "integrity": "sha512-268cYeh0GNWm26nqicXGuAZOlodvR/huY6KGAP5NuoRhrGnDTv5jgCGt9pZelk6qXsBGPEUMqE6xaYYpTSaHmg==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "peer": true,
       "dependencies": {
-        "framesync": "6.0.1",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "11.0.0",
-        "style-value-types": "5.0.0",
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
       },
       "optionalDependencies": {
@@ -11761,15 +11760,6 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true,
       "peer": true
-    },
-    "node_modules/framer-motion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/framesync": {
       "version": "5.3.0",
@@ -19041,23 +19031,14 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.0.tgz",
-      "integrity": "sha512-kJDyaG00TtcANP5JZ51od+DCqopxBm2a/Txh3Usu23L9qntjY5wumvcVf578N8qXEHR1a+jx9XCv8zOntdYalQ==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "peer": true,
       "dependencies": {
-        "framesync": "^6.0.1",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/popmotion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "peer": true,
-      "dependencies": {
+        "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
       }
     },
@@ -23303,9 +23284,9 @@
       }
     },
     "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
       "peer": true,
       "dependencies": {
         "hey-listen": "^1.0.8",
@@ -27325,120 +27306,119 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@chakra-ui/accordion": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.3.10.tgz",
-      "integrity": "sha512-jlhxPRAA/nbuksIMpvNZjKLSm03fo8ljmWbJRqZC00ExFyLuBJ2olGVm3MTge1CCfJiOVQuiR6e7/k6fXHDvoA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.3.8.tgz",
+      "integrity": "sha512-LsdRGct1hLEDUyuZp6db2VOYCvBXN1rdJEmnqJWFp8ppePApdccwow74dDQRuZSwe3B/JLBUQ54Cdk4YUH2aAg==",
       "requires": {
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/alert": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.2.9.tgz",
-      "integrity": "sha512-3vH1mY2TKauTka57fWu4REIlD5QeBC+Sr88CQx7ErCQbg/Yh9YvBwIt/4Eiy6IeLF/DofHy8Pe2R+bwlUIXXTw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.2.8.tgz",
+      "integrity": "sha512-/91WfnGYGUDBeDlQ4I2ZAP+NHloAGPFsjNyw9if5dreeDA9zgOhUr2s4qj8uzZ9NtLurvWg7YMA8kqvmD/f7/w==",
       "requires": {
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/anatomy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.1.0.tgz",
-      "integrity": "sha512-Q9v5tAqX4m2oVUyO0MJn/tq7PpuHe44pJizo6Imwmp7VMDxGJ8lNBkh1mLA17ZIXWpgMRysbREOU/QPaq6hDVg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.0.1.tgz",
+      "integrity": "sha512-eMmusEHhQJn465txOdEUM2yx2A2DoRfMQWwAxoW4GwwbJTD6q8fuGEIf6jaTQ7QtDLcJ9JOkYA7C0f3SKRTGGg==",
       "requires": {
-        "@chakra-ui/theme-tools": "^1.2.3"
+        "@chakra-ui/theme-tools": "^1.2.1"
       }
     },
     "@chakra-ui/avatar": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.2.12.tgz",
-      "integrity": "sha512-sbteyANEaesY8HuFiRXX41tMS+IqiA77r2854ra+KIvBGz4yhSiHkMI0Di1yqG5vBaDJvST9ygVgU4kG++Ce4g==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.2.11.tgz",
+      "integrity": "sha512-h+Fo0bjRQTgDgga0n9RCQtJtRgUc2KowMhfajzjFyhtspSfhZauSjazKqDtiPkzD7alc+herEGEMi0RQRuQXig==",
       "requires": {
-        "@chakra-ui/image": "1.0.22",
+        "@chakra-ui/image": "1.0.21",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/breadcrumb": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.2.10.tgz",
-      "integrity": "sha512-2e3G9wLMCR9rf2j0eUuOL6uqmvhJe5r4hSITcDCM4cTuxfLnJPJcdDJ5Y2J+/eSDb2MUeXDozTzcSAnV/mZciw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.2.9.tgz",
+      "integrity": "sha512-MYyG6Flnw6TXTvX1fS88SZs6R4m8DMQHn67V+mypDN5htWVHku4d1P3jAhuHganu3ql+C0K2E2Qve78gWMbi/g==",
       "requires": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/button": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.4.6.tgz",
-      "integrity": "sha512-YcVZjM660LyfsGGZBPLtgaxFCEjZWin9lUAGME1iyAhVYGCj0nbNsXkClbGV/Q9EQhP7mPySm5N9GP9DzCaFzA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.4.5.tgz",
+      "integrity": "sha512-fWwSpgM0h0e+TcXEq6cCJhHSRxTsKDvaE2KJa9KJcqKSjad6p4SSQf1UEw0TstxhrqbgvjDlvYcUjJ4MH6u04Q==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/spinner": "1.1.14",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/spinner": "1.1.13",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/checkbox": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.5.10.tgz",
-      "integrity": "sha512-URS8wFK8DT6pk/KhdixlfDbyLYsLgEC9Iy4c53tOrcKEaSFf/hnyDIJ3w8xN0PxdO9F+UAhCbX4L6DGMgVD9ww==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.5.8.tgz",
+      "integrity": "sha512-eZK720TfnZ2aYs34MpfCyAou94TS5qjarAlE/UjkOH4XhZH49Pf6Ck6ai+7hrALn7yi61qVt0MoE5Dd2KsedYA==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/clickable": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.1.9.tgz",
-      "integrity": "sha512-4uX1IRQbznPUAB3CeNZJK+wFNsGPdRt4NPz0GW7Mep6lw/A7rfyTBANBdM7hK2VMqBnIceS2goWbPftrrFIvhA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.1.8.tgz",
+      "integrity": "sha512-o17ljVD3qf2dsJqVhRX4V/xFtwJ9sAzCGcZrXV/O/dWAVDNuL8fGMdx5FileUVdFFi50w3tBuM4hxZRD5KNeGQ==",
       "requires": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/close-button": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.13.tgz",
-      "integrity": "sha512-YuTeZAJ7VyuxFlCSc7IXhC6HDSN77zWf1EKZDiFJWzpLDVVCpgf4bw7klBBWVbno2bVcHY7OPQeflcokFJ9Idg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.12.tgz",
+      "integrity": "sha512-ZuNNhkOfwFKdjUPHvwkRapCv8vto857wYYw/OtogDp6XcTYBPudeQl29nglhoI8fQAvEt7wmMZAZaTwAAW0dNQ==",
       "requires": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/color-mode": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.2.0.tgz",
-      "integrity": "sha512-8oaFYqswjqfAKeMlK15q09tkB4ZDIlWpzUlSdh2jrJs3NCBacsSadH+y9lPexdfKfhCIn7jeHk2SDd8MYBgQHA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.1.13.tgz",
+      "integrity": "sha512-IYCOfeP+5a/OFmixNN2nkcZIRwC7qNb26I7zqZ/hEQYr4gZi7FKEthKjpvZWKCwLRSNiidhkaPLzAf+lhqM/Qg==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/control-box": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.17.tgz",
-      "integrity": "sha512-q2bkaw33KEamuSXSdNxjVCYHMY7Z3lrZppD7CB2bT77uIQCTldVHEX99Qf8clTqwXuPgXDc81+/WXDAXqm1v3A==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.16.tgz",
+      "integrity": "sha512-Smkk9Olr6mhkUEktgGLw1oc4fZr58U3Ts5bMKJsTSBIRdsol+Tm3oFUzLKADD7udhMaz+7+aEx4WiTrg5tWzzA==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/counter": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.1.11.tgz",
-      "integrity": "sha512-Z3SCtvXfBdkWiRCtx8S+7URcayUY5IfYAuXQKRkpt/vNwYCGPFT5dMFy/wafHNXx0T4Oaga5qdGHqmt8BsLqBw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.1.10.tgz",
+      "integrity": "sha512-63LfIKK2duHyY9n8AfoXfwmQYkmNNaItAIB2ZNT230eTY0RwuKiAi+J4C/N9amxCB7EUw15gQphb2DjjL5D3GQ==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/css-reset": {
@@ -27456,279 +27436,279 @@
       }
     },
     "@chakra-ui/editable": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.2.11.tgz",
-      "integrity": "sha512-G8uVbtAACu11jSxoE2so2RNYyes5F0w9Yl6oqWjEKBvTJTO0lt588HduFp0uZ2ptagV/UEDiihWIr5M34orZrQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.2.10.tgz",
+      "integrity": "sha512-UYhg60F46Z4W85amYV3f4KTKjxfDL3GxcAN5d9r/E75jHrluwd4YGr/nlVhg57AhFhteiPpIdQx/NQ68KQ2KJA==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/focus-lock": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.12.tgz",
-      "integrity": "sha512-NirFUA34xxsY7tioCfYW8PCk16figLyKlYwRtHhAKfN2zajWft1XqEmmM1cQGiTo7EpbxdD24mReU1Sym2vvfQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.11.tgz",
+      "integrity": "sha512-piJwxQCxPIx5d9jPNr4aQ0BoDU1+tNecNKAoUz+U0mXa334O3DSb84cbsOjBQn9VBLV82FtmtvrF8FwrT9cl9Q==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "react-focus-lock": "2.5.0"
       }
     },
     "@chakra-ui/form-control": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.4.3.tgz",
-      "integrity": "sha512-uHulh477WgB5YYoamcNdQpH6/p+Gf2Nk1sC6YzqhG6brJAoXWRxa5oazgpUt0U/AAlA+W1rMTciUKidGxM4Hbw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.4.2.tgz",
+      "integrity": "sha512-VmoyNAh+bWj4p1ocMZDfrdJgo6pG+cgfJZ62YBSWZk7glK5ZsUNFZfd/TlxKkINKzDQyhBEEPzNjNV9TcVymmA==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/hooks": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.6.2.tgz",
-      "integrity": "sha512-B4nAMFnwS7jamugVwl6JnALZJhxf4vxyZmwY1qjVSoe3lY8ZyqssI2TI6yla4WHa7gny2beG0SXS2+gCEGtwmA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.6.1.tgz",
+      "integrity": "sha512-377Wvrt2BxpEY+1dDMsvm3J/E4GTdrxJM4fju24iUg0iFv87jg+jf6GXPsrZfdN6a9XfCCmclcmLxEH/0Trwpg==",
       "requires": {
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "compute-scroll-into-view": "1.0.14",
         "copy-to-clipboard": "3.3.1"
       }
     },
     "@chakra-ui/icon": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.13.tgz",
-      "integrity": "sha512-yVZr1YMd3YEd0toHKmLxNH4LlLQ60vzuaKYVOmAO9c/gxxPMNYM4Il260Q5W2lxOOzoimfQnZlNfTUPCwHHfUg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.12.tgz",
+      "integrity": "sha512-MVzsW+IqAYUGPjxOiEWu9kU3kl3gQ8tNONN77EyDEEcbqPOCgPOomitQ4/scmgSWWWOrAL+SvjlbykXtH8g6+Q==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/image": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.22.tgz",
-      "integrity": "sha512-+WRYWhZU0izZehwX5x52snIALd61NEY/9mHM/xWMEPl8kTivBhC6VrLv5xuhv5vJc21Witu8zuSttqF3j0V1iw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.21.tgz",
+      "integrity": "sha512-efknvUiUPEarhOAivbel89RLlYR5sA2E5vvmmbPXp348TGBiVvpxrmtfuUKZjbaF6ZBkkZsVPk6zJFE1PgwJbA==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/input": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.2.12.tgz",
-      "integrity": "sha512-eiYVXIDAWCzAUNaDfsbHcr3xLwyY3K8w1VIczjxlnEl/s9zPczKO44OuP3aM/zQ5JHio3YPkR2WLQ0/8jdBckw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.2.11.tgz",
+      "integrity": "sha512-/UaUcdSoVA2Bd9sdODnuNpK0+lI68fyigzHWe3z6lF1wmLZB546MxXxt70ZvZWsu+eJ41qBNpx81BZZ9zCJP8w==",
       "requires": {
-        "@chakra-ui/form-control": "1.4.3",
+        "@chakra-ui/form-control": "1.4.2",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/layout": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.4.11.tgz",
-      "integrity": "sha512-Aj7W89wJjWH+LPIUO+2IIeam6x+fPWOWDFczzkDwGm/2T/qMy+UJ6sO2Vs00plEvCf1yQamrdR9W3F9o1QIEEA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.4.10.tgz",
+      "integrity": "sha512-KtJOKCYyCzUBRrBRNAr9SAhvC6KtSxzIM1NynA0dJSGEVHdkeVchfoZRSNfji60T0vNVA6hVGdgBi9DjZlh02Q==",
       "requires": {
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/live-region": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.16.tgz",
-      "integrity": "sha512-U4fw8qgVfIq0xM6+LEARBlj0eiD7SY19f+/doeBaQTHwjVhQ4AflrQL6hm8jqpR7O9iHSUhW25S9yRRSfA+O9g==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.15.tgz",
+      "integrity": "sha512-Gl9q2Cb7xY68LoEo1qXGUyQp4A01Dd62apJY3Ox2RorcE7DiCQXr1KVGefiRBbcny/borbgrNVL9VcTl24ZNrA==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/media-query": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.1.5.tgz",
-      "integrity": "sha512-9Dk1oJVJT9nRB3aVx2bzUMmPwlqm9dAj0GY+L8twg8MgaebjtxXlz3xqitRfdP2Wd1M0yiK6/vyicn4qB7C6Kg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.1.3.tgz",
+      "integrity": "sha512-/LdpMTCW7PLR2uWRwTYrWK7TZZI6MmVVlCCXicqNTfx8Seu87F54pr7D/T/nkxYOM419KF/gQQjGDUxl2N6V6Q==",
       "requires": {
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/menu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.7.8.tgz",
-      "integrity": "sha512-ut4hWKjTkUfT/hew5tvx3fE1um447zLijPcrFDyUwX780/IQAGV31bcJcGSMarLbsAgBOAaVaoiwBQvL0QLe2g==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.7.6.tgz",
+      "integrity": "sha512-3O0zSvZrJmReM8iaeZ447KY4swMT/al0QJyloO7LNa3ex4uNQRw9ff5YXgKk+EURNvRwI75Lc2tEwpOHGNczWw==",
       "requires": {
-        "@chakra-ui/clickable": "1.1.9",
+        "@chakra-ui/clickable": "1.1.8",
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/modal": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.9.4.tgz",
-      "integrity": "sha512-TZ/XS/8uZwx7VCp1Lhf83U2BZNGj7djDbXJPeLp6VXZ1WYhwh1lF5A1H5RcH7WzN+kvrjv1rmSlTAXNlHTgDag==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.9.2.tgz",
+      "integrity": "sha512-5QPDca8q1YB0XgB6Whuj1B0dzRzSuYQS7demz3TOuEWHKcmNSz/hx3YprMFgEVEx0Awg3HaWomnyj7AG+m/2dQ==",
       "requires": {
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/focus-lock": "1.1.12",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/portal": "1.2.11",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/focus-lock": "1.1.11",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/portal": "1.2.10",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.4.1"
       }
     },
     "@chakra-ui/number-input": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.2.12.tgz",
-      "integrity": "sha512-0gLII6l6Nee8BH4yBDm/P6u4DIPt/TfbnRnKhuX8iAaxfC7YdOaLJFShQpa5UkQ/56Me98nb78+Zli56cc8FYg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.2.11.tgz",
+      "integrity": "sha512-tB4+SFyZrsDW3rzKoW+Wy34dQEZhqP2EMOnTflxIWxF4A66hf3Sz/6av0b6CEhlSsOd59QQd8GaT1FvHWdhz7A==",
       "requires": {
-        "@chakra-ui/counter": "1.1.11",
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
+        "@chakra-ui/counter": "1.1.10",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/pin-input": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.6.7.tgz",
-      "integrity": "sha512-lt45R03xM5cdKxG7l2uXVnxebxfFaGPxs3/Yj97lZ/yQaG8N7iYwIdPKDH26vAvBZFRZayQJTgtUcJpeK/dn0g==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.6.6.tgz",
+      "integrity": "sha512-c4C4IT+FVIVc8uX4HQLlGdWCE3WqwH5ZBv393ukd7VGOfn8G/jmgOCafn2VbW8TsAwqpvQ/IH3TUbcFI75Drkg==",
       "requires": {
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/popover": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.9.1.tgz",
-      "integrity": "sha512-MtKvtntLQ5v3N+FUa4cPjd8EVNbNCCeTd/rPDdcH7HBnPqyDndtagE+GQGjseHmXuSY3nr7X+FnSsYktD+wnBg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.8.5.tgz",
+      "integrity": "sha512-SM10pQEIRSM7Y0Ygnuv0Skzxm8NES/UP9qcrfrFLJOMjmVxf52NZBPcNA4pIMEM4ocSHq6AyCHzhTXHr8a7HpQ==",
       "requires": {
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/popper": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.3.1.tgz",
-      "integrity": "sha512-iRsJTWw27c7HN+304UxzT5tDssEsCKBsfXDL9cbgwyhs4D9GJQGqM3eJDHXvvd1DAf9WZuWzya3sjvl3YhPtPw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.3.0.tgz",
+      "integrity": "sha512-K3Bw4RqttnX6TegLCBcMIez3w8YJFhUyLIkGUH0g2OCGgOajwucryFjNpuWRwkH4xcQPHghS9OVPYxRYTB22xA==",
       "requires": {
         "@chakra-ui/react-utils": "1.1.2",
         "@popperjs/core": "2.4.4"
       }
     },
     "@chakra-ui/portal": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.2.11.tgz",
-      "integrity": "sha512-APp7L0Ql4eCHY9OkcJevuzNj/I07hOsn3aHiJmfV3o2whEWd/0P1pkEG5eTb2Gul7WS9+fxaPUL5Zzl44jxkUQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.2.10.tgz",
+      "integrity": "sha512-fK5wyZcPZ9DIYsD2fzRWMHiaI2yal54BaojKmCKyBOzC3M1QLHwHF31qbyS7xbo0f2dtzsLPUz1bC0nsTwUXmA==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/progress": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.16.tgz",
-      "integrity": "sha512-zS1GcHAPvsoCRE7A/fM28ZxVVXo5Iymv0RqXEu2p4vs5HuZnRebB0elWiDNlkrnAPVPpN+qGVz5kVnnp9QsFIw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.15.tgz",
+      "integrity": "sha512-DFKAYUjkbsfFJ8T9B5fqGHyuHQeKrCaJgPQDRr9v9th8oRhuUGuKM2mHgCfkGbQwRWwF5ViWz38tSJLOcwPGng==",
       "requires": {
-        "@chakra-ui/theme-tools": "1.2.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/theme-tools": "1.2.2",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/provider": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.6.11.tgz",
-      "integrity": "sha512-yyH9yV/V7qV0hTaY5mV02cmWIK4ouV4gEbPabKsT+tkjxA/ygw98MZ8cjUptGv7u3OIRry/7AWgmT3IU8iKm8A==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.6.9.tgz",
+      "integrity": "sha512-NS60y6AYTjngk+tNuNCvgJUo5VVSJeyzmm+3Ujvl3nKwHnsUrwvvug5XhPrZI3b3K9910BG6xk0+ptWqaHCWvQ==",
       "requires": {
         "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/portal": "1.2.11",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/portal": "1.2.10",
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/radio": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.3.13.tgz",
-      "integrity": "sha512-0bbnUYpA39WihLdYPb+xF/rDXiTvTiQCEVr75R0RTm19AmxvfnfJNdEzFb1nIfcu/uzlyFCSoe7OpPih1Pdquw==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.3.11.tgz",
+      "integrity": "sha512-pV7bIucW1N99DeNQLE54zRhgU6kD/vg7bAfNU3kHhg14xYmuB3F/4S9ad22V41nM1/g9S66kqUPmEadvhKWsXg==",
       "requires": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/react": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.6.12.tgz",
-      "integrity": "sha512-hlFZPU0ZApEbzdUoUyfr5PCX8UhO4qYmTrZRhWG4noQj/uQu5WkysSHW9k8dtBS2jGIctyY6BQjm7doaQv8Mqg==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.6.10.tgz",
+      "integrity": "sha512-eIPBRRssimuM+T1zIGtZ+2910BvjOirb85/iPfqJj2uQCCy/FGQvPUpU7QYJt30zsgyRzJGe/G7D8cJO0MFlzg==",
       "requires": {
-        "@chakra-ui/accordion": "1.3.10",
-        "@chakra-ui/alert": "1.2.9",
-        "@chakra-ui/avatar": "1.2.12",
-        "@chakra-ui/breadcrumb": "1.2.10",
-        "@chakra-ui/button": "1.4.6",
-        "@chakra-ui/checkbox": "1.5.10",
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/control-box": "1.0.17",
-        "@chakra-ui/counter": "1.1.11",
+        "@chakra-ui/accordion": "1.3.8",
+        "@chakra-ui/alert": "1.2.8",
+        "@chakra-ui/avatar": "1.2.11",
+        "@chakra-ui/breadcrumb": "1.2.9",
+        "@chakra-ui/button": "1.4.5",
+        "@chakra-ui/checkbox": "1.5.8",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/control-box": "1.0.16",
+        "@chakra-ui/counter": "1.1.10",
         "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/editable": "1.2.11",
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/image": "1.0.22",
-        "@chakra-ui/input": "1.2.12",
-        "@chakra-ui/layout": "1.4.11",
-        "@chakra-ui/live-region": "1.0.16",
-        "@chakra-ui/media-query": "1.1.5",
-        "@chakra-ui/menu": "1.7.8",
-        "@chakra-ui/modal": "1.9.4",
-        "@chakra-ui/number-input": "1.2.12",
-        "@chakra-ui/pin-input": "1.6.7",
-        "@chakra-ui/popover": "1.9.1",
-        "@chakra-ui/popper": "2.3.1",
-        "@chakra-ui/portal": "1.2.11",
-        "@chakra-ui/progress": "1.1.16",
-        "@chakra-ui/provider": "1.6.11",
-        "@chakra-ui/radio": "1.3.13",
-        "@chakra-ui/react-env": "1.0.8",
-        "@chakra-ui/select": "1.1.17",
-        "@chakra-ui/skeleton": "1.1.21",
-        "@chakra-ui/slider": "1.4.2",
-        "@chakra-ui/spinner": "1.1.14",
-        "@chakra-ui/stat": "1.1.14",
-        "@chakra-ui/switch": "1.2.13",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/table": "1.2.8",
-        "@chakra-ui/tabs": "1.5.7",
-        "@chakra-ui/tag": "1.1.14",
-        "@chakra-ui/textarea": "1.1.16",
-        "@chakra-ui/theme": "1.11.1",
-        "@chakra-ui/toast": "1.3.4",
-        "@chakra-ui/tooltip": "1.3.14",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/editable": "1.2.10",
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/image": "1.0.21",
+        "@chakra-ui/input": "1.2.11",
+        "@chakra-ui/layout": "1.4.10",
+        "@chakra-ui/live-region": "1.0.15",
+        "@chakra-ui/media-query": "1.1.3",
+        "@chakra-ui/menu": "1.7.6",
+        "@chakra-ui/modal": "1.9.2",
+        "@chakra-ui/number-input": "1.2.11",
+        "@chakra-ui/pin-input": "1.6.6",
+        "@chakra-ui/popover": "1.8.5",
+        "@chakra-ui/popper": "2.3.0",
+        "@chakra-ui/portal": "1.2.10",
+        "@chakra-ui/progress": "1.1.15",
+        "@chakra-ui/provider": "1.6.9",
+        "@chakra-ui/radio": "1.3.11",
+        "@chakra-ui/react-env": "1.0.7",
+        "@chakra-ui/select": "1.1.16",
+        "@chakra-ui/skeleton": "1.1.19",
+        "@chakra-ui/slider": "1.4.1",
+        "@chakra-ui/spinner": "1.1.13",
+        "@chakra-ui/stat": "1.1.13",
+        "@chakra-ui/switch": "1.2.11",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/table": "1.2.7",
+        "@chakra-ui/tabs": "1.5.6",
+        "@chakra-ui/tag": "1.1.13",
+        "@chakra-ui/textarea": "1.1.15",
+        "@chakra-ui/theme": "1.10.4",
+        "@chakra-ui/toast": "1.3.2",
+        "@chakra-ui/tooltip": "1.3.12",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/react-env": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.0.8.tgz",
-      "integrity": "sha512-iA5D1BgcrXrwf0XIBMdvWced+9nH312KLPeQMYHZx8i0n9YqwyJBxUhcruyaKQB+m+NRO2sjkKLLH4wnCG9dwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.0.7.tgz",
+      "integrity": "sha512-3ANGROM7wZL4lLiY5GCdslLhNv44xa4cykyBed9B/O0B0J4xqIbVCwLMV2aNSCXwwUChFgjmBsDvk0vnMvclmg==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/react-utils": {
@@ -27740,180 +27720,180 @@
       }
     },
     "@chakra-ui/select": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.17.tgz",
-      "integrity": "sha512-E+I6vZAxsmnzge8xxaj3AAuqhFEn3L3qVI/fAoA5xyjE0JgJwmrqVXYhDLBANTGnv1YoEohspEUPyc7U3LYabQ==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.16.tgz",
+      "integrity": "sha512-2Hoq5B4ukEKLOn2TEnw07EGrFLM9ZDOXQltQ4MKXmjkw0EWCE9mwGbW1FK4pp+CW0Qmp34qiYhV6mzaC09iMgQ==",
       "requires": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/skeleton": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.21.tgz",
-      "integrity": "sha512-MQwitvzPk9JN9HgcM7Ggd4AX4j8T9GpMoNatGvjyPdcHW2hUa9wiLrblhoYGaM2pN/4ww4kUwRK5O3Nvame+fg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.19.tgz",
+      "integrity": "sha512-+JoJxs28PirYmTAaPKabEPcVUWKjFqVvmN8ygK+p3poZQ6J4csCWv7DHbh2dHcvTXJFckuGqmQYFcflW11OoPg==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/media-query": "1.1.5",
-        "@chakra-ui/system": "1.7.6",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/media-query": "1.1.3",
+        "@chakra-ui/system": "1.7.4",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/slider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.4.2.tgz",
-      "integrity": "sha512-L+rNPGlmjcC1AiZ/BAgMfv+44pZS8NoWEGBkIIV3jCmGy/XMl8dkAL3EbdPHs/favQICKGsEmTV33AeAy0bVAQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.4.1.tgz",
+      "integrity": "sha512-7RwnH0bSmZD8TQi7LcK3aszG80qzawE9i0OkIfiNODBOqY3ijI5mU6rFsXJ614gJTmNYD/1z08/E3SZYeBLZHQ==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/spinner": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.14.tgz",
-      "integrity": "sha512-767yIR+RrM9iPXB77EvCrwTtaWhvR3p+vWyfPnRVEQR7kd6NDO696altdQZyUO0hVLyhr3bBPCXofSEChinFHA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.13.tgz",
+      "integrity": "sha512-LpO24XfpkG6pAdcppayNjfdSX8pSHBoi1oxNKCI6JysNgBO+HCWdaz/LaJRB6WEIXZu764XtHEB/mTMdP7edyg==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/stat": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.14.tgz",
-      "integrity": "sha512-dhE8m0JeQcDouXEJiMTlXf8QkRhfozc3vfTcyBo4p+mZs4+QXOw1/jcxsPQBzJQ0kNYV8y7LDzJp+J62FoPX1g==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.13.tgz",
+      "integrity": "sha512-XV6AMKVj/iF3pmao4wK3gnW7meH0W9yfEREA5/8vif/9exvfX6KDz/04irjnFIO/cDu7QHQKQmXTnhe1zLwvMA==",
       "requires": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/styled-system": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.13.0.tgz",
-      "integrity": "sha512-+pdJ2ZnIS2uqJhm2Lyi5asYGJnwrZcFH/4rje18e6wh39Y937EDr0XRuwqbqL9Lk2C4G1H/M1br0cAmO85kHIw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.12.3.tgz",
+      "integrity": "sha512-Rgan47tBgqvE6K6wKEMjRpK/pM+6aHvn18MoZFWcrMCMfd7QxGuhI9MHaQP8b20i11bjtTlUd6AGs3PEMl6ZyQ==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "csstype": "^3.0.6"
       }
     },
     "@chakra-ui/switch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.2.13.tgz",
-      "integrity": "sha512-nD9Sm+d2NfI6sVA9Y14az3yHdCUMkk+h0n7pDughI2p3VMlG196li/bI8BSwnIa8y4XtpARSACo5dx8tWnOD1Q==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.2.11.tgz",
+      "integrity": "sha512-3cZmLR0dQLQSrGQ8lJgsdxUNrek8ZpMdA8pzFASKOhge3goeHsbiyxFutbYagBYLmS573kFVHu/o/RDVnP5xxA==",
       "requires": {
-        "@chakra-ui/checkbox": "1.5.10",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/checkbox": "1.5.8",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/system": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.7.6.tgz",
-      "integrity": "sha512-83h5Ky+Ks8ddeU77ozwZlyxU1+ESysmrJ0bGCohmD69LxUZHUrcK4csUOJl9AuZioufoQdYvR3xUJFEM8v0d2w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.7.4.tgz",
+      "integrity": "sha512-YZMPP+OCuV5edxXuwDPP7TEVl13Kziq0vf/GjgnCizcgUImSRL9eUaPcF4INvGbvS/rcAeG9mZn26DMpFwVV7g==",
       "requires": {
-        "@chakra-ui/color-mode": "1.2.0",
+        "@chakra-ui/color-mode": "1.1.13",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/styled-system": "1.13.0",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/styled-system": "1.12.3",
+        "@chakra-ui/utils": "1.8.3",
         "react-fast-compare": "3.2.0"
       }
     },
     "@chakra-ui/table": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.2.8.tgz",
-      "integrity": "sha512-Ra6qM+8osM6EwGidn9jrzdIufo5tQ8WMJkuXyv9mByjJnzbr2EOQqexHHA8AwCMsxaFieWBG9QPuuDWavl8ptQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.2.7.tgz",
+      "integrity": "sha512-fx7Hl1I16DCCD/pPBtkH/gl6ielUkLg8qQfPJ+5nbE8xrRM5Nxp2RqFuuFrJ0qGLZ+OZrshPm9r86JVrS6ZmOw==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/tabs": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.5.7.tgz",
-      "integrity": "sha512-+z9FsdY9Qukp9nShgh+LR/cMJGzwhGdgmav/AX/P/f/C/32PFYhmBZrKobHJwozYZeDebBeb8zhxqV8VROrfRQ==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.5.6.tgz",
+      "integrity": "sha512-s83Bosv7aQkcE6ufaAx6yRur8bV2uIuVAaTczMv4oxH/5OU2wNwA4rGbdiPbrxDf9M8M0AuH/mqJ+2uSu7Vdxg==",
       "requires": {
-        "@chakra-ui/clickable": "1.1.9",
+        "@chakra-ui/clickable": "1.1.8",
         "@chakra-ui/descendant": "2.0.1",
-        "@chakra-ui/hooks": "1.6.2",
+        "@chakra-ui/hooks": "1.6.1",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/tag": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.14.tgz",
-      "integrity": "sha512-FfROxP2WJIimYWr6IRuLnJlH6an4QoJvXMO98yQYSXqycsOcuVNA+XP3aRCa6+o9qcL95AqkAidkpXSd8+sHsw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.13.tgz",
+      "integrity": "sha512-p1BxgqFnDzVFQrBJ1EItM+BCNjfJ9vCjg5lQK13JeLWHa6kHR+2agzNgxH+F9jzhKGY17BHroc2YYW4yKzD61Q==",
       "requires": {
-        "@chakra-ui/icon": "1.1.13",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/icon": "1.1.12",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/textarea": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.16.tgz",
-      "integrity": "sha512-wXYmZSsoYspH3Rtzhb9joysIfzHlegds9ABlBeuothYqz6HEQg7+DiTIdVmqtMydExdU+fhxuhwQ/EIGXCronA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.15.tgz",
+      "integrity": "sha512-q6yvyEdZ+72Gq6eE76vJxCo5aZcYdiORJHTmELtJWo4h+a1ASd8OBdIkygbvqKnT/jssnH2b2S9kFf8EcEPkMg==",
       "requires": {
-        "@chakra-ui/form-control": "1.4.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/form-control": "1.4.2",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/theme": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.11.1.tgz",
-      "integrity": "sha512-0E4Vb6AP/W400nj9qDUhT+LPzpz2fi99lBCffIwR53m9t+xWjWWdB7saXJ2Np1xKdkhGbzSpcn3Fo8Q3CzVM7w==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.10.4.tgz",
+      "integrity": "sha512-FaO5Qr1oGP+1JoCIotoqWT9RF0aguXmKjgz+4xDM8E+Gct6juuj+td43NfzeXr/FJXiXjL8u1G4RWxAeR2FxZQ==",
       "requires": {
-        "@chakra-ui/anatomy": "1.1.0",
-        "@chakra-ui/theme-tools": "1.2.3",
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/anatomy": "1.0.1",
+        "@chakra-ui/theme-tools": "1.2.2",
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/theme-tools": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.2.3.tgz",
-      "integrity": "sha512-4vYW5KiJHRpqiuAw6opDMdIOMywL47gCtFiOP1CwwObXxrHetEHyJvMt9qnx+AfSMyCFGyHz8sFjDmLc+v/jEA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.2.2.tgz",
+      "integrity": "sha512-+2xPTW7/rFr++Qu/ibZsM1dq5qmvvjg6+Af4SRZw1AvjGq4CTxuV7upXo5zJM3Q3OgzOtU9Q9RATap3fhEHkyA==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/utils": "1.8.3",
         "@ctrl/tinycolor": "^3.4.0"
       }
     },
     "@chakra-ui/toast": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.3.4.tgz",
-      "integrity": "sha512-0RMMldpvtita0zfFE5Jwp9JphUVL2P8jDfoiPJrqKD6K/7vT4dj3PyWhiIedes4yv4SM/dI3dnXKA8fChQaotQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.3.2.tgz",
+      "integrity": "sha512-uREAV+UoPvbTktQXgGhaExOX4RIKAlj54K9yOojO2FOBDCywtq0TdlI4eMk/dZvlz2SIuTWveK/C4CHBBbcd4Q==",
       "requires": {
-        "@chakra-ui/alert": "1.2.9",
-        "@chakra-ui/close-button": "1.1.13",
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/theme": "1.11.1",
-        "@chakra-ui/transition": "1.3.8",
-        "@chakra-ui/utils": "1.8.4",
+        "@chakra-ui/alert": "1.2.8",
+        "@chakra-ui/close-button": "1.1.12",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/theme": "1.10.4",
+        "@chakra-ui/transition": "1.3.6",
+        "@chakra-ui/utils": "1.8.3",
         "@reach/alert": "0.13.2"
       }
     },
     "@chakra-ui/tooltip": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.3.14.tgz",
-      "integrity": "sha512-P7npmVnCcGdTxwbf8lIHcsvpPdLpQLgyOcdEykJd6iSEb33SquVK2RULrktawn/NqbAohulUrvVoIHDhY9j92A==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.3.12.tgz",
+      "integrity": "sha512-zF4pWU//9YSIR3D9cljO+BNlYettKXqgVermTg8z7KvKMmgH+Ni99OA7aWQ6g3vii9LzJryi5kUdxfApoLCm9Q==",
       "requires": {
-        "@chakra-ui/hooks": "1.6.2",
-        "@chakra-ui/popper": "2.3.1",
-        "@chakra-ui/portal": "1.2.11",
+        "@chakra-ui/hooks": "1.6.1",
+        "@chakra-ui/popper": "2.3.0",
+        "@chakra-ui/portal": "1.2.10",
         "@chakra-ui/react-utils": "1.1.2",
-        "@chakra-ui/utils": "1.8.4",
-        "@chakra-ui/visually-hidden": "1.0.16"
+        "@chakra-ui/utils": "1.8.3",
+        "@chakra-ui/visually-hidden": "1.0.15"
       }
     },
     "@chakra-ui/transition": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.3.8.tgz",
-      "integrity": "sha512-YvcHkazYUIBaew5dfrts9Wp6/LPhHgbJoRYrKHBcfsDU+a63g/HoN4SCB19B46+pV3L6Fg4VPnOIED7KL7uoXg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.3.6.tgz",
+      "integrity": "sha512-P6H88iHWwElGpqrH3RoEhWTZToFw3ZQx2XyJhVUHNroavkxQ48wyRcoFIQ/btKAInQ+5xyyKISRLZlvAuy6ONg==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@chakra-ui/utils": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.8.4.tgz",
-      "integrity": "sha512-lMk+FD70zgI8Fn6Ee5h6T2FJdJLnYIYaRQI+Au5izjl8e3V2OZ/Tdi72LW9FnHlQyFZ5N24HGefZlNxOEDUjmw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.8.3.tgz",
+      "integrity": "sha512-v184c2TYwQYBEcDI/9C1DjN668jZVTJeb/DPtucAjEHNi4T0py3tjGDbUd05LoNoZ64uijtWYanfrr6Abe4m1Q==",
       "requires": {
         "@types/lodash.mergewith": "4.6.6",
         "css-box-model": "1.2.1",
@@ -27922,11 +27902,11 @@
       }
     },
     "@chakra-ui/visually-hidden": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.16.tgz",
-      "integrity": "sha512-UQfSepguq/A0OzhW6tzBspLim8nMlG4G1pFeQRyuGAqJnoh1fCk749jcv32+FDBaeI60JGMCap6LcYgarxpt3A==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.15.tgz",
+      "integrity": "sha512-/qGI47YamrgazFt9KS4YxIt5U2/RT6jxdjHj1Tn3D2clivB1n+H+v5fQC9xFfjm7ul0QZwEhBrYhynqr5ybZkg==",
       "requires": {
-        "@chakra-ui/utils": "1.8.4"
+        "@chakra-ui/utils": "1.8.3"
       }
     },
     "@cnakazawa/watch": {
@@ -29777,9 +29757,9 @@
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
     },
     "@types/lodash": {
-      "version": "4.14.176",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
-      "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+      "version": "4.14.175",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
     },
     "@types/lodash.mergewith": {
       "version": "4.6.6",
@@ -34934,16 +34914,16 @@
       }
     },
     "framer-motion": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.2.0.tgz",
-      "integrity": "sha512-268cYeh0GNWm26nqicXGuAZOlodvR/huY6KGAP5NuoRhrGnDTv5jgCGt9pZelk6qXsBGPEUMqE6xaYYpTSaHmg==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "peer": true,
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "framesync": "6.0.1",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "11.0.0",
-        "style-value-types": "5.0.0",
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -34963,15 +34943,6 @@
           "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
           "optional": true,
           "peer": true
-        },
-        "framesync": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
         }
       }
     },
@@ -40492,26 +40463,15 @@
       }
     },
     "popmotion": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.0.tgz",
-      "integrity": "sha512-kJDyaG00TtcANP5JZ51od+DCqopxBm2a/Txh3Usu23L9qntjY5wumvcVf578N8qXEHR1a+jx9XCv8zOntdYalQ==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "peer": true,
       "requires": {
-        "framesync": "^6.0.1",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
+        "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "framesync": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "portfinder": {
@@ -43901,9 +43861,9 @@
       }
     },
     "style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
       "peer": true,
       "requires": {
         "hey-listen": "^1.0.8",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@chakra-ui/react": "^1.6.12",
+    "@chakra-ui/react": "^1.6.10",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
     "@fullstory/browser": "^1.4.9",


### PR DESCRIPTION
This version introduces a bug that ignores applilcation preferences for light/dark mode, always setting to system/browser default[^1].
Reverts opengovsg/askgovsg#724


[^1]: chakra-ui/chakra-ui#4987