### PR TITLE
refactor(searchbox): darken shadow, use Chakra UnorderedList

### DIFF
--- a/client/src/components/SearchBox/SearchBox.component.jsx
+++ b/client/src/components/SearchBox/SearchBox.component.jsx
@@ -1,15 +1,16 @@
 import { Input, InputGroup, InputRightElement } from '@chakra-ui/input'
+import { UnorderedList } from '@chakra-ui/layout'
 import * as FullStory from '@fullstory/browser'
 import Downshift from 'downshift'
 import Fuse from 'fuse.js'
 import { BiSearch } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { Link, useNavigate } from 'react-router-dom'
+import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import {
   getAgencyById,
   GET_AGENCY_BY_ID_QUERY_KEY,
 } from '../../services/AgencyService'
-import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import {
   listPosts,
   LIST_POSTS_FOR_SEARCH_QUERY_KEY,
@@ -182,7 +183,7 @@ const SearchBox = ({
                   })}
                 />
               </InputGroup>
-              <ul
+              <UnorderedList
                 {...getMenuProps({
                   className: 'search-results',
                 })}
@@ -204,7 +205,7 @@ const SearchBox = ({
                       )
                     })
                   : null}
-              </ul>
+              </UnorderedList>
             </div>
           )}
         </Downshift>

--- a/client/src/components/SearchBox/SearchBox.styles.scss
+++ b/client/src/components/SearchBox/SearchBox.styles.scss
@@ -46,7 +46,7 @@
         z-index: 50;
         margin-inline-start: 0;
         // copied box-shadow from chakra UI shadow 2xl,
-        // with color from dark-lg
+        // with a much darker shade
         box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
         border-radius: $btn-radius; 
       }

--- a/client/src/components/SearchBox/SearchBox.styles.scss
+++ b/client/src/components/SearchBox/SearchBox.styles.scss
@@ -44,8 +44,10 @@
         width: 100%;
   
         z-index: 50;
-        // copied box-shadow from chakra UI shadow 2xl
-        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        margin-inline-start: 0;
+        // copied box-shadow from chakra UI shadow 2xl,
+        // with color from dark-lg
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
         border-radius: $btn-radius; 
       }
       


### PR DESCRIPTION
## Problem and Solution

Darken the shadow around search box results to highlight it better to user.

Take the chance to use Chakra's unordered list instead of `<ul>`, ensuring we override the former's CSS margin to retain layout

## Screenshots

### Before
![Screenshot_20211111-112623](https://user-images.githubusercontent.com/10572368/141231939-740aafce-d3f2-4977-9eb2-c3049c099208.png)

### After
![image-1](https://user-images.githubusercontent.com/10572368/141231798-82754502-980f-4340-af19-6d80d38f3bac.png)
