### PR TITLE
fix(server): refactor server code to only read index file when needed

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -183,18 +183,6 @@ const apiOptions = {
   enquiries: new EnquiryController({ enquiryService, recaptchaService }),
 }
 
-const index = fs.readFileSync(
-  path.resolve(__dirname, '../../..', 'client', 'build', 'index.html'),
-)
-
-const webController = new WebController({
-  agencyService,
-  answersService,
-  postService,
-  webService: new WebService(),
-  index,
-})
-
 const moduleLogger = createLogger(module)
 
 if (baseConfig.nodeEnv === Environment.Prod) {
@@ -250,6 +238,18 @@ if (baseConfig.nodeEnv === Environment.Prod) {
       },
     }),
   )
+
+  const index = fs.readFileSync(
+    path.resolve(__dirname, '../../..', 'client', 'build', 'index.html'),
+  )
+
+  const webController = new WebController({
+    agencyService,
+    answersService,
+    postService,
+    webService: new WebService(),
+    index,
+  })
 
   app.use('/', routeWeb({ controller: webController }))
 


### PR DESCRIPTION
## Problem

Client build is required when running development environment as the server tries to find the index.html file from it. This causes the server to crash when client is not built. Mentioned by @mdonoughe in https://github.com/opengovsg/askgovsg/pull/703#discussion_r739934554.

## Solution

- shift index and webController into code block which only runs in production environment

## Tests

Ensure that there is no `build` directory in `client` then run `npm run dev`.
