### PR TITLE
test(search): add service tests and env vars for opensearch

### DIFF
--- a/server/src/bootstrap/config/search.ts
+++ b/server/src/bootstrap/config/search.ts
@@ -1,0 +1,42 @@
+import convict, { Schema } from 'convict'
+import { url } from 'convict-format-with-validator'
+
+convict.addFormat(url)
+
+export type SearchConfig = {
+  host: string
+  username: string
+  password: string
+  port: number
+}
+
+const searchSchema: Schema<SearchConfig> = {
+  host: {
+    doc: 'Host for opensearch service',
+    format: String,
+    default: 'localhost',
+    env: 'SEARCH_HOST',
+  },
+  username: {
+    doc: 'Username for opensearch service',
+    format: String,
+    default: 'admin',
+    env: 'SEARCH_USERNAME',
+  },
+  password: {
+    doc: 'Password for opensearch service',
+    format: String,
+    default: 'admin',
+    env: 'SEARCH_PASSWORD',
+  },
+  port: {
+    doc: 'Port for opensearch service',
+    format: 'port',
+    default: 9200,
+    env: 'SEARCH_POST',
+  },
+}
+
+export const searchConfig = convict(searchSchema)
+  .validate({ allowed: 'strict' })
+  .getProperties()

--- a/server/src/modules/search/__tests__/search.service.spec.ts
+++ b/server/src/modules/search/__tests__/search.service.spec.ts
@@ -1,0 +1,256 @@
+import { StatusCodes } from 'http-status-codes'
+import { SearchEntry, SearchService } from '../search.service'
+import { Mocker } from './opensearch-mock'
+// import { baseConfig, Environment } from '../../../bootstrap/config/base'
+// import { searchConfig } from '../../../bootstrap/config/search'
+// import { Client, errors, Connection } from '@opensearch-project/opensearch'
+// import fs from 'fs'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Client, errors } = require('@opensearch-project/opensearch')
+
+describe('Search Service', () => {
+  // // Uncomment to test with live opensearch service
+  // const host = searchConfig.host
+  // const protocol = 'https'
+  // const port = searchConfig.port
+  // const auth = `${searchConfig.username}:${encodeURIComponent(
+  //   searchConfig.password,
+  // )}`
+  // let connectionOptions
+  // if (baseConfig.nodeEnv === Environment.Dev) {
+  //   connectionOptions = { rejectUnauthorized: false } // Turn off certificate verification (rejectUnauthorized: false)
+  // } else {
+  //   connectionOptions = {
+  //     ca: fs.readFileSync('/etc/ssl/certs/ca-certificates.crt'),
+  //   }
+  // }
+  // const client = new Client({
+  //   node: protocol + '://' + auth + '@' + host + ':' + port,
+  //   ssl: connectionOptions,
+  // })
+
+  // Comment when testing with live opensearch service
+  const host = 'localhost'
+  const protocol = 'https'
+  const port = 9200
+  const auth = 'admin:admin'
+  const mock = new Mocker()
+  const client = new Client({
+    node: protocol + '://' + auth + '@' + host + ':' + port,
+    Connection: mock.getConnection(),
+  })
+
+  const searchService: SearchService = new SearchService({
+    client,
+  })
+
+  const indexName = 'search_entries'
+
+  const searchEntriesDataset: SearchEntry[] = []
+
+  for (let i = 1; i < 3; i++) {
+    searchEntriesDataset.push({
+      title: `title ${i * 10}`,
+      description: `description ${i * 100}`,
+      answer: `answer ${i * 1000}`,
+      agencyId: i,
+      postId: i,
+      topicId: null,
+    })
+  }
+
+  describe('indexAllData', () => {
+    it('should successfully index database on OpenSearch', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'PUT',
+          path: '/:indexName',
+        },
+        () => {
+          return { status: 'ok' }
+        },
+      )
+      const body = searchEntriesDataset.flatMap((doc) => [
+        { index: { _index: indexName } },
+        doc,
+      ])
+      mock.add(
+        {
+          method: 'POST',
+          path: '/_bulk',
+          body: body,
+        },
+        () => {
+          const items = []
+          for (const _ of searchEntriesDataset) {
+            items.push({
+              index: {
+                _index: indexName,
+                status: StatusCodes.CREATED,
+              },
+            })
+          }
+          return {
+            errors: false,
+            items: items,
+          }
+        },
+      )
+
+      const response = await searchService.indexAllData(
+        indexName,
+        searchEntriesDataset,
+      )
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.errors).toBeFalsy()
+        for (const item of response.value.items) {
+          expect(item.index._index).toBe(indexName)
+          expect(item.index.status).toBe(StatusCodes.CREATED)
+        }
+      }
+    })
+
+    it('should throw BAD REQUEST error if client.indicies.create does not succeed', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'PUT',
+          path: '/:indexName',
+        },
+        () => {
+          return new errors.ResponseError({
+            body: { errors: {}, status: StatusCodes.BAD_REQUEST },
+            statusCode: StatusCodes.BAD_REQUEST,
+          })
+        },
+      )
+
+      // // Uncomment to test with live opensearch service
+      // await searchService.indexAllData(indexName, searchEntriesDataset)
+      const response = await searchService.indexAllData(
+        indexName,
+        searchEntriesDataset,
+      )
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        // TODO: Refactor to use object directly - currently unable to do so due to
+        // incorrect typing of return type.
+        const responseErrorJson = JSON.parse(JSON.stringify(response.error))
+        expect(responseErrorJson.meta.statusCode).toEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+        expect(responseErrorJson.meta.body.status).toEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+        expect(responseErrorJson.name).toEqual('ResponseError')
+      }
+    })
+
+    it('should throw BAD REQUEST error if client.bulk does not succeed', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'PUT',
+          path: '/:indexName',
+        },
+        () => {
+          return { status: 'ok' }
+        },
+      )
+      mock.add(
+        {
+          method: 'POST',
+          path: '/_bulk',
+        },
+        () => {
+          return new errors.ResponseError({
+            body: { errors: {}, status: StatusCodes.BAD_REQUEST },
+            statusCode: StatusCodes.BAD_REQUEST,
+          })
+        },
+      )
+
+      const response = await searchService.indexAllData(indexName, [])
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        // TODO: Proper typing to remove JSON parse and stringify
+        const responseErrorJson = JSON.parse(JSON.stringify(response.error))
+        expect(responseErrorJson.meta.statusCode).toEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+        expect(responseErrorJson.meta.body.status).toEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+        expect(responseErrorJson.name).toEqual('ResponseError')
+      }
+    })
+
+    it('should return error documents if some operations for client.bulk fail', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'PUT',
+          path: '/:indexName',
+        },
+        () => {
+          return { status: 'ok' }
+        },
+      )
+      mock.add(
+        {
+          method: 'POST',
+          path: '/_bulk',
+        },
+        () => {
+          const items = []
+          for (const _ of searchEntriesDataset) {
+            items.push({
+              index: {
+                error: {
+                  type: 'error type',
+                  reason: 'error reason',
+                },
+                _index: indexName,
+                status: StatusCodes.BAD_REQUEST,
+              },
+            })
+          }
+          return {
+            errors: true,
+            items: items,
+          }
+        },
+      )
+
+      const response = await searchService.indexAllData(
+        indexName,
+        searchEntriesDataset,
+      )
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        if (Array.isArray(response.error)) {
+          for (const err of response.error) {
+            // TODO: Proper typing to remove JSON parse and stringify
+            const responseErrorJson = JSON.parse(JSON.stringify(err))
+            expect(responseErrorJson.status).toBe(StatusCodes.BAD_REQUEST)
+          }
+        }
+      }
+    })
+
+    // // Uncomment if testing with live opensearch service
+    // afterEach(async () => {
+    //   await client.indices.delete({
+    //     index: indexName,
+    //   })
+    // })
+
+    // Comment when testing with live opensearch service
+    afterEach(async () => {
+      mock.clearAll()
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Add tests for indexAllData in search service to make sure that both search service and opensearch mock work.

work towards #720

## Solution

- improve error typing of search service (still needs to be improved)
- search service tests include comments to test on live opensearch service

**Additional Features**:

- add env vars required to connect to opensearch service in config

## Deploy Notes

Environment variables have been added to the staging as well. Not needed at this stage, for future use.

**New environment variables**:

- `SEARCH_HOST`: string for opensearch host (default: `localhost`)
- `SEARCH_USERNAME`: string for master user's username (default: `admin`)
- `SEARCH_PASSWORD`: string for master user's password (default: `admin`)
- `SEARCH_PORT`: port number to connect to for search (default: `9200`)
