### PR TITLE
feat(search): expose search query endpoint

### DIFF
--- a/server/src/modules/search/__tests__/search.routes.spec.ts
+++ b/server/src/modules/search/__tests__/search.routes.spec.ts
@@ -5,9 +5,9 @@ import supertest from 'supertest'
 import { SearchController } from '../search.controller'
 import { routeSearch } from '../search.routes'
 
-describe('/search', () => {
-  describe('GET /search', () => {
-    const path = '/search'
+describe('/', () => {
+  describe('GET /', () => {
+    const path = '/'
 
     const answersService = {
       listAnswers: jest.fn(),
@@ -105,7 +105,6 @@ describe('/search', () => {
     })
 
     it('uses trimmed search query to search posts', async () => {
-      const path = '/search'
       const app = express()
       app.use(router)
       const request = supertest(app)

--- a/server/src/modules/search/search.routes.ts
+++ b/server/src/modules/search/search.routes.ts
@@ -17,7 +17,7 @@ export const routeSearch = ({
    * @access  Public
    */
   router.get(
-    '/search',
+    '/',
     [
       query('agencyId').isInt().toInt().optional({ nullable: true }),
       query('query').isString().trim(),

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -15,6 +15,8 @@ import { FileController } from '../modules/file/file.controller'
 import { routeFiles } from '../modules/file/file.routes'
 import { PostController } from '../modules/post/post.controller'
 import { routePosts } from '../modules/post/post.routes'
+import { SearchController } from '../modules/search/search.controller'
+import { routeSearch } from '../modules/search/search.routes'
 import { TagsController } from '../modules/tags/tags.controller'
 import { routeTags } from '../modules/tags/tags.routes'
 import { TopicsController } from '../modules/topics/topics.controller'
@@ -50,6 +52,7 @@ type ApiRouterOptions = {
     controller: TopicsController
     authMiddleware: AuthMiddleware
   }
+  search: SearchController
 }
 
 export const api = (options: ApiRouterOptions): express.Router => {
@@ -64,6 +67,7 @@ export const api = (options: ApiRouterOptions): express.Router => {
   router.use('/agencies', routeAgencies(options.agency))
   router.use('/enquiries', routeEnquiries({ controller: options.enquiries }))
   router.use('/topics', routeTopics(options.topics))
+  router.use('/search', routeSearch({ controller: options.search }))
 
   return router
 }


### PR DESCRIPTION
- use relative paths for routes within search module
- mount search routes on app

Closes #688

Note: As data has not been indexed on opensearch and my mistake of creating custom errors, the generic 'Internal Server Error' message will be returned when the search endpoint is hit. This will be fixed in PR #816. For now, opensearch errors can be viewed on [CloudWatch](https://ap-southeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-1#logsV2:log-groups/log-group/$252Faws$252Felasticbeanstalk$252Fhelpgovsg-staging-env$252Fvar$252Flog$252Feb-docker$252Fcontainers$252Feb-current-app$252Fstdouterr.log).

## Tests

Send a GET request to `/api/v1/search?query=hi`. Return body should be `{"message":"Internal Server Error"}`. 

If not mounted properly, return body will be the standard `/not-found` response, which is the standard `index.html` page for built apps and the following if in development environment:

```html
<!DOCTYPE html>
<html lang="en">

<head>
	<meta charset="utf-8">
	<title>Error</title>
</head>

<body>
	<pre>Cannot GET /api/v1/search</pre>
</body>

</html>
```
