### PR TITLE
feat(search): add searchPosts to service and related tests

### DIFF
--- a/server/src/modules/search/__tests__/search.service.spec.ts
+++ b/server/src/modules/search/__tests__/search.service.spec.ts
@@ -5,7 +5,7 @@ import { Mocker } from './opensearch-mock'
 // // Uncomment to test with live opensearch service
 // import { baseConfig, Environment } from '../../../bootstrap/config/base'
 // import { searchConfig } from '../../../bootstrap/config/search'
-// import { Client, errors, Connection } from '@opensearch-project/opensearch'
+// import { Client } from '@opensearch-project/opensearch'
 // import fs from 'fs'
 
 // Comment when testing with live opensearch service
@@ -255,5 +255,233 @@ describe('Search Service', () => {
     afterEach(async () => {
       mock.clearAll()
     })
+  })
+
+  describe('searchPosts', () => {
+    // // Uncomment if testing with live opensearch service
+    // beforeAll(async() => {
+    //   await searchService.indexAllData(
+    //     indexName,
+    //     searchEntriesDataset,
+    //   )
+    // })
+
+    it('should successfully search index based on query when a keyword in one of the fields is mentioned', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: `/${indexName}/_search`,
+        },
+        () => {
+          return {
+            hits: {
+              total: { value: 2, relation: 'eq' },
+              hits: [{}, {}],
+            },
+          }
+        },
+      )
+
+      const searchValue = 'answerr'
+      const response = await searchService.searchPosts(indexName, searchValue)
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.statusCode).toBe(StatusCodes.OK)
+        expect(response.value.body.hits.total.value).toBeGreaterThan(0)
+        expect(response.value.body.hits.hits.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('should successfully search index based on query when a keyword is missing a letter', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: `/${indexName}/_search`,
+        },
+        () => {
+          return {
+            hits: {
+              total: { value: 2, relation: 'eq' },
+              hits: [{}, {}],
+            },
+          }
+        },
+      )
+
+      const searchValue = 'descriptio'
+      const response = await searchService.searchPosts(indexName, searchValue)
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.statusCode).toBe(StatusCodes.OK)
+        expect(response.value.body.hits.total.value).toBeGreaterThan(0)
+        expect(response.value.body.hits.hits.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('should successfully search index based on query when characters are transposed', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: `/${indexName}/_search`,
+        },
+        () => {
+          return {
+            hits: {
+              total: { value: 2, relation: 'eq' },
+              hits: [{}, {}],
+            },
+          }
+        },
+      )
+
+      const searchValue = 'descripiton'
+      const response = await searchService.searchPosts(indexName, searchValue)
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.statusCode).toBe(StatusCodes.OK)
+        expect(response.value.body.hits.hits.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('should rank hits based on relevance', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: `/${indexName}/_search`,
+        },
+        () => {
+          return {
+            hits: {
+              total: { value: 2, relation: 'eq' },
+              hits: [
+                {
+                  _index: indexName,
+                  _score: 0.8754687,
+                  _source: {
+                    agencyId: 2,
+                    answer: 'answer 2000',
+                    description: 'description 200',
+                    postId: 2,
+                    title: 'title 20',
+                    topicId: null,
+                  },
+                  _type: '_doc',
+                },
+                {
+                  _index: indexName,
+                  _score: 0.18232156,
+                  _source: {
+                    agencyId: 1,
+                    answer: 'answer 1000',
+                    description: 'description 100',
+                    postId: 1,
+                    title: 'title 10',
+                    topicId: null,
+                  },
+                  _type: '_doc',
+                },
+              ],
+            },
+          }
+        },
+      )
+
+      const searchValue = 'title 20'
+      const response = await searchService.searchPosts(indexName, searchValue)
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.statusCode).toBe(StatusCodes.OK)
+        expect(response.value.body.hits.total.value).toBeGreaterThan(0)
+        expect(response.value.body.hits.hits.length).toBeGreaterThan(0)
+        expect(response.value.body.hits.hits[0]._source.postId).toBe(2)
+      }
+    })
+
+    it('should be able to filter search by agency', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: `/${indexName}/_search`,
+        },
+        () => {
+          return {
+            hits: {
+              total: { value: 1, relation: 'eq' },
+              hits: [
+                {
+                  _source: {
+                    agencyId: 1,
+                  },
+                },
+              ],
+            },
+          }
+        },
+      )
+
+      const searchValue = 'answer'
+      const agencyId = 1
+      const response = await searchService.searchPosts(
+        indexName,
+        searchValue,
+        agencyId,
+      )
+
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        expect(response.value.statusCode).toBe(StatusCodes.OK)
+        expect(response.value.body.hits.total.value).toBe(1)
+        expect(response.value.body.hits.hits.length).toBe(1)
+        expect(response.value.body.hits.hits[0]._source.agencyId).toBe(agencyId)
+      }
+    })
+
+    it('should throw error if client.search does not succeed', async () => {
+      // Comment when testing with live opensearch service
+      mock.add(
+        {
+          method: 'POST',
+          path: '/indexName/_search',
+        },
+        () => {
+          return new errors.ResponseError({
+            body: { errors: {}, status: StatusCodes.BAD_REQUEST },
+            statusCode: StatusCodes.BAD_REQUEST,
+          })
+        },
+      )
+
+      const searchValue = 'title'
+      const response = await searchService.searchPosts(
+        'indexName', // non-existent index name causes error
+        searchValue,
+      )
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        expect(response.error.meta.statusCode).toBeGreaterThanOrEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+        expect(response.error.meta.body.status).toBeGreaterThanOrEqual(
+          StatusCodes.BAD_REQUEST,
+        )
+      }
+    })
+
+    // Comment when testing with live opensearch service
+    afterEach(async () => {
+      mock.clearAll()
+    })
+
+    // // Uncomment if testing with live opensearch service
+    // afterAll(async () => {
+    //   await client.indices.delete({
+    //     index: indexName,
+    //   })
+    // })
   })
 })

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -107,6 +107,13 @@ export class SearchService {
     })
   }
 
