### PR TITLE
fix(search): correct typo in env var SEARCH_PORT

### DIFF
--- a/server/src/bootstrap/config/search.ts
+++ b/server/src/bootstrap/config/search.ts
@@ -33,7 +33,7 @@ const searchSchema: Schema<SearchConfig> = {
     doc: 'Port for opensearch service',
     format: 'port',
     default: 9200,
-    env: 'SEARCH_POST',
+    env: 'SEARCH_PORT',
   },
 }
 


### PR DESCRIPTION
## Problem

Code base was trying to import `SEARCH_POST` instead of `SEARCH_PORT` (oops)

## Solution

Correct typo above.
