### PR TITLE
feat(search): add searchPosts to routes and related tests

### DIFF
--- a/server/src/modules/search/__tests__/search.controller.spec.ts
+++ b/server/src/modules/search/__tests__/search.controller.spec.ts
@@ -253,7 +253,7 @@ describe('SearchController', () => {
       expect(response.body).toStrictEqual(sampleHits)
     })
 
-    it('returns Internal Server Error when searchService throws Response Error', async () => {
+    it('returns Internal Server Error when searchService throws Error', async () => {
       searchService.searchPosts.mockReturnValue(
         errAsync(
           new errors.ResponseError({
@@ -275,7 +275,7 @@ describe('SearchController', () => {
       )
 
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
-      expect(response.body).toStrictEqual({ message: 'Server Error' })
+      expect(response.body).toStrictEqual({ message: 'Internal Server Error' })
     })
 
     afterEach(() => {

--- a/server/src/modules/search/__tests__/search.controller.spec.ts
+++ b/server/src/modules/search/__tests__/search.controller.spec.ts
@@ -240,13 +240,13 @@ describe('SearchController', () => {
 
       const app = express()
       app.get(
-        '/questions',
-        [query('agencyId').isInt().toInt(), query('search').isString().trim()],
+        '/search',
+        [query('agencyId').isInt().toInt(), query('query').isString().trim()],
         searchController.searchPosts,
       )
       const request = supertest(app)
       const response = await request.get(
-        `/questions?agencyId=${agencyId}&search=${searchQuery}`,
+        `/search?agencyId=${agencyId}&query=${searchQuery}`,
       )
 
       expect(response.status).toEqual(StatusCodes.OK)
@@ -265,14 +265,12 @@ describe('SearchController', () => {
 
       const app = express()
       app.get(
-        '/questions',
-        [query('agencyId').isInt().toInt(), query('search').isString().trim()],
+        '/search',
+        [query('agencyId').isInt().toInt(), query('query').isString().trim()],
         searchController.searchPosts,
       )
       const request = supertest(app)
-      const response = await request.get(
-        `/questions?agencyId=1&search=searchQuery`,
-      )
+      const response = await request.get(`/search?agencyId=1&query=searchQuery`)
 
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(response.body).toStrictEqual({ message: 'Internal Server Error' })

--- a/server/src/modules/search/__tests__/search.routes.spec.ts
+++ b/server/src/modules/search/__tests__/search.routes.spec.ts
@@ -5,8 +5,10 @@ import supertest from 'supertest'
 import { SearchController } from '../search.controller'
 import { routeSearch } from '../search.routes'
 
-describe('/questions', () => {
-  describe('GET /questions', () => {
+describe('/search', () => {
+  describe('GET /search', () => {
+    const path = '/search'
+
     const answersService = {
       listAnswers: jest.fn(),
     }
@@ -69,7 +71,6 @@ describe('/questions', () => {
       statusCode: 200,
     }
     it('returns OK on valid query', async () => {
-      const path = '/questions'
       const app = express()
       app.use(router)
       const request = supertest(app)
@@ -78,14 +79,13 @@ describe('/questions', () => {
         okAsync(sampleSearchPostsResponse),
       )
 
-      const response = await request.get(path).query({ search: 'test' })
+      const response = await request.get(path).query({ query: 'test' })
 
       expect(response.status).toEqual(StatusCodes.OK)
       expect(response.body).toStrictEqual(sampleHits)
     })
 
     it('returns BAD REQUEST on invalid agencyId format', async () => {
-      const path = '/questions'
       const app = express()
       app.use(router)
       const request = supertest(app)
@@ -96,7 +96,7 @@ describe('/questions', () => {
 
       const response = await request
         .get(path)
-        .query({ agencyId: 'test', search: 'test search' })
+        .query({ agencyId: 'test', query: 'test search' })
 
       expect(response.status).toEqual(StatusCodes.BAD_REQUEST)
       expect(response.body).toStrictEqual({
@@ -105,7 +105,7 @@ describe('/questions', () => {
     })
 
     it('uses trimmed search query to search posts', async () => {
-      const path = '/questions'
+      const path = '/search'
       const app = express()
       app.use(router)
       const request = supertest(app)
@@ -117,7 +117,7 @@ describe('/questions', () => {
       const trimmedSearch = 'test search'
       const response = await request
         .get(path)
-        .query({ search: ` ${trimmedSearch}      ` })
+        .query({ query: ` ${trimmedSearch}      ` })
 
       expect(response.status).toEqual(StatusCodes.OK)
       expect(searchService.searchPosts).toHaveBeenCalledWith(

--- a/server/src/modules/search/__tests__/search.routes.spec.ts
+++ b/server/src/modules/search/__tests__/search.routes.spec.ts
@@ -1,0 +1,130 @@
+import express from 'express'
+import { StatusCodes } from 'http-status-codes'
+import { okAsync } from 'neverthrow'
+import supertest from 'supertest'
+import { SearchController } from '../search.controller'
+import { routeSearch } from '../search.routes'
+
+describe('/questions', () => {
+  describe('GET /questions', () => {
+    const answersService = {
+      listAnswers: jest.fn(),
+    }
+    const postService = {
+      listPosts: jest.fn(),
+    }
+    const searchService = {
+      indexAllData: jest.fn(),
+      searchPosts: jest.fn(),
+    }
+
+    const controller = new SearchController({
+      answersService,
+      postService,
+      searchService,
+    })
+    const router = routeSearch({ controller })
+
+    const sampleHits = [
+      {
+        _id: 'm42WIn0BbFqfMhuFmmR4',
+        _index: 'search_entries',
+        _score: 0.8754687,
+        _source: {
+          agencyId: 2,
+          answer: 'answer 2000',
+          description: 'description 200',
+          postId: 2,
+          title: 'title 20',
+          topicId: null,
+        },
+        _type: '_doc',
+      },
+      {
+        _id: 'mo2WIn0BbFqfMhuFmmR4',
+        _index: 'search_entries',
+        _score: 0.18232156,
+        _source: {
+          agencyId: 1,
+          answer: 'answer 1000',
+          description: 'description 100',
+          postId: 1,
+          title: 'title 10',
+          topicId: null,
+        },
+        _type: '_doc',
+      },
+    ]
+    const sampleSearchPostsResponse = {
+      body: {
+        _shards: { failed: 0, skipped: 0, successful: 1, total: 1 },
+        hits: {
+          hits: sampleHits,
+          max_score: 0.8754687,
+          total: { relation: 'eq', value: 2 },
+        },
+        timed_out: false,
+        took: 10,
+      },
+      statusCode: 200,
+    }
+    it('returns OK on valid query', async () => {
+      const path = '/questions'
+      const app = express()
+      app.use(router)
+      const request = supertest(app)
+
+      searchService.searchPosts.mockReturnValue(
+        okAsync(sampleSearchPostsResponse),
+      )
+
+      const response = await request.get(path).query({ search: 'test' })
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual(sampleHits)
+    })
+
+    it('returns BAD REQUEST on invalid agencyId format', async () => {
+      const path = '/questions'
+      const app = express()
+      app.use(router)
+      const request = supertest(app)
+
+      searchService.searchPosts.mockReturnValue(
+        okAsync(sampleSearchPostsResponse),
+      )
+
+      const response = await request
+        .get(path)
+        .query({ agencyId: 'test', search: 'test search' })
+
+      expect(response.status).toEqual(StatusCodes.BAD_REQUEST)
+      expect(response.body).toStrictEqual({
+        message: 'Bad Request Error - query does not pass validation checks',
+      })
+    })
+
+    it('uses trimmed search query to search posts', async () => {
+      const path = '/questions'
+      const app = express()
+      app.use(router)
+      const request = supertest(app)
+
+      searchService.searchPosts.mockReturnValue(
+        okAsync(sampleSearchPostsResponse),
+      )
+
+      const trimmedSearch = 'test search'
+      const response = await request
+        .get(path)
+        .query({ search: ` ${trimmedSearch}      ` })
+
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(searchService.searchPosts).toHaveBeenCalledWith(
+        'search_entries',
+        trimmedSearch,
+        undefined,
+      )
+    })
+  })
+})

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -114,7 +114,7 @@ export class SearchController {
     undefined,
     Buffer | Message,
     undefined,
-    { agencyId: number | undefined; search: string }
+    { agencyId: number | undefined; query: string }
   > = async (req, res) => {
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
@@ -123,7 +123,7 @@ export class SearchController {
         meta: {
           function: 'searchPosts',
           agencyId: req.query.agencyId,
-          query: req.query.search,
+          query: req.query.query,
         },
         error: errors,
       })
@@ -135,7 +135,7 @@ export class SearchController {
     return (
       await this.searchService.searchPosts(
         index,
-        req.query.search,
+        req.query.query,
         req.query.agencyId,
       )
     )
@@ -148,7 +148,7 @@ export class SearchController {
           meta: {
             function: 'searchPosts',
             agencyId: req.query.agencyId,
-            query: req.query.search,
+            query: req.query.query,
           },
           error,
         })

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -1,3 +1,4 @@
+import { validationResult } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
 import { ResultAsync } from 'neverthrow'
 import sanitizeHtml from 'sanitize-html'
@@ -115,6 +116,21 @@ export class SearchController {
     undefined,
     { agencyId: number | undefined; search: string }
   > = async (req, res) => {
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      logger.error({
+        message: 'Error while searching posts - request validation',
+        meta: {
+          function: 'searchPosts',
+          agencyId: req.query.agencyId,
+          query: req.query.search,
+        },
+        error: errors,
+      })
+      return res.status(StatusCodes.BAD_REQUEST).send({
+        message: 'Bad Request Error - query does not pass validation checks',
+      })
+    }
     const index = 'search_entries'
     return (
       await this.searchService.searchPosts(
@@ -138,7 +154,7 @@ export class SearchController {
         })
         return res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Server Error' })
+          .json({ message: 'Internal Server Error' })
       })
   }
 }

--- a/server/src/modules/search/search.routes.ts
+++ b/server/src/modules/search/search.routes.ts
@@ -1,0 +1,29 @@
+import express from 'express'
+import { query } from 'express-validator'
+import { SearchController } from './search.controller'
+
+export const routeSearch = ({
+  controller,
+}: {
+  controller: SearchController
+}): express.Router => {
+  const router = express.Router()
+
+  /**
+   * Lists all answers to a post
+   * @route   GET /questions
+   * @returns 200 relevant search entries sorted by relevance
+   * @returns 500 search request fails
+   * @access  Public
+   */
+  router.get(
+    '/questions',
+    [
+      query('agencyId').isInt().toInt().optional({ nullable: true }),
+      query('search').isString().trim(),
+    ],
+    controller.searchPosts,
+  )
+
+  return router
+}

--- a/server/src/modules/search/search.routes.ts
+++ b/server/src/modules/search/search.routes.ts
@@ -17,10 +17,10 @@ export const routeSearch = ({
    * @access  Public
    */
   router.get(
-    '/questions',
+    '/search',
     [
       query('agencyId').isInt().toInt().optional({ nullable: true }),
-      query('search').isString().trim(),
+      query('query').isString().trim(),
     ],
     controller.searchPosts,
   )


### PR DESCRIPTION
## Problem

Works towards #688

## Solution

Set up search query (`searchPosts`) on service routes. Search request endpoint will be `/search?agencyId=<number>&query=<string>`.

**Improvements**:

- Add request validation to controller