### PR TITLE
fix(post): fix getRelatedPosts sequelize query

### DIFF
--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -128,14 +128,16 @@ export class PostService {
           attributes: {
             include: [
               [
-                Sequelize.fn('COUNT', Sequelize.col('topicId')),
-                'relatedTopics',
+                Sequelize.literal(
+                  `CASE WHEN TopicId = ${post.topicId} THEN 1 ELSE 0 END`,
+                ),
+                'relatedTopic',
               ],
               [Sequelize.fn('COUNT', Sequelize.col('tags.id')), 'relatedTags'],
             ] as ProjectionAlias[],
           },
           order: [
-            [Sequelize.col('relatedTopics'), 'DESC'],
+            [Sequelize.col('relatedTopic'), 'DESC'],
             [Sequelize.col('relatedTags'), 'DESC'],
             ['views', 'DESC'],
           ] as OrderItem[],
@@ -173,7 +175,7 @@ export class PostService {
           },
         },
       ],
-      group: 'id',
+      group: ['id'],
       subQuery: false,
       limit: numberOfRelatedPosts,
     })


### PR DESCRIPTION
## Problem

getRelatedPosts does not follow the intended ordering of posts, namely that posts with the same topicId are not displayed at the top.

## Solution

Instead of `COUNT`, use a `CASE WHEN` to identity posts with the same topicId

## Before & After Screenshots

**BEFORE**:

![Screenshot 2021-11-24 at 12 49 28 PM](https://user-images.githubusercontent.com/56983748/143177045-39801832-6abc-413a-8a71-6feda902ee31.png)
**AFTER**:
![Screenshot 2021-11-24 at 12 51 44 PM](https://user-images.githubusercontent.com/56983748/143177049-33fddf29-53fe-4d50-b253-3de42c692039.png)

