### PR TITLE
feat(search): add opensearch-mock for better testing

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
   moduleNameMapper: {
     '~shared/(.*)': '<rootDir>/../shared/build/$1',
   },
+  testPathIgnorePatterns: [
+    '<rootDir>/src/modules/search/__tests__/opensearch-mock',
+  ],
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -80,6 +80,8 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "find-my-way": "^4.3.3",
+        "into-stream": "^6.0.0",
         "jest": "^27.3.1",
         "lint-staged": "^11.2.6",
         "neat-csv": "^7.0.0",
@@ -6377,24 +6379,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8041,6 +8025,12 @@
         "node >=0.6.0"
       ]
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8197,6 +8187,21 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/find-my-way": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz",
+      "integrity": "sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==",
+      "dev": true,
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "safe-regex2": "^2.0.0",
+        "semver-store": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/find-node-modules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
@@ -8334,6 +8339,16 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "node_modules/fs-extra": {
@@ -9121,6 +9136,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dev": true,
+      "dependencies": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/invert-kv": {
@@ -12968,6 +12999,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -13052,6 +13092,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-passwd": {
@@ -13724,6 +13782,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/retry-as-promised": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
@@ -13805,6 +13872,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dev": true,
+      "dependencies": {
+        "ret": "~0.2.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -13875,6 +13951,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "node_modules/semver-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
+      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
       "dev": true
     },
     "node_modules/send": {
@@ -21483,20 +21565,6 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        }
       }
     },
     "create-require": {
@@ -22763,6 +22831,12 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -22899,6 +22973,18 @@
         }
       }
     },
+    "find-my-way": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz",
+      "integrity": "sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==",
+      "dev": true,
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "safe-regex2": "^2.0.0",
+        "semver-store": "^0.3.0"
+      }
+    },
     "find-node-modules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
@@ -22999,6 +23085,16 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -23592,6 +23688,16 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dev": true,
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
       }
     },
     "invert-kv": {
@@ -26528,6 +26634,12 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
+    "p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -26584,6 +26696,18 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parse-passwd": {
@@ -27087,6 +27211,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true
+    },
     "retry-as-promised": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
@@ -27137,6 +27267,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dev": true,
+      "requires": {
+        "ret": "~0.2.0"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -27195,6 +27334,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
+      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
       "dev": true
     },
     "send": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.40.0",
+        "@opensearch-project/opensearch": "^1.0.0",
         "axios": "^0.24.0",
         "bcrypt": "^5.0.0",
         "bcryptjs": "^2.4.3",
@@ -3698,6 +3699,25 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@opensearch-project/opensearch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-1.0.0.tgz",
+      "integrity": "sha512-vLZTwQtUtDhtSVMfqV1DsfC8u0DKtwKtUvBXvCGeUY2/gdu/FyiQQr/nucdGGPnXLTT6SRWQmeiIVhhbx+Ocwg==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "hpagent": "^0.1.1",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@opensearch-project/opensearch/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -8751,6 +8771,11 @@
       "optionalDependencies": {
         "unix-dgram": "2.0.x"
       }
+    },
+    "node_modules/hpagent": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -13826,6 +13851,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "node_modules/semver": {
       "version": "7.3.5",
@@ -19265,6 +19295,24 @@
         "fastq": "^1.6.0"
       }
     },
+    "@opensearch-project/opensearch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-1.0.0.tgz",
+      "integrity": "sha512-vLZTwQtUtDhtSVMfqV1DsfC8u0DKtwKtUvBXvCGeUY2/gdu/FyiQQr/nucdGGPnXLTT6SRWQmeiIVhhbx+Ocwg==",
+      "requires": {
+        "debug": "^4.3.1",
+        "hpagent": "^0.1.1",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -23279,6 +23327,11 @@
         "unix-dgram": "2.0.x"
       }
     },
