### PR TITLE
feat(search): add searchPosts to controller and related tests

### DIFF
--- a/server/src/modules/search/__tests__/search.controller.spec.ts
+++ b/server/src/modules/search/__tests__/search.controller.spec.ts
@@ -1,6 +1,9 @@
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
+import express from 'express'
+import { query } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync } from 'neverthrow'
+import supertest from 'supertest'
 import { PostStatus } from '../../../../../shared/src/types/base'
 import { DatabaseError } from '../../core/core.errors'
 import { InvalidTopicsError } from '../../post/post.errors'
@@ -20,6 +23,7 @@ describe('SearchController', () => {
   }
   const searchService = {
     indexAllData: jest.fn(),
+    searchPosts: jest.fn(),
   }
 
   const searchController = new SearchController({
@@ -59,86 +63,223 @@ describe('SearchController', () => {
     })
   }
 
-  it('returns OK on a valid query', async () => {
-    postService.listPosts.mockResolvedValue(mockListPostsValue)
-    answersService.listAnswers.mockImplementation((postId) =>
-      Promise.resolve([
-        { body: `<p>answer ${postId}</p>` },
-        { body: `<p>another answer ${postId}</p>` },
-      ]),
-    )
-    searchService.indexAllData.mockReturnValue(
-      okAsync({
-        errors: false,
-        items: mockReturnItems,
-      }),
-    )
+  describe('indexAllData', () => {
+    it('returns OK on a valid query', async () => {
+      postService.listPosts.mockResolvedValue(mockListPostsValue)
+      answersService.listAnswers.mockImplementation((postId) =>
+        Promise.resolve([
+          { body: `<p>answer ${postId}</p>` },
+          { body: `<p>another answer ${postId}</p>` },
+        ]),
+      )
+      searchService.indexAllData.mockReturnValue(
+        okAsync({
+          errors: false,
+          items: mockReturnItems,
+        }),
+      )
 
-    const response = await searchController.indexAllData(indexName)
+      const response = await searchController.indexAllData(indexName)
 
-    expect(response.isOk()).toBeTruthy()
-    if (response.isOk()) {
-      // TODO: Proper typing to remove JSON parse and stringify
-      const responseValue = JSON.parse(JSON.stringify(response.value))
-      expect(responseValue.errors).toBeFalsy()
-      for (const item of responseValue.items) {
-        for (const key in item) {
-          expect(item[key].status).toBe(StatusCodes.CREATED)
-          expect(item[key]._index).toBe(indexName)
+      expect(response.isOk()).toBeTruthy()
+      if (response.isOk()) {
+        // TODO: Proper typing to remove JSON parse and stringify
+        const responseValue = JSON.parse(JSON.stringify(response.value))
+        expect(responseValue.errors).toBeFalsy()
+        for (const item of responseValue.items) {
+          for (const key in item) {
+            expect(item[key].status).toBe(StatusCodes.CREATED)
+            expect(item[key]._index).toBe(indexName)
+          }
         }
       }
-    }
+    })
+
+    it('returns InvalidTopicsError when postService.listPosts throws InvalidTopicsError', async () => {
+      postService.listPosts.mockRejectedValue(new InvalidTopicsError())
+
+      const response = await searchController.indexAllData(indexName)
+
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        expect(response.error).toStrictEqual(new InvalidTopicsError())
+      }
+    })
+
+    it('returns Database Error when listAnswers throws Database Error', async () => {
+      postService.listPosts.mockResolvedValue(mockListPostsValue)
+      answersService.listAnswers.mockRejectedValue(new DatabaseError())
+
+      const response = await searchController.indexAllData(indexName)
+
+      // expect(response).toBe('')
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        expect(response.error).toStrictEqual(new DatabaseError())
+      }
+    })
+
+    it('returns Response Error when searchService.indexAllData throws Response Error', async () => {
+      postService.listPosts.mockResolvedValue(mockListPostsValue)
+      answersService.listAnswers.mockImplementation((postId) =>
+        Promise.resolve([
+          { body: `<p>answer ${postId}</p>` },
+          { body: `<p>another answer ${postId}</p>` },
+        ]),
+      )
+      searchService.indexAllData.mockReturnValue(
+        errAsync(
+          new errors.ResponseError({
+            body: { errors: {}, status: StatusCodes.BAD_REQUEST },
+            statusCode: StatusCodes.BAD_REQUEST,
+          }),
+        ),
+      )
+
+      const response = await searchController.indexAllData(indexName)
+      expect(response.isErr()).toBeTruthy()
+      if (response.isErr()) {
+        expect(response.error).toBeInstanceOf(ResponseError)
+      }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
   })
 
-  it('returns InvalidTopicsError when postService.listPosts throws InvalidTopicsError', async () => {
-    postService.listPosts.mockRejectedValue(new InvalidTopicsError())
-
-    const response = await searchController.indexAllData(indexName)
-
-    expect(response.isErr()).toBeTruthy()
-    if (response.isErr()) {
-      expect(response.error).toStrictEqual(new InvalidTopicsError())
+  describe('searchPosts', () => {
+    const sampleHits = [
+      {
+        _id: 'm42WIn0BbFqfMhuFmmR4',
+        _index: 'search_entries',
+        _score: 0.8754687,
+        _source: {
+          agencyId: 2,
+          answer: 'answer 2000',
+          description: 'description 200',
+          postId: 2,
+          title: 'title 20',
+          topicId: null,
+        },
+        _type: '_doc',
+      },
+      {
+        _id: 'mo2WIn0BbFqfMhuFmmR4',
+        _index: 'search_entries',
+        _score: 0.18232156,
+        _source: {
+          agencyId: 1,
+          answer: 'answer 1000',
+          description: 'description 100',
+          postId: 1,
+          title: 'title 10',
+          topicId: null,
+        },
+        _type: '_doc',
+      },
+    ]
+    const sampleSearchPostsResponse = {
+      body: {
+        _shards: { failed: 0, skipped: 0, successful: 1, total: 1 },
+        hits: {
+          hits: sampleHits,
+          max_score: 0.8754687,
+          total: { relation: 'eq', value: 2 },
+        },
+        timed_out: false,
+        took: 10,
+      },
+      headers: {
+        'content-length': '598',
+        'content-type': 'application/json; charset=UTF-8',
+      },
+      meta: {
+        aborted: false,
+        attempts: 0,
+        connection: {
+          _openRequests: 0,
+          deadCount: 0,
+          headers: {},
+          id: 'https://localhost:9200/',
+          resurrectTimeout: 0,
+          roles: { data: true, ingest: true, master: true },
+          status: 'alive',
+          url: 'https://localhost:9200/',
+        },
+        context: null,
+        name: 'opensearch-js',
+        request: {
+          id: 3,
+          options: {},
+          params: {
+            body: '{"query":{"multi_match":{"query":"title 20","fields":["title","description","answer"],"type":"most_fields","zero_terms_query":"all","fuzziness":"AUTO"}}}',
+            headers: {
+              'content-length': '153',
+              'content-type': 'application/json',
+              'user-agent':
+                'opensearch-js/1.0.0 (darwin 21.1.0-x64; Node.js v14.17.6)',
+            },
+            method: 'POST',
+            path: '/search_entries/_search',
+            querystring: '',
+            timeout: 30000,
+          },
+        },
+      },
+      statusCode: 200,
     }
-  })
 
-  it('returns Database Error when listAnswers throws Database Error', async () => {
-    postService.listPosts.mockResolvedValue(mockListPostsValue)
-    answersService.listAnswers.mockRejectedValue(new DatabaseError())
+    it('returns OK on a valid query', async () => {
+      searchService.searchPosts.mockReturnValue(
+        okAsync(sampleSearchPostsResponse),
+      )
 
-    const response = await searchController.indexAllData(indexName)
+      const agencyId = 1
+      const searchQuery = 'title'
 
-    // expect(response).toBe('')
-    expect(response.isErr()).toBeTruthy()
-    if (response.isErr()) {
-      expect(response.error).toStrictEqual(new DatabaseError())
-    }
-  })
+      const app = express()
+      app.get(
+        '/questions',
+        [query('agencyId').isInt().toInt(), query('search').isString().trim()],
+        searchController.searchPosts,
+      )
+      const request = supertest(app)
+      const response = await request.get(
+        `/questions?agencyId=${agencyId}&search=${searchQuery}`,
+      )
 
-  it('returns Response Error when searchService.indexAllData throws Response Error', async () => {
-    postService.listPosts.mockResolvedValue(mockListPostsValue)
-    answersService.listAnswers.mockImplementation((postId) =>
-      Promise.resolve([
-        { body: `<p>answer ${postId}</p>` },
-        { body: `<p>another answer ${postId}</p>` },
-      ]),
-    )
-    searchService.indexAllData.mockReturnValue(
-      errAsync(
-        new errors.ResponseError({
-          body: { errors: {}, status: StatusCodes.BAD_REQUEST },
-          statusCode: StatusCodes.BAD_REQUEST,
-        }),
-      ),
-    )
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(sampleHits)
+    })
 
-    const response = await searchController.indexAllData(indexName)
-    expect(response.isErr()).toBeTruthy()
-    if (response.isErr()) {
-      expect(response.error).toBeInstanceOf(ResponseError)
-    }
-  })
+    it('returns Internal Server Error when searchService throws Response Error', async () => {
+      searchService.searchPosts.mockReturnValue(
+        errAsync(
+          new errors.ResponseError({
+            body: { errors: {}, status: StatusCodes.BAD_REQUEST },
+            statusCode: StatusCodes.BAD_REQUEST,
+          }),
+        ),
+      )
 
-  afterEach(() => {
-    jest.resetAllMocks()
+      const app = express()
+      app.get(
+        '/questions',
+        [query('agencyId').isInt().toInt(), query('search').isString().trim()],
+        searchController.searchPosts,
+      )
+      const request = supertest(app)
+      const response = await request.get(
+        `/questions?agencyId=1&search=searchQuery`,
+      )
+
+      expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(response.body).toStrictEqual({ message: 'Server Error' })
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
   })
 })

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -1,6 +1,9 @@
+import { StatusCodes } from 'http-status-codes'
 import { ResultAsync } from 'neverthrow'
 import sanitizeHtml from 'sanitize-html'
 import { createLogger } from '../../bootstrap/logging'
+import { Message } from '../../types/message-type'
+import { ControllerHandler } from '../../types/response-handler'
 import { SortType } from '../../types/sort-type'
 import { AnswersService } from '../answers/answers.service'
 import { DatabaseError } from '../core/core.errors'
@@ -18,7 +21,7 @@ const logger = createLogger(module)
 export class SearchController {
   private answersService: Pick<AnswersService, 'listAnswers'>
   private postService: Pick<PostService, 'listPosts'>
-  private searchService: Pick<SearchService, 'indexAllData'>
+  private searchService: Pick<SearchService, 'indexAllData' | 'searchPosts'>
 
   constructor({
     answersService,
@@ -27,7 +30,7 @@ export class SearchController {
   }: {
     answersService: Pick<AnswersService, 'listAnswers'>
     postService: Pick<PostService, 'listPosts'>
-    searchService: Pick<SearchService, 'indexAllData'>
+    searchService: Pick<SearchService, 'indexAllData' | 'searchPosts'>
   }) {
     this.answersService = answersService
     this.postService = postService
@@ -97,5 +100,38 @@ export class SearchController {
         )
       })
       .andThen((result) => result)
+  }
+
+  searchPosts: ControllerHandler<
+    undefined,
+    Buffer | Message,
+    undefined,
+    { agencyId: number | undefined; search: string }
+  > = async (req, res) => {
+    const index = 'search_entries'
+    return (
+      await this.searchService.searchPosts(
+        index,
+        req.query.search,
+        req.query.agencyId,
+      )
+    )
+      .map((response) => {
+        return res.status(StatusCodes.OK).json(response.body.hits.hits)
+      })
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error while searching posts',
+          meta: {
+            function: 'searchPosts',
+            agencyId: req.query.agencyId,
+            query: req.query.search,
+          },
+          error,
+        })
+        return res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Server Error' })
+      })
   }
 }

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -102,6 +102,13 @@ export class SearchController {
       .andThen((result) => result)
   }
 
+  /**
+   * Handle responses related to post searches
+   * @query agencyId
+   * @query search
+   * @returns 200 relevant search entries sorted by relevance
+   * @returns 500 search request fails
+   */
   searchPosts: ControllerHandler<
     undefined,
     Buffer | Message,


### PR DESCRIPTION
## Problem

Works towards #688

## Solution

Set up search query (`searchPosts`) on service controller.

**Improvements**:

Wrap `indexAllData` controller tests in a `describe` block.