### PR TITLE
refactor(header): reorg logo render, migrate to Chakra theme

### DIFF
--- a/client/src/components/Header/Header.component.tsx
+++ b/client/src/components/Header/Header.component.tsx
@@ -15,7 +15,6 @@ import { useQuery } from 'react-query'
 import { Link as RouterLink, matchPath, useLocation } from 'react-router-dom'
 import { TagType } from '~shared/types/base'
 import { ReactComponent as Ask } from '../../assets/ask.svg'
-import { ReactComponent as Logo } from '../../assets/logo-alpha.svg'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   getAgencyByShortName,
@@ -218,27 +217,23 @@ const Header = (): JSX.Element => {
           as={RouterLink}
           to={agency ? `/agency/${agency.shortname}` : '/'}
         >
-          {agency ? (
-            <HStack>
-              <Box marginRight="-1px">
-                <Ask />
-              </Box>
-              <Text
-                // Force margins here to override stubborn and temperatmental
-                // Chakra defaults for content within HStack
-                marginInlineStart="0 !important"
-                marginTop="auto !important"
-                marginBottom="1px !important"
-                position="relative"
-                textStyle="logo"
-                color="black"
-              >
-                {agency.shortname.toUpperCase()}
-              </Text>
-            </HStack>
-          ) : (
-            <Logo />
-          )}
+          <HStack>
+            <Box marginRight="-2px">
+              <Ask />
+            </Box>
+            <Text
+              // Force margins here to override stubborn and temperatmental
+              // Chakra defaults for content within HStack
+              marginInlineStart="0 !important"
+              marginTop="auto !important"
+              marginBottom="1px !important"
+              position="relative"
+              textStyle="logo"
+              color="black"
+            >
+              {agency?.shortname.toUpperCase() || 'gov'}
+            </Text>
+          </HStack>
         </Link>
 
         <Flex d={{ base: 'none', sm: 'block' }}>
@@ -260,31 +255,35 @@ const Header = (): JSX.Element => {
     >
       <Masthead />
       {deviceType === device.desktop ? (
-        <LogoBar />
-      ) : matchQuestions ? null : (
-        <Collapse in={headerIsOpen} animateOpacity={false}>
+        <>
           <LogoBar />
-        </Collapse>
-      )}
-      {deviceType === device.desktop && !headerIsOpen ? (
-        <Flex
-          h="56px"
-          m="auto"
-          px={{ base: '24px', md: 'auto' }}
-          maxW="680px"
-          w="100%"
-          mt="-68px"
-          d={{ base: 'none', xl: 'block' }}
-        >
-          <SearchBox agencyId={agency?.id} />
-        </Flex>
-      ) : null}
-      {!matchQuestions && deviceType === device.desktop ? (
-        <Collapse in={headerIsOpen} animateOpacity={false}>
+          {!headerIsOpen ? (
+            <Flex
+              h="56px"
+              m="auto"
+              px={{ base: '24px', md: 'auto' }}
+              maxW="680px"
+              w="100%"
+              mt="-68px"
+            >
+              <SearchBox agencyId={agency?.id} />
+            </Flex>
+          ) : null}
+          {!matchQuestions ? (
+            <Collapse in={headerIsOpen} animateOpacity={false}>
+              <ExpandedSearch />
+            </Collapse>
+          ) : null}
+        </>
+      ) : (
+        <>
+          {!matchQuestions ? (
+            <Collapse in={headerIsOpen} animateOpacity={false}>
+              <LogoBar />
+            </Collapse>
+          ) : null}
           <ExpandedSearch />
-        </Collapse>
-      ) : matchQuestions && deviceType === device.desktop ? null : (
-        <ExpandedSearch />
+        </>
       )}
     </Flex>
   )

--- a/client/src/components/Header/Header.component.tsx
+++ b/client/src/components/Header/Header.component.tsx
@@ -8,6 +8,7 @@ import {
   Link,
   Text,
   useDisclosure,
+  useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 import { BiLinkExternal } from 'react-icons/bi'
@@ -31,6 +32,7 @@ import { SearchBox } from '../SearchBox/SearchBox.component'
 import Spinner from '../Spinner/Spinner.component'
 
 const Header = (): JSX.Element => {
+  const styles = useMultiStyleConfig('Header', {})
   const { user, logout } = useAuth()
 
   const location = useLocation()
@@ -164,37 +166,16 @@ const Header = (): JSX.Element => {
 
   const ExpandedSearch = () => {
     return (
-      <Box
-        bg="white"
-        h={{ base: '100px', xl: '152px' }}
-        className="top-background"
-      >
-        <Flex
-          direction="row"
-          justifyContent="flex-start"
-          className="home-search"
-        >
-          {/* TODO: might need to do some enforcing to ensure you can only */}
-          {/* enter a single agency in the URL */}
-
-          <Flex
-            h="56px"
-            m="auto"
-            mt={{ base: '20px', xl: '64px' }}
-            px={{ base: '24px', md: 'auto' }}
-            maxW="680px"
-            w="100%"
-          >
+      <Box sx={styles.expandedSearchContainer}>
+        <Flex direction="row">
+          <Flex sx={styles.expandedSearch}>
             <SearchBox agencyId={agency?.id} />
           </Flex>
         </Flex>
         {agencyShortName && (
-          <AgencyLogo
-            ml="36px"
-            mt="-55px"
-            display={{ base: 'none', xl: 'flex' }}
-            agency={agency}
-          />
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          <AgencyLogo {...styles.expandedSearchAgencyLogo} agency={agency} />
         )}
       </Box>
     )
@@ -202,41 +183,23 @@ const Header = (): JSX.Element => {
 
   const LogoBar = () => {
     return (
-      <Flex
-        bg="white"
-        justify="space-between"
-        align="center"
-        px={8}
-        py={4}
-        shrink={0}
-      >
+      <Flex justify="space-between" sx={styles.logoBarContainer}>
         <Link
-          _hover={{
-            textDecoration: 'none',
-          }}
+          sx={styles.logoBarRouterLink}
           as={RouterLink}
           to={agency ? `/agency/${agency.shortname}` : '/'}
         >
           <HStack>
-            <Box marginRight="-2px">
+            <Box sx={styles.logoBarAsk}>
               <Ask />
             </Box>
-            <Text
-              // Force margins here to override stubborn and temperatmental
-              // Chakra defaults for content within HStack
-              marginInlineStart="0 !important"
-              marginTop="auto !important"
-              marginBottom="1px !important"
-              position="relative"
-              textStyle="logo"
-              color="black"
-            >
+            <Text sx={styles.logoBarText}>
               {agency?.shortname.toUpperCase() || 'gov'}
             </Text>
           </HStack>
         </Link>
 
-        <Flex d={{ base: 'none', sm: 'block' }}>
+        <Flex sx={styles.logoBarWebsiteLink}>
           {agency?.website && <WebsiteLinks />}
         </Flex>
         {user && <AuthLinks />}
@@ -245,27 +208,13 @@ const Header = (): JSX.Element => {
   }
 
   return (
-    <Flex
-      direction="column"
-      sx={{
-        position: 'sticky',
-        top: '0',
-        'z-index': '999',
-      }}
-    >
+    <Flex direction="column" sx={styles.root}>
       <Masthead />
       {deviceType === device.desktop ? (
         <>
           <LogoBar />
           {!headerIsOpen ? (
-            <Flex
-              h="56px"
-              m="auto"
-              px={{ base: '24px', md: 'auto' }}
-              maxW="680px"
-              w="100%"
-              mt="-68px"
-            >
+            <Flex sx={styles.collapsedSearch}>
               <SearchBox agencyId={agency?.id} />
             </Flex>
           ) : null}

--- a/client/src/theme/components/Header.ts
+++ b/client/src/theme/components/Header.ts
@@ -1,0 +1,74 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const Header: ComponentMultiStyleConfig = {
+  parts: [
+    'root',
+    'collapsedSearch',
+    'expandedSearch',
+    'expandedSearchContainer',
+    'expandedSearchAgencyLogo',
+    'logoBarContainer',
+    'logoBarRouterLink',
+    'logoBarAsk',
+    'logoBarText',
+    'logoBarWebsiteLink',
+  ],
+  baseStyle: () => ({
+    root: {
+      position: 'sticky',
+      top: 0,
+      zIndex: 999,
+    },
+    collapsedSearch: {
+      h: '56px',
+      m: 'auto',
+      px: { base: '24px', md: 'auto' },
+      maxW: '680px',
+      w: '100%',
+      mt: '-68px',
+    },
+    expandedSearchContainer: {
+      bg: 'white',
+      h: { base: '100px', xl: '152px' },
+    },
+    expandedSearchAgencyLogo: {
+      ml: '36px',
+      mt: '-55px',
+      display: { base: 'none', xl: 'flex' },
+    },
+    expandedSearch: {
+      h: '56px',
+      m: 'auto',
+      mt: { base: '20px', xl: '64px' },
+      px: { base: '24px', md: 'auto' },
+      maxW: '680px',
+      w: '100%',
+    },
+    logoBarContainer: {
+      bg: 'white',
+      px: 8,
+      py: 4,
+      shrink: 0,
+      align: 'center',
+    },
+    logoBarRouterLink: {
+      _hover: {
+        textDecoration: 'none',
+      },
+    },
+    logoBarAsk: { marginRight: '-2px' },
+    logoBarText: {
+      // Force margins here to override stubborn and temperamental
+      // Chakra defaults for content within HStack
+      marginInlineStart: '0 !important',
+      marginTop: 'auto !important',
+      marginBottom: '1px !important',
+      position: 'relative',
+      textStyle: 'logo',
+      color: 'black',
+    },
+    logoBarWebsiteLink: {
+      d: { base: 'none', sm: 'block' },
+    },
+  }),
+}

--- a/client/src/theme/components/index.ts
+++ b/client/src/theme/components/index.ts
@@ -3,9 +3,11 @@ import { StyledToast } from './StyledToast'
 import { SearchBox } from './SearchBox'
 import { Pagination } from './Pagination'
 import { ImageUpload } from './ImageUpload'
+import { Header } from './Header'
 
 export const components = {
   Button,
+  Header,
   StyledToast,
   SearchBox,
   Pagination,


### PR DESCRIPTION
## Problem and Solution

- Rework layout for readability
- Rework logo render such that AskGov logo is rendered just like the agency-specific ones
- Migrate styling to Chakra theme, leaving some components alone as they are fairly self-contained

## Screenshots (Before and After)
![image](https://user-images.githubusercontent.com/10572368/142806822-e23c6cfe-491a-4e21-ab72-e747f294444a.png)
