### PR TITLE
feat(imagecontrol): change background of image upload box upon hover

### DIFF
--- a/client/src/components/RichText/ImageControl.tsx
+++ b/client/src/components/RichText/ImageControl.tsx
@@ -58,6 +58,7 @@ export const ImageControl = ({
   const [imageLoading, setImageLoading] = useState(false)
   const [fileName, setFileName] = useState('')
   const [fileSize, setFileSize] = useState(0)
+  const [isDragOver, setIsDragOver] = useState(false)
   const WIDTH = '100%'
 
   const {
@@ -95,6 +96,12 @@ export const ImageControl = ({
 
   const onDragEnter = (e: DragEvent<HTMLDivElement>) => {
     e.stopPropagation()
+    setIsDragOver(true)
+  }
+
+  const onDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+    setIsDragOver(false)
   }
 
   const toggleShowImageLoading = () => {
@@ -123,7 +130,7 @@ export const ImageControl = ({
   const onImageDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     e.stopPropagation()
-
+    setIsDragOver(false)
     // Check if property name is files or items
     // IE uses 'files' instead of 'items'
     let data
@@ -206,43 +213,59 @@ export const ImageControl = ({
                         </HStack>
                       </Box>
                     ) : (
-                      <Box
-                        sx={styles.fileUploadBox}
-                        onClick={fileUploadClick}
-                        onDragEnter={onDragEnter}
-                        onDragOver={stopPropagation}
-                        onDrop={onImageDrop}
-                        cursor="pointer"
-                      >
-                        <label
-                          htmlFor="file"
-                          className="rdw-image-modal-upload-option-label"
+                      <VStack alignContent="left" alignItems="left">
+                        <Box
+                          bg={isDragOver ? 'secondary.200' : 'secondary.100'}
+                          border={isDragOver ? '1px' : '2px'}
+                          borderColor={
+                            isDragOver ? 'Secondary.800' : 'neutral.700'
+                          }
+                          borderStyle={isDragOver ? 'solid' : 'dashed'}
+                          sx={styles.fileUploadBox}
+                          onClick={fileUploadClick}
+                          onDragEnter={onDragEnter}
+                          onDragOver={stopPropagation}
+                          onDragLeave={onDragLeave}
+                          onDrop={onImageDrop}
+                          cursor="pointer"
+                          className="image-modal-upload-box"
                         >
-                          <Flex>
-                            <VStack>
-                              <BiCloudUpload size="50px" />
+                          <label
+                            htmlFor="file"
+                            className="rdw-image-modal-upload-option-label"
+                          >
+                            {isDragOver ? (
+                              <Text sx={styles.dragOverText}>
+                                Drop media to upload
+                              </Text>
+                            ) : (
                               <Flex>
-                                <Text sx={styles.fileUploadText} as="u">
-                                  Choose file
-                                </Text>
-                                <Text sx={styles.fileUploadText}>
-                                  &nbsp;or drag and drop here
-                                </Text>
+                                <VStack>
+                                  <BiCloudUpload size="50px" />
+                                  <Flex>
+                                    <Text sx={styles.fileUploadText} as="u">
+                                      Choose file
+                                    </Text>
+                                    <Text sx={styles.fileUploadText}>
+                                      &nbsp;or drag and drop here
+                                    </Text>
+                                  </Flex>
+                                </VStack>
                               </Flex>
-                            </VStack>
-                          </Flex>
-                        </label>
-                        <input
-                          type="file"
-                          id="file"
-                          accept={config.inputAccept}
-                          onChange={selectImage}
-                          className="rdw-image-modal-upload-option-input"
-                        />
-                        <Text textStyle="body-2" pt="8px">
+                            )}
+                          </label>
+                          <Input
+                            type="file"
+                            id="file"
+                            accept={config.inputAccept}
+                            onChange={selectImage}
+                            className="rdw-image-modal-upload-option-input"
+                          />
+                        </Box>
+                        <Text sx={styles.maxFileSizeText}>
                           Maximum file size: 10MB
                         </Text>
-                      </Box>
+                      </VStack>
                     )}
                   </TabPanel>
                 </TabPanels>

--- a/client/src/theme/components/ImageControl.tsx
+++ b/client/src/theme/components/ImageControl.tsx
@@ -8,6 +8,7 @@ export const ImageControl: ComponentMultiStyleConfig = {
     'uploadedLargeBox',
     'uploadedImageFlexBox',
     'fileUploadBox',
+    'dragOverText',
     'fileUploadText',
     'fileUploadFormatText',
     'altTextBox',
@@ -15,6 +16,7 @@ export const ImageControl: ComponentMultiStyleConfig = {
     'buttonsFlexBox',
     'cancelButton',
     'submitButton',
+    'maxFileSizeText',
   ],
   baseStyle: () => ({
     box: {
@@ -63,10 +65,10 @@ export const ImageControl: ComponentMultiStyleConfig = {
     fileUploadBox: {
       w: '600px',
       h: '216px',
-      bg: 'secondary.100',
-      border: '1px',
-      borderColor: 'Secondary.100',
-      borderStyle: 'dashed',
+    },
+    dragOverText: {
+      textStyle: 'subhead-1',
+      color: 'secondary.800',
     },
     fileUploadText: {
       fontFamily: 'Inter',
@@ -107,6 +109,9 @@ export const ImageControl: ComponentMultiStyleConfig = {
       textStyle: 'subhead-1',
       backgroundColor: 'secondary.700',
       color: 'white',
+    },
+    maxFileSizeText: {
+      textStyle: 'body-2',
     },
   }),
 }


### PR DESCRIPTION
## Problem and Solution

Change the background of the image upload area when a file is dragged over it, to better indicate the image upload tool's drag and drop functionality. [Figma reference](https://www.figma.com/file/O6lxjjfn04Ow6nn2TMStpk/AskGov-Design-Master-v2?node-id=6430%3A78425) 

Closes #847


## Before & After Screenshots

**BEFORE**:

| Before | After |
| - | - |
| <img width="889" alt="Screenshot 2021-11-26 at 3 09 05 PM" src="https://user-images.githubusercontent.com/56983748/143541095-cebc823d-3117-44d0-acbc-9ef754a8fb61.png"> | <img width="905" alt="Screenshot 2021-11-26 at 3 08 20 PM" src="https://user-images.githubusercontent.com/56983748/143541080-2cb784dc-31b6-4f31-a3a9-7661689fdaef.png"> |

## Tests

- Post a new question, drag and drop an image into the image upload tool. The background of the upload area should change when a file hovers over it.