### PR TITLE
fix(searchbox): enforce max height of 56px

### DIFF
--- a/client/src/theme/components/SearchBox.tsx
+++ b/client/src/theme/components/SearchBox.tsx
@@ -30,6 +30,7 @@ export const SearchBox: ComponentMultiStyleConfig = {
       boxShadow: '0px 0px 10px var(--chakra-colors-secondary-100)',
       w: '100%',
       h: '100%',
+      maxH: '56px',
     },
     input: {
       fontSize: '16px',


### PR DESCRIPTION
# Problem and Solution

Follows up on #757 

# Test

Ensure that enquiry modal's searchbox remains fixed in height