### PR TITLE
test(topics): add test coverage

### DIFF
--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -2,27 +2,13 @@ import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import supertest from 'supertest'
 import { TopicsController } from '../topics.controller'
+import { ControllerHandler } from '../../../types/response-handler'
 import { errAsync, okAsync } from 'neverthrow'
 import { MissingTopicError } from '../topics.errors'
 import { DatabaseError } from '../../core/core.errors'
 
 describe('TopicsController', () => {
-  const agency = {
-    id: 1,
-    shortname: 'was',
-    longname: 'Work Allocation Singapore',
-    email: 'enquiries@was.gov.sg',
-    logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
-  }
-
-  const mockTopic = {
-    id: 1,
-    name: '1',
-    description: '',
-    agencyId: 1,
-    parentId: null,
-  }
-
+  const path = '/topics'
   const authService = {
     checkIfWhitelistedOfficer: jest.fn(),
     hasPermissionToAnswer: jest.fn(),
@@ -46,69 +32,421 @@ describe('TopicsController', () => {
     topicsService,
   })
 
-  const app = express()
-  app.get('/:agencyId', topicsController.listTopicsUsedByAgency)
-  const request = supertest(app)
+  // Set up auth middleware to inject user
+  let user: Express.User | undefined = { id: 1 }
+  const middleware: ControllerHandler = (req, res, next) => {
+    req.user = user
+    next()
+  }
+
+  const noErrors: { errors: () => { msg: string }[] }[] = []
+  let errors: { errors: () => { msg: string }[] }[] = noErrors
+  const invalidateIfHasErrors: ControllerHandler = (req, _res, next) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    req['express-validator#contexts'] = errors
+    next()
+  }
+
+  const mockAgency = {
+    id: 1,
+    shortname: 'was',
+    longname: 'Work Allocation Singapore',
+    email: 'enquiries@was.gov.sg',
+    logo: 'https://logos.ask.gov.sg/askgov-logo.svg',
+  }
+
+  const mockTopicId = 1
+  const mockTopic = {
+    name: '1',
+    description: '',
+    agencyId: 1,
+    parentId: null,
+  }
 
   beforeEach(() => {
-    topicsService.findOneById.mockReset()
-    topicsService.listTopicsUsedByAgency.mockReset()
-    topicsService.createTopic.mockReset()
-    topicsService.deleteTopicById.mockReset()
-    topicsService.updateTopicById.mockReset()
-    topicsService.listTopics.mockReset()
-    topicsService.getTopicById.mockReset()
-    topicsService.listTopicsUsedByAgency.mockReturnValue(okAsync(mockTopic))
+    user = { id: 1 }
+    jest.resetAllMocks()
   })
 
   afterEach(async () => {
     jest.clearAllMocks()
   })
 
-  describe('listTopicsUsedByAgency', () => {
-    it('should return 200 on successful data retrieval', async () => {
-      const agencyId = `${agency.id}`
+  describe('getTopicById', () => {
+    const app = express()
+    app.use(express.json())
+    app.use(middleware)
+    app.get(path + '/:topicId', topicsController.getTopicById)
+    const request = supertest(app)
 
-      const response = await request.get(`/${agencyId}`)
+    it('returns OK on valid query', async () => {
+      topicsService.getTopicById.mockReturnValue(okAsync(mockTopic))
+      const response = await request.get(path + `/${mockTopicId}`)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(mockTopic)
+      expect(topicsService.getTopicById).toHaveBeenCalledWith(mockTopicId)
+    })
+  })
+
+  describe('listTopicsUsedByAgency', () => {
+    const app = express()
+    app.use(express.json())
+    app.use(middleware)
+    app.get(
+      '/agencies/:agencyId/topics',
+      topicsController.listTopicsUsedByAgency,
+    )
+    const request = supertest(app)
+
+    it('should return 200 on successful data retrieval', async () => {
+      const agencyId = mockAgency.id
+      topicsService.listTopicsUsedByAgency.mockReturnValue(okAsync(mockTopic))
+
+      const response = await request.get(`/agencies/${agencyId}/topics`)
 
       expect(response.status).toEqual(StatusCodes.OK)
       expect(response.body).toStrictEqual(mockTopic)
       expect(topicsService.listTopicsUsedByAgency).toHaveBeenCalledWith(
-        Number(agencyId),
+        agencyId,
       )
     })
 
     it('returns NOT_FOUND on invalid query', async () => {
-      const agencyId = `${agency.id}`
+      const agencyId = mockAgency.id
 
       topicsService.listTopicsUsedByAgency.mockReturnValue(
         errAsync(new MissingTopicError()),
       )
 
-      const response = await request.get(`/${agencyId}`)
+      const response = await request.get(`/agencies/${agencyId}/topics`)
 
       expect(response.status).toEqual(StatusCodes.NOT_FOUND)
       expect(response.body).toStrictEqual({ message: 'Topic not found' })
       expect(topicsService.listTopicsUsedByAgency).toHaveBeenCalledWith(
-        Number(agencyId),
+        agencyId,
       )
     })
 
     it('returns INTERNAL_SERVER_ERROR', async () => {
-      const agencyId = `${agency.id}`
+      const agencyId = mockAgency.id
 
       topicsService.listTopicsUsedByAgency.mockReturnValue(
         errAsync(new DatabaseError()),
       )
 
-      const response = await request.get(`/${agencyId}`)
+      const response = await request.get(`/agencies/${agencyId}/topics`)
 
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(topicsService.listTopicsUsedByAgency).toHaveBeenCalledWith(
-        Number(agencyId),
+        agencyId,
       )
     })
   })
 
-  //TODO: add remaining unit tests for createTopic, deleteTopic, updateTopic
+  describe('createTopic', () => {
+    beforeEach(() => {
+      authService.hasPermissionToAnswer.mockReset()
+      topicsService.createTopic.mockReset()
+      errors = noErrors
+    })
+    it('returns 401 on no user', async () => {
+      user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.post(path, topicsController.createTopic)
+      const request = supertest(app)
+
+      const response = await request.post(path)
+
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
+      expect(response.body).toStrictEqual({
+        message: 'User not signed in',
+      })
+      expect(topicsService.createTopic).not.toHaveBeenCalled()
+    })
+    it('returns 403 on user from a different agency', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(false)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.post(path, topicsController.createTopic)
+      const request = supertest(app)
+
+      const response = await request.post(path)
+      expect(response.status).toEqual(StatusCodes.FORBIDDEN)
+      expect(response.body).toStrictEqual({
+        message: 'You do not have permission to create this topic',
+      })
+      expect(topicsService.createTopic).not.toHaveBeenCalled()
+    })
+    it('returns 400 on bad request', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(true)
+
+      errors = [
+        {
+          errors: () => [
+            {
+              msg: 'Validation Error',
+            },
+          ],
+        },
+      ]
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.post(path, topicsController.createTopic)
+      const request = supertest(app)
+
+      const response = await request.post(path).send(mockTopic)
+
+      expect(response.status).toEqual(StatusCodes.BAD_REQUEST)
+      expect(topicsService.createTopic).not.toHaveBeenCalled()
+    })
+    it('returns 500 on topicsService problem', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(true)
+      topicsService.createTopic.mockReturnValue(errAsync(new DatabaseError()))
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.post(path, topicsController.createTopic)
+      const request = supertest(app)
+
+      const response = await request.post(path).send(mockTopic)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(topicsService.createTopic).toHaveBeenCalledWith(mockTopic)
+    })
+    it('returns 200 on successful creation', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(true)
+      topicsService.createTopic.mockReturnValue(okAsync(mockTopic))
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.post(path, topicsController.createTopic)
+      const request = supertest(app)
+
+      const response = await request.post(path).send(mockTopic)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(mockTopic)
+    })
+  })
+
+  describe('updateTopic', () => {
+    const updateTopic = {
+      id: mockTopicId,
+      name: mockTopic.name,
+      description: mockTopic.description,
+      parentId: mockTopic.parentId,
+    }
+
+    beforeEach(() => {
+      authService.hasPermissionToAnswer.mockReset()
+      topicsService.updateTopicById.mockReset()
+      topicsService.updateTopicById.mockReturnValue(okAsync(1))
+      errors = noErrors
+    })
+
+    it('returns 401 on no user', async () => {
+      user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.put(path + '/:id', topicsController.updateTopic)
+      const request = supertest(app)
+
+      const response = await request
+        .put(path + `/${mockTopicId}`)
+        .send(updateTopic)
+
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
+      expect(response.body).toStrictEqual({
+        message: 'User not signed in',
+      })
+      expect(topicsService.updateTopicById).not.toHaveBeenCalled()
+    })
+    it('returns 403 on user from a different agency', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(false)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.put(path + '/:id', topicsController.updateTopic)
+      const request = supertest(app)
+
+      const response = await request
+        .put(path + `/${mockTopicId}`)
+        .send(updateTopic)
+
+      expect(response.status).toEqual(StatusCodes.FORBIDDEN)
+      expect(response.body).toStrictEqual({
+        message: 'You do not have permission to update this topic',
+      })
+      expect(topicsService.updateTopicById).not.toHaveBeenCalled()
+    })
+    it('returns 400 on bad request', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(true)
+
+      errors = [
+        {
+          errors: () => [
+            {
+              msg: 'Validation Error',
+            },
+          ],
+        },
+      ]
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.put(path + '/:id', topicsController.updateTopic)
+      const request = supertest(app)
+
+      const response = await request
+        .put(path + `/${mockTopicId}`)
+        .send(updateTopic)
+
+      expect(response.status).toEqual(StatusCodes.BAD_REQUEST)
+      expect(topicsService.updateTopicById).not.toHaveBeenCalled()
+    })
+    it('returns 500 on topicsService problem', async () => {
+      authService.verifyUserCanModifyTopic.mockResolvedValue(true)
+      topicsService.updateTopicById.mockReturnValue(
+        errAsync(new DatabaseError()),
+      )
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.put(path + '/:id', topicsController.updateTopic)
+      const request = supertest(app)
+
+      const response = await request
+        .put(path + `/${mockTopicId}`)
+        .send(updateTopic)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(topicsService.updateTopicById).toHaveBeenCalledWith(updateTopic)
+    })
+    it('returns 200 on successful update', async () => {
+      authService.verifyUserCanModifyTopic.mockResolvedValue(true)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.put(path + '/:id', topicsController.updateTopic)
+      const request = supertest(app)
+
+      const response = await request
+        .put(path + `/${mockTopicId}`)
+        .send(updateTopic)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        message: 'Topic updated',
+      })
+      expect(topicsService.updateTopicById).toHaveBeenCalledWith(updateTopic)
+    })
+  })
+
+  describe('deleteTopic', () => {
+    beforeEach(() => {
+      authService.hasPermissionToAnswer.mockReset()
+      topicsService.deleteTopicById.mockReset()
+      topicsService.deleteTopicById.mockReturnValue(okAsync(1))
+      errors = noErrors
+    })
+
+    it('returns 401 on no user', async () => {
+      user = undefined
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.delete(path + '/:id', topicsController.deleteTopic)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${mockTopicId}`)
+
+      expect(response.status).toEqual(StatusCodes.UNAUTHORIZED)
+      expect(response.body).toStrictEqual({
+        message: 'User not signed in',
+      })
+      expect(topicsService.deleteTopicById).not.toHaveBeenCalled()
+    })
+    it('returns 403 on user from a different agency', async () => {
+      authService.verifyUserInAgency.mockResolvedValue(false)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.delete(path + '/:id', topicsController.deleteTopic)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${mockTopicId}`)
+
+      expect(response.status).toEqual(StatusCodes.FORBIDDEN)
+      expect(response.body).toStrictEqual({
+        message: 'You do not have permission to delete this topic',
+      })
+      expect(topicsService.deleteTopicById).not.toHaveBeenCalled()
+    })
+    it('returns 500 on topicsService problem', async () => {
+      authService.verifyUserCanModifyTopic.mockResolvedValue(true)
+      topicsService.deleteTopicById.mockReturnValue(
+        errAsync(new DatabaseError()),
+      )
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.delete(path + '/:id', topicsController.deleteTopic)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${mockTopicId}`)
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(topicsService.deleteTopicById).toHaveBeenCalledWith(mockTopicId)
+    })
+    it('returns 200 on successful deletion', async () => {
+      authService.verifyUserCanModifyTopic.mockResolvedValue(true)
+
+      const app = express()
+      app.use(express.json())
+      app.use(middleware)
+      app.use(invalidateIfHasErrors)
+      app.delete(path + '/:id', topicsController.deleteTopic)
+      const request = supertest(app)
+
+      const response = await request.delete(path + `/${mockTopicId}`)
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual({
+        message: 'OK',
+      })
+      expect(topicsService.deleteTopicById).toHaveBeenCalledWith(mockTopicId)
+    })
+  })
 })

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -98,7 +98,7 @@ export class TopicsController {
       name: string
       description: string
       agencyId: number
-      parentId: number
+      parentId: number | null
     },
     undefined
   > = async (req, res) => {

--- a/server/src/modules/topics/topics.routes.ts
+++ b/server/src/modules/topics/topics.routes.ts
@@ -70,7 +70,11 @@ export const routeTopics = ({
    * @return 500 if database error
    * @access Private
    */
-  router.delete('/:id([0-9]+$)', controller.deleteTopic)
+  router.delete(
+    '/:id([0-9]+$)',
+    authMiddleware.authenticate,
+    controller.deleteTopic,
+  )
 
   /**
    * Update a post
@@ -82,7 +86,25 @@ export const routeTopics = ({
    * @return 500 if database error
    * @access Private
    */
-  router.put('/:id([0-9]+$)', controller.updateTopic)
+  router.put(
+    '/:id([0-9]+$)',
+    [
+      authMiddleware.authenticate,
+      check(
+        'name',
+        'Enter a topic name with minimum 1 character and maximum 30 characters',
+      ).isLength({
+        min: 1,
+        max: 30,
+      }),
+      check('description', 'Enter a description with minimum 10 characters')
+        .isLength({
+          min: 10,
+        })
+        .optional({ nullable: true, checkFalsy: true }),
+    ],
+    controller.updateTopic,
+  )
 
   return router
 }

--- a/server/src/modules/topics/topics.service.ts
+++ b/server/src/modules/topics/topics.service.ts
@@ -143,7 +143,7 @@ export class TopicsService {
   createTopic = (newTopic: {
     name: string
     description: string
-    parentId: number
+    parentId: number | null
     agencyId: number
   }): ResultAsync<Topic, DatabaseError> => {
     return ResultAsync.fromPromise(


### PR DESCRIPTION
## Problem

Unit tests are missing from topics module

Closes #694 

## Solution

- Provide remaining test coverage for topics module
- Add `null` to `parentId` type in `topics.service` and `topics.controller`
- Add validation checks to `topics.routes`