+  /**
+   * Searches posts in opensearch index
+   * @param index index name
+   * @param searchQuery search query entered by user
+   * @param agencyId agency id
+   * @returns results async with relevant search entries ranked by relevance
+   */
   searchPosts = async (
     index: string,
     searchQuery: string,

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -1,5 +1,8 @@
 import { Client } from '@opensearch-project/opensearch'
-import { BulkResponseItemBase } from '@opensearch-project/opensearch/api/types'
+import {
+  BulkResponseItemBase,
+  QueryDslMultiMatchQuery,
+} from '@opensearch-project/opensearch/api/types'
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { createLogger } from '../../bootstrap/logging'
@@ -102,5 +105,38 @@ export class SearchService {
         return okAsync(bulkResponse)
       })
     })
+  }
+
+  searchPosts = async (
+    index: string,
+    searchQuery: string,
+    agencyId?: number,
+  ) => {
+    const multiMatchQuery: QueryDslMultiMatchQuery = {
+      query: searchQuery,
+      fields: ['title', 'description', 'answer'],
+      type: 'most_fields',
+      fuzziness: 'AUTO',
+    }
+    return ResultAsync.fromPromise(
+      this.client.search({
+        index,
+        body: {
+          query: { multi_match: multiMatchQuery },
+          ...(agencyId && { post_filter: { term: { agencyId: agencyId } } }),
+        },
+      }),
+      (err) => {
+        logger.error({
+          message:
+            'Error while searching data for OpenSearch - client.indices.search',
+          meta: {
+            function: 'searchPosts',
+          },
+          error: err,
+        })
+        return err as ResponseError
+      },
+    )
   }
 }


### PR DESCRIPTION
## Problem

Related #688

## Solution

Set up search query (`searchPosts`) on search service.

**Features**:

- fulfills basic requirements:
    1. Able to search multiple fields (title, description and answer)
    2. Able to filter by agency
    3. Able to account for typos
- uses scenario-based testing (hence overlapping coverage)