+    "hpagent": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -27124,6 +27177,11 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "semver": {
       "version": "7.3.5",

--- a/server/package.json
+++ b/server/package.json
@@ -87,6 +87,8 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "find-my-way": "^4.3.3",
+    "into-stream": "^6.0.0",
     "jest": "^27.3.1",
     "lint-staged": "^11.2.6",
     "neat-csv": "^7.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.40.0",
+    "@opensearch-project/opensearch": "^1.0.0",
     "axios": "^0.24.0",
     "bcrypt": "^5.0.0",
     "bcryptjs": "^2.4.3",

--- a/server/src/modules/search/__tests__/opensearch-mock/LICENSE
+++ b/server/src/modules/search/__tests__/opensearch-mock/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Elastic and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/server/src/modules/search/__tests__/opensearch-mock/index.js
+++ b/server/src/modules/search/__tests__/opensearch-mock/index.js
@@ -1,0 +1,263 @@
+/**
+ * Modifications made by AskGov Contributors:
+ * - Replaced '@elastic/elasticsearch' import with '@opensearch-project/opensearch'
+ * - Replaced router symbol 'elasticsearch-mock-router' with 'opensearch-mock-router'
+ * - Replaced ElasticsearchClientError with OpenSearchClientError
+ * - Removed 'x-elastic-product' field from stream header
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+ * See the LICENSE file in directory or at http://www.apache.org/licenses/LICENSE-2.0
+ * for more information.
+ */
+
+'use strict'
+
+/* eslint-disable */
+const { gunzip, createGunzip } = require('zlib')
+const querystring = require('querystring')
+const { Connection, errors } = require('@opensearch-project/opensearch')
+const Router = require('find-my-way')
+const intoStream = require('into-stream')
+const equal = require('fast-deep-equal')
+const kRouter = Symbol('opensearch-mock-router')
+/* eslint-enable */
+
+const noop = () => {} // eslint-disable-line
+const {
+  ConfigurationError,
+  ConnectionError,
+  ResponseError,
+  RequestAbortedError,
+  OpenSearchClientError,
+} = errors
+
+class Mocker {
+  constructor() {
+    this[kRouter] = Router({ ignoreTrailingSlash: true })
+  }
+
+  add(pattern, fn) {
+    for (const key of ['method', 'path']) {
+      if (Array.isArray(pattern[key])) {
+        for (const value of pattern[key]) {
+          this.add({ ...pattern, [key]: value }, fn)
+        }
+        return this
+      }
+    }
+
+    if (typeof pattern.method !== 'string')
+      throw new ConfigurationError('The method is not defined')
+    if (typeof pattern.path !== 'string')
+      throw new ConfigurationError('The path is not defined')
+    if (typeof fn !== 'function')
+      throw new ConfigurationError('The resolver function is not defined')
+
+    const handler = this[kRouter].find(pattern.method, pattern.path)
+    if (handler) {
+      handler.store.push({ ...pattern, fn })
+      // order the patterns in descending order, so we will match
+      // more precise patterns first and the loose ones
+      handler.store.sort(
+        (a, b) => Object.keys(b).length - Object.keys(a).length,
+      )
+    } else {
+      // eslint-disable-next-line
+      this[kRouter].on(pattern.method, pattern.path, noop, [{ ...pattern, fn }])
+    }
+    return this
+  }
+
+  get(params) {
+    const handler = this[kRouter].find(params.method, params.path)
+    if (!handler) return null
+    for (const { body, querystring, fn } of handler.store) {
+      if (body !== undefined && querystring !== undefined) {
+        if (
+          equal(params.body, body) &&
+          equal(params.querystring, querystring)
+        ) {
+          return fn
+        }
+      } else if (body !== undefined && querystring === undefined) {
+        if (equal(params.body, body)) {
+          return fn
+        }
+      } else if (body === undefined && querystring !== undefined) {
+        if (equal(params.querystring, querystring)) {
+          return fn
+        }
+      } else {
+        return fn
+      }
+    }
+    return null
+  }
+
+  clear(pattern) {
+    for (const key of ['method', 'path']) {
+      if (Array.isArray(pattern[key])) {
+        for (const value of pattern[key]) {
+          this.clear({ ...pattern, [key]: value })
+        }
+        return this
+      }
+    }
+
+    if (typeof pattern.method !== 'string')
+      throw new ConfigurationError('The method is not defined')
+    if (typeof pattern.path !== 'string')
+      throw new ConfigurationError('The path is not defined')
+
+    this[kRouter].off(pattern.method, pattern.path)
+    return this
+  }
+
+  clearAll() {
+    this[kRouter].reset()
+    return this
+  }
+
+  getConnection() {
+    return buildConnectionClass(this)
+  }
+}
+
+function buildConnectionClass(mocker) {
+  class MockConnection extends Connection {
+    request(params, callback) {
+      let aborted = false
+      normalizeParams(params, prepareResponse)
+
+      function prepareResponse(error, params) {
+        if (aborted) {
+          return callback(new RequestAbortedError(), null)
+        }
+        if (error) {
+          return callback(new ConnectionError(error.message), null)
+        }
+
+        let stream = null
+        let payload = ''
+        let statusCode = 200
+
+        const resolver = mocker.get(params)
+
+        if (resolver === null) {
+          // return info route for product check unless configured otherwise
+          if (params.method === 'GET' && params.path === '/') {
+            payload = { version: { number: '8.0.0-SNAPSHOT' } }
+          } else {
+            payload = { error: 'Mock not found' }
+            statusCode = 404
+          }
+          stream = intoStream(JSON.stringify(payload))
+        } else {
+          payload = resolver(params)
+          if (payload instanceof ResponseError) {
+            statusCode = payload.statusCode
+            payload = payload.body
+          } else if (payload instanceof OpenSearchClientError) {
+            return callback(payload, null)
+          }
+          stream = intoStream(
+            typeof payload === 'string' ? payload : JSON.stringify(payload),
+          )
+        }
+
+        stream.statusCode = statusCode
+        stream.headers = {
+          'content-type':
+            typeof payload === 'string'
+              ? 'text/plain;utf=8'
+              : 'application/json;utf=8',
+          date: new Date().toISOString(),
+          connection: 'keep-alive',
+          'content-length': Buffer.byteLength(
+            typeof payload === 'string' ? payload : JSON.stringify(payload),
+          ),
+        }
+
+        callback(null, stream)
+      }
+
+      return {
+        abort() {
+          aborted = true
+        },
+      }
+    }
+  }
+
+  return MockConnection
+}
+
+function normalizeParams(params, callback) {
+  const normalized = {
+    method: params.method,
+    path: params.path,
+    body: null,
+    // querystring.parse returns a null object prototype
+    // which break the fast-deep-equal algorithm
+    querystring: { ...querystring.parse(params.querystring) },
+  }
+
+  const compression =
+    (params.headers['Content-Encoding'] ||
+      params.headers['content-encoding']) === 'gzip'
+  const type =
+    params.headers['Content-Type'] || params.headers['content-type'] || ''
+
+  if (isStream(params.body)) {
+    normalized.body = ''
+    const stream = compression ? params.body.pipe(createGunzip()) : params.body
+    stream.on('error', (err) => callback(err, null))
+    stream.on('data', (chunk) => {
+      normalized.body += chunk
+    })
+    stream.on('end', () => {
+      normalized.body = type.includes('x-ndjson')
+        ? normalized.body
+            .split(/\n|\n\r/)
+            .filter(Boolean)
+            .map((l) => JSON.parse(l))
+        : JSON.parse(normalized.body)
+      callback(null, normalized)
+    })
+  } else if (params.body) {
+    if (compression) {
+      gunzip(params.body, (err, buffer) => {
+        if (err) {
+          return callback(err, null)
+        }
+        buffer = buffer.toString()
+        normalized.body = type.includes('x-ndjson')
+          ? buffer
+              .split(/\n|\n\r/)
+              .filter(Boolean)
+              .map((l) => JSON.parse(l))
+          : JSON.parse(buffer)
+        callback(null, normalized)
+      })
+    } else {
+      normalized.body = type.includes('x-ndjson')
+        ? params.body
+            .split(/\n|\n\r/)
+            .filter(Boolean)
+            .map((l) => JSON.parse(l))
+        : JSON.parse(params.body)
+      setImmediate(callback, null, normalized)
+    }
+  } else {
+    setImmediate(callback, null, normalized)
+  }
+}
+
+function isStream(obj) {
+  return obj != null && typeof obj.pipe === 'function'
+}
+
+module.exports = {
+  Mocker,
+}

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -1,0 +1,128 @@
+import { Client } from '@opensearch-project/opensearch'
+import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { createLogger } from '../../bootstrap/logging'
+
+const logger = createLogger(module)
+
+export type SearchEntry = {
+  title: string
+  description: string | null
+  answer: string
+  agencyId: number
+  postId: number
+  topicId: number | null
+}
+
+export class SearchService {
+  private client: Client
+
+  constructor({ client }: { client: Client }) {
+    this.client = client
+  }
+
+  indexAllData = async (
+    indexName: string,
+    searchEntriesDataset: SearchEntry[],
+  ) => {
+    return ResultAsync.fromPromise(
+      this.client.indices.create({
+        index: indexName,
+      }),
+      (err) => {
+        logger.error({
+          message:
+            'Error while indexing data for OpenSearch - client.indices.create',
+          meta: {
+            function: 'indexAllData',
+          },
+          error: err,
+        })
+        return err as ResponseError
+      },
+    ).andThen((_) => {
+      const body = searchEntriesDataset.flatMap((doc) => [
+        { index: { _index: indexName } },
+        doc,
+      ])
+      return ResultAsync.fromPromise(
+        this.client.bulk({
+          refresh: true,
+          body,
+        }),
+        (err) => {
+          logger.error({
+            message: 'Error while indexing data for OpenSearch - client.bulk',
+            meta: {
+              function: 'indexAllData',
+            },
+            error: err,
+          })
+          return err as ResponseError
+        },
+      ).andThen(({ body: bulkResponse }) => {
+        if (bulkResponse.errors) {
+          const erroredDocuments: {
+            // If the status is 429 it means that you can retry the document,
+            // otherwise it's very likely a mapping error, and you should
+            // fix the document before to try it again.
+            status: any
+            error: any
+            operation:
+              | {
+                  title: string
+                  description: string | null
+                  answer: string
+                  agencyId: number
+                  postId: number
+                  topicId: number | null
+                }
+              | { index: { _index: string } }
+            document:
+              | {
+                  title: string
+                  description: string | null
+                  answer: string
+                  agencyId: number
+                  postId: number
+                  topicId: number | null
+                }
+              | { index: { _index: string } }
+          }[] = []
+          // The items array has the same order of the dataset we just indexed.
+          // The presence of the `error` key indicates that the operation
+          // that we did for the document has failed.
+          bulkResponse.items.forEach(
+            (
+              action: { [x: string]: { status: any; error: any } },
+              i: number,
+            ) => {
+              const operation = Object.keys(action)[0]
+              if (action[operation].error) {
+                erroredDocuments.push({
+                  // If the status is 429 it means that you can retry the document,
+                  // otherwise it's very likely a mapping error, and you should
+                  // fix the document before to try it again.
+                  status: action[operation].status,
+                  error: action[operation].error,
+                  operation: body[i * 2],
+                  document: body[i * 2 + 1],
+                })
+              }
+            },
+          )
+          logger.error({
+            message:
+              'Error while indexing data for OpenSearch - client.bulk (some operations)',
+            meta: {
+              function: 'indexAllData',
+            },
+            error: erroredDocuments,
+          })
+          return errAsync(erroredDocuments)
+        }
+        return okAsync(bulkResponse)
+      })
+    })
+  }
+}

--- a/server/src/modules/web/__tests__/web.service.spec.ts
+++ b/server/src/modules/web/__tests__/web.service.spec.ts
@@ -23,7 +23,7 @@ describe('WebService', () => {
   const index = Buffer.from(indexStr)
 
   describe('getAgencyPage', () => {
-    it('should return correctly modified agency index', async () => {
+    it('should return correctly modified agency index', () => {
       const agencyShortname = 'agency_shortname'
       const agencyLongname = 'agency_longname'
 
@@ -75,7 +75,7 @@ describe('WebService', () => {
   })
 
   describe('getQuestionPage', () => {
-    it('should return correctly modified post index', async () => {
+    it('should return correctly modified post index', () => {
       const postTitle = 'post_title'
       const postDescription = 'post_description'
 


### PR DESCRIPTION
## Problem

Unable to test opensearch-related code in an isolated way.

Closes #743

## Solution

Implement an opensearch mock adapted from @elastic/elasticsearch-mock. Includes implementation of search service to index all data as well.

Note: Check comments for appropriate use of licensed code by elastic.

## Tests

Try running search related tests when they are out.

## Deploy Notes

**New dev dependencies**:

- `find-my-way`: "^4.3.3",
- `into-stream`: "^6.0.0",
