### PR TITLE
refactor: move remaining js(x) files to TypeScript

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,26 +1,18 @@
 module.exports = {
-  extends: ['plugin:prettier/recommended'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  plugins: ['@typescript-eslint'],
   rules: {
     'no-console': 'warn',
     'no-undef': 'error',
   },
-  parser: 'babel-eslint',
-  overrides: [
-    {
-      files: ['src/**/*.jsx?'],
-      extends: ['plugin:react/recommended', 'plugin:prettier/recommended'],
-    },
-    {
-      files: ['src/**/*.ts', 'src/**/*.tsx'],
-      parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint'],
-      extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
-      ],
-    },
-  ],
-  ignorePatterns: ['node_modules/**/*', 'build/**/*'],
+  parser: '@typescript-eslint/parser',
+  ignorePatterns: ['node_modules/**/*', 'build/**/*', 'config-overrides.js'],
+  globals: {
+    JSX: true,
+  },
   env: {
     browser: true,
     node: true,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -53,7 +53,6 @@
         "@types/styled-components": "^5.1.15",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
-        "babel-eslint": "^10.1.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -70,7 +70,6 @@
     "@types/styled-components": "^5.1.15",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "babel-eslint": "^10.1.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/client/src/api/types/post.ts
+++ b/client/src/api/types/post.ts
@@ -14,9 +14,10 @@ export type BasePostDto = BaseModelParams & {
 }
 
 // Backend does not select updatedAt
-export type GetSinglePostDto = Omit<BasePostDto, 'updatedAt'> & {
+export type GetSinglePostDto = BasePostDto & {
   tags: BaseTagDto[]
   user: Pick<User, 'displayname'>
+  relatedPosts: BasePostDto[]
 }
 
 export type GetPostsDto = {

--- a/client/src/components/OptionsMenu/OptionsMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsMenu.component.tsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import { BiRightArrowAlt } from 'react-icons/bi'
-import { useEffect, useState, ReactElement, createRef } from 'react'
+import { LegacyRef, useEffect, useState, ReactElement, createRef } from 'react'
 import { useQuery } from 'react-query'
 import { Link as RouterLink, useParams } from 'react-router-dom'
 import { Topic } from '~shared/types/base'
@@ -57,7 +57,7 @@ const OptionsMenu = (): ReactElement => {
     setHasTopicsKey(topicsSpecified)
   })
 
-  const accordionRef: React.LegacyRef<HTMLButtonElement> = createRef()
+  const accordionRef: LegacyRef<HTMLButtonElement> = createRef()
 
   const googleAnalytics = useGoogleAnalytics()
 

--- a/client/src/components/PostItem/PostItem.component.tsx
+++ b/client/src/components/PostItem/PostItem.component.tsx
@@ -1,13 +1,16 @@
 import { Link, Text } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
-import { TagType } from '~shared/types/base'
+import { BasePostDto } from '../../api'
 import { useAuth } from '../../contexts/AuthContext'
 import EditButton from '../EditButton/EditButton.component'
-import { RichTextFrontPreview } from '../RichText/RichTextEditor.component'
 import './PostItem.styles.scss'
 
 // Note: PostItem is the component for the homepage
-const PostItem = ({ post: { id, title, tags, agencyId } }) => {
+const PostItem = ({
+  post: { id, title, tags, agencyId },
+}: {
+  post: BasePostDto
+}): JSX.Element => {
   const { user } = useAuth()
 
   const isAgencyMember = user && tags && user.agencyId === agencyId

--- a/client/src/components/PostList/PostList.component.tsx
+++ b/client/src/components/PostList/PostList.component.tsx
@@ -1,23 +1,19 @@
-import PostItem from '../../components/PostItem/PostItem.component'
-
 import { Text } from '@chakra-ui/react'
-import { useQuery } from 'react-query'
-import { useParams } from 'react-router-dom'
-import {
-  getAgencyByShortName,
-  GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
-} from '../../services/AgencyService'
-import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import * as FullStory from '@fullstory/browser'
 import { useEffect, useRef } from 'react'
+import { useParams } from 'react-router-dom'
+import { BasePostDto } from '../../api'
+import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
+import PostItem from '../PostItem/PostItem.component'
 
-const PostList = ({ posts, defaultText, alertIfMoreThanDays }) => {
+const PostList = ({
+  posts,
+  defaultText,
+}: {
+  posts?: BasePostDto[]
+  defaultText?: string
+}): JSX.Element => {
   const { agency: agencyShortName } = useParams()
-  const { data: agency } = useQuery(
-    [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
-    () => getAgencyByShortName({ shortname: agencyShortName }),
-    { enabled: !!agencyShortName },
-  )
   defaultText = defaultText ?? 'There are no posts to display.'
 
   // Creates reference for maxScroll variable with initial value of 0
@@ -28,7 +24,7 @@ const PostList = ({ posts, defaultText, alertIfMoreThanDays }) => {
     maxScroll.current = Math.max(maxScroll.current, window.pageYOffset)
   }
 
-  const sendMaxScrollToAnalytics = (maxScrollPossible) => {
+  const sendMaxScrollToAnalytics = (maxScrollPossible: number) => {
     // The following is required to restrict the percentage to 100 due to browser compatibility issues:
     // https://stackoverflow.com/questions/17688595/finding-the-maximum-scroll-position-of-a-page
     maxScrollPossible = Math.max(maxScrollPossible, maxScroll.current)
@@ -46,7 +42,7 @@ const PostList = ({ posts, defaultText, alertIfMoreThanDays }) => {
     })
   }
 
-  const removeListenerAndSendEvent = (maxScrollPossible) => {
+  const removeListenerAndSendEvent = (maxScrollPossible: number) => {
     window.removeEventListener('scroll', updateMaxScroll)
     if (maxScroll.current !== 0) sendMaxScrollToAnalytics(maxScrollPossible)
   }
@@ -75,12 +71,7 @@ const PostList = ({ posts, defaultText, alertIfMoreThanDays }) => {
       {posts && posts.length > 0 ? (
         <div className="questions">
           {posts.map((post) => (
-            <PostItem
-              key={post.id}
-              post={post}
-              alertIfMoreThanDays={alertIfMoreThanDays}
-              agency={agency}
-            />
+            <PostItem key={post.id} post={post} />
           ))}
         </div>
       ) : (

--- a/client/src/components/QuestionsList/QuestionsList.component.tsx
+++ b/client/src/components/QuestionsList/QuestionsList.component.tsx
@@ -13,8 +13,8 @@ import Spinner from '../Spinner/Spinner.component'
 
 interface QuestionsListProps {
   sort: string
-  agencyId: number
-  tags: string
+  agencyId?: number
+  tags?: string
   topics: string
   pageSize: number
   footerControl?: JSX.Element
@@ -74,7 +74,6 @@ const QuestionsList = ({
       <PostListComponent
         posts={data?.posts.slice(0, pageSize)}
         defaultText={undefined}
-        alertIfMoreThanDays={undefined}
       />
       <Center my={5}>
         {footerControl ?? (

--- a/client/src/components/RichText/ImageControl.tsx
+++ b/client/src/components/RichText/ImageControl.tsx
@@ -22,7 +22,13 @@ import {
   Divider,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
-import { MouseEventHandler, useState } from 'react'
+import {
+  ChangeEvent,
+  DragEvent,
+  MouseEvent,
+  MouseEventHandler,
+  useState,
+} from 'react'
 import { BiImage, BiTrash, BiCloudUpload } from 'react-icons/bi'
 import { UploadCallback } from './RichTextEditor.component'
 
@@ -59,7 +65,7 @@ export const ImageControl = ({
     isOpen: isImageModalOpen,
   } = useDisclosure()
 
-  const stopPropagation = (e: React.MouseEvent<HTMLElement>) => {
+  const stopPropagation = (e: MouseEvent<HTMLElement>) => {
     if (!fileUpload) {
       e.preventDefault()
       e.stopPropagation()
@@ -81,12 +87,12 @@ export const ImageControl = ({
     setImgSrc('')
     setAlt('')
   }
-  const fileUploadClick = (e: React.MouseEvent<HTMLElement>) => {
+  const fileUploadClick = (e: MouseEvent<HTMLElement>) => {
     setFileUpload(true)
     e.stopPropagation()
   }
 
-  const onDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+  const onDragEnter = (e: DragEvent<HTMLDivElement>) => {
     e.stopPropagation()
   }
 
@@ -113,7 +119,7 @@ export const ImageControl = ({
       })
   }
 
-  const onImageDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  const onImageDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     e.stopPropagation()
 
@@ -142,7 +148,7 @@ export const ImageControl = ({
     }
   }
 
-  const selectImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const selectImage = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       uploadImage(e.target.files[0])
     }
@@ -254,7 +260,7 @@ export const ImageControl = ({
                       value={alt}
                       isRequired
                       placeholder="e.g. Table of the different quarantine types"
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
                         setAlt(e.target.value)
                       }
                     />

--- a/client/src/components/RichText/LinkControl.tsx
+++ b/client/src/components/RichText/LinkControl.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Input, Text } from '@chakra-ui/react'
-import { MouseEventHandler, useState } from 'react'
+import { ChangeEvent, MouseEvent, MouseEventHandler, useState } from 'react'
 import { BiLink } from 'react-icons/bi'
 import { useStyledToast } from '../StyledToast/StyledToast'
 import styles from './RichTextEditor.module.scss'
@@ -46,7 +46,7 @@ export const LinkControl = ({
     }
   }
 
-  const stopPropagation = (e: React.MouseEvent<HTMLElement>) => {
+  const stopPropagation = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation()
   }
 
@@ -66,7 +66,7 @@ export const LinkControl = ({
           <Input
             value={url}
             type="text"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setURL(e.target.value)
             }
           />

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -33,7 +33,7 @@ import {
 import { isUserPublicOfficer } from '../../services/user.service'
 import { getTopicsQuery, isSpecified } from '../../util/urlparser'
 
-const HomePage = () => {
+const HomePage = (): JSX.Element => {
   const [hasTopicsKey, setHasTopicsKey] = useState(false)
   const navigate = useNavigate()
   // check URL
@@ -50,7 +50,7 @@ const HomePage = () => {
   const { agency: agencyShortName } = useParams()
   const { data: agency } = useQuery(
     [GET_AGENCY_BY_SHORTNAME_QUERY_KEY, agencyShortName],
-    () => getAgencyByShortName({ shortname: agencyShortName }),
+    () => getAgencyByShortName({ shortname: `${agencyShortName}` }),
     { enabled: !!agencyShortName },
   )
 
@@ -68,7 +68,7 @@ const HomePage = () => {
   const [sortState, setSortState] = useState(options[1])
   const [queryState, setQueryState] = useState('')
 
-  const isAuthenticatedOfficer = isUserPublicOfficer(user)
+  const isAuthenticatedOfficer = user !== null && isUserPublicOfficer(user)
 
   return (
     <Flex direction="column" height="100%" className="home-page">
@@ -130,8 +130,8 @@ const HomePage = () => {
               spacing={{ base: 2, sm: 4 }}
               direction={{ base: 'column', md: 'row' }}
             >
-              <Menu matchWidth autoSelect={false} offset={0}>
-                {({ isOpen }) => (
+              <Menu matchWidth autoSelect={false} offset={[0, 0]}>
+                {() => (
                   <>
                     <MenuButton
                       as={Button}

--- a/client/src/pages/Post/AnswerSection/AnswerSection.component.tsx
+++ b/client/src/pages/Post/AnswerSection/AnswerSection.component.tsx
@@ -1,9 +1,14 @@
 import { SkeletonText } from '@chakra-ui/react'
+import { GetAnswersForPostDto } from '../../../api'
+import { sortByCreatedAt } from '../../../util/date'
 import AnswerItem from './AnswerItem/AnswerItem.component'
 import './AnswerSection.styles.scss'
-import { sortByCreatedAt } from '../../../util/date'
 
-const AnswerSection = ({ answers }) => {
+const AnswerSection = ({
+  answers,
+}: {
+  answers?: GetAnswersForPostDto
+}): JSX.Element => {
   return !answers ? (
     <SkeletonText />
   ) : (

--- a/client/src/pages/Post/QuestionSection/PostCell/PostCell.component.tsx
+++ b/client/src/pages/Post/QuestionSection/PostCell/PostCell.component.tsx
@@ -1,11 +1,15 @@
 import { RichTextPreview } from '../../../../components/RichText/RichTextEditor.component'
 import './PostCell.styles.scss'
 
-const PostCell = ({ post }) => {
+const PostCell = ({
+  post,
+}: {
+  post?: { description: string }
+}): JSX.Element => {
   return (
     <>
       <div className="post-cell">
-        {post.description && (
+        {post?.description && (
           <div className="post-text">
             <RichTextPreview value={post.description} />
           </div>

--- a/client/src/pages/Post/QuestionSection/QuestionSection.component.tsx
+++ b/client/src/pages/Post/QuestionSection/QuestionSection.component.tsx
@@ -2,7 +2,11 @@ import PostCell from './PostCell/PostCell.component'
 
 import './QuestionSection.styles.scss'
 
-const QuestionSection = ({ post }) => {
+const QuestionSection = ({
+  post,
+}: {
+  post?: { description: string }
+}): JSX.Element => {
   return (
     <>
       <div className="question">

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -1,4 +1,0 @@
-import { PermissionType } from '~shared/types/base'
-
-export const isUserPublicOfficer = (user) =>
-  !!user?.username?.endsWith('.gov.sg')

--- a/client/src/services/user.service.ts
+++ b/client/src/services/user.service.ts
@@ -1,0 +1,4 @@
+import { User } from '~shared/types/base'
+
+export const isUserPublicOfficer = (user?: User): boolean =>
+  !!user?.username?.endsWith('.gov.sg')


### PR DESCRIPTION
## Problem

Because we still have vanilla JavaScript files, we still have to keep babel-eslint,
which is holding us back from the eslint v8

## Solution

- Convert all remaining js/jsx files to TypeScript, adjusting
  for types in the process
- Remove references to React global, using proper imports instead
- Configure eslint to recognise the JSX global and ignore the
  react-scripts config overrides
