### PR TITLE
fix(sticky-nav): add sticky nav to tablet view

### DIFF
--- a/client/src/components/Header/Header.component.jsx
+++ b/client/src/components/Header/Header.component.jsx
@@ -155,7 +155,7 @@ const Header = () => {
   // attach to matchQuestions?.path instead of matchQuestions because matchQuestions is
   // an object and will trigger the callback without values within the object changing
   useEffect(() => {
-    if (deviceType !== device.tablet && !matchQuestions) {
+    if (!matchQuestions) {
       openHeader()
       window.addEventListener('scroll', checkHeaderState)
       return () => {
@@ -164,13 +164,13 @@ const Header = () => {
     } else {
       closeHeader()
     }
-  }, [matchQuestions?.pathname, deviceType])
+  }, [matchQuestions?.pathname])
 
   const expandedSearch = () => {
     return (
       <Box
         bg="white"
-        h={{ base: '100px', md: '152px' }}
+        h={{ base: '100px', xl: '152px' }}
         className="top-background"
       >
         <Flex
@@ -184,7 +184,7 @@ const Header = () => {
           <Flex
             h="56px"
             m="auto"
-            mt={{ base: '20px', md: '64px' }}
+            mt={{ base: '20px', xl: '64px' }}
             px={{ base: '24px', md: 'auto' }}
             maxW="680px"
             w="100%"
@@ -193,7 +193,7 @@ const Header = () => {
           </Flex>
         </Flex>
         {Boolean(agency) ? (
-          <Box px="36px" mt="-55px" display={{ base: 'none', lg: 'flex' }}>
+          <Box px="36px" mt="-55px" display={{ base: 'none', xl: 'flex' }}>
             <AgencyLogo agency={agency} />
           </Box>
         ) : null}
@@ -255,22 +255,14 @@ const Header = () => {
     <Flex
       direction="column"
       sx={{
-        position: {
-          base: '-webkit-sticky',
-          sm: 'static',
-          xl: '-webkit-sticky',
-        } /* Safari */,
-        position: {
-          base: 'sticky',
-          sm: 'static',
-          xl: 'sticky',
-        },
+        position: '-webkit-sticky' /* Safari */,
+        position: 'sticky',
         top: '0',
         'z-index': '999',
       }}
     >
       <Masthead />
-      {deviceType !== device.mobile ? (
+      {deviceType === device.desktop ? (
         askgovLogoBar()
       ) : matchQuestions ? null : (
         <Collapse in={headerIsOpen} animateOpacity={false}>
@@ -294,7 +286,7 @@ const Header = () => {
         <Collapse in={headerIsOpen} animateOpacity={false}>
           {expandedSearch()}
         </Collapse>
-      ) : matchQuestions && deviceType !== device.mobile ? null : (
+      ) : matchQuestions && deviceType === device.desktop ? null : (
         expandedSearch()
       )}
     </Flex>


### PR DESCRIPTION
## Problem

Tablet does not have sticky navigation.

## Solution

Add sticky nav to tablet: sticky nav on tablet version behaves the same way as mobile

## Before & After Screenshots (of tablet view)

**BEFORE**:

Main pages:

https://user-images.githubusercontent.com/37061143/141396725-1f2493ab-1a63-457f-8bd2-4da74dc2c9c8.mov

Pages with `/questions` (post page and search results page):

https://user-images.githubusercontent.com/37061143/141396813-df34ced5-7087-4bf5-892d-f90e3892ae69.mov

**AFTER**:

Main pages:

https://user-images.githubusercontent.com/37061143/141396892-16cdfbb7-b0b3-4b37-b9e0-661f39174864.mov

Pages with `/questions` (post page and search results page):

https://user-images.githubusercontent.com/37061143/141396894-9e85e144-b8c5-4b14-8a2e-25c8c74ca679.mov

## Tests

Adjust screen size to be of tablet size (480px-1440px in width). Navigation bar should be sticky and behave like it does in the mobile version.
