### PR TITLE
feat(search): set doc _id as postId to access search entries with postId easily

### DIFF
--- a/server/src/modules/search/__tests__/search.controller.spec.ts
+++ b/server/src/modules/search/__tests__/search.controller.spec.ts
@@ -123,7 +123,7 @@ describe('SearchController', () => {
           id: 3,
           options: {},
           params: {
-            body: '{"query":{"multi_match":{"query":"title 20","fields":["title","description","answer"],"type":"most_fields","zero_terms_query":"all","fuzziness":"AUTO"}}}',
+            body: '{"query":{"multi_match":{"query":"title 20","fields":["title","description","answers"],"type":"most_fields","zero_terms_query":"all","fuzziness":"AUTO"}}}',
             headers: {
               'content-length': '153',
               'content-type': 'application/json',

--- a/server/src/modules/search/__tests__/search.service.spec.ts
+++ b/server/src/modules/search/__tests__/search.service.spec.ts
@@ -57,7 +57,7 @@ describe('Search Service', () => {
     searchEntriesDataset.push({
       title: `title ${i * 10}`,
       description: `description ${i * 100}`,
-      answer: `answer ${i * 1000}`,
+      answers: [`answer ${i * 1000}`],
       agencyId: i,
       postId: i,
       topicId: null,

--- a/server/src/modules/search/backfill/__tests__/backfill.service.spec.ts
+++ b/server/src/modules/search/backfill/__tests__/backfill.service.spec.ts
@@ -78,7 +78,7 @@ describe('BackfillSearchService', () => {
         },
       )
       const body = searchEntriesDataset.flatMap((doc) => [
-        { index: { _index: indexName } },
+        { index: { _index: indexName, _id: doc.postId } },
         doc,
       ])
       mock.add(
@@ -139,7 +139,7 @@ describe('BackfillSearchService', () => {
         },
       )
       const body = searchEntriesDataset.flatMap((doc) => [
-        { index: { _index: indexName } },
+        { index: { _index: indexName, _id: doc.postId } },
         doc,
       ])
       mock.add(

--- a/server/src/modules/search/backfill/__tests__/backfill.service.spec.ts
+++ b/server/src/modules/search/backfill/__tests__/backfill.service.spec.ts
@@ -1,7 +1,8 @@
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
 import { StatusCodes } from 'http-status-codes'
 import { Mocker } from '../../opensearch-mock'
-import { BackfillService, SearchEntry } from '../backfill.service'
+import { BackfillService } from '../backfill.service'
+import { SearchEntry } from '../../search.service'
 
 // // Uncomment to test with live opensearch service
 // import { baseConfig, Environment } from '../../../bootstrap/config/base'
@@ -57,7 +58,7 @@ describe('BackfillSearchService', () => {
     searchEntriesDataset.push({
       title: `title ${i * 10}`,
       description: `description ${i * 100}`,
-      answer: `answer ${i * 1000}`,
+      answers: [`answer ${i * 1000}`],
       agencyId: i,
       postId: i,
       topicId: null,

--- a/server/src/modules/search/backfill/backfill.controller.ts
+++ b/server/src/modules/search/backfill/backfill.controller.ts
@@ -6,7 +6,8 @@ import { AnswersService } from '../../answers/answers.service'
 import { DatabaseError } from '../../core/core.errors'
 import { InvalidTagsError, InvalidTopicsError } from '../../post/post.errors'
 import { PostService } from '../../post/post.service'
-import { BackfillService, SearchEntry } from './backfill.service'
+import { SearchEntry } from '../search.service'
+import { BackfillService } from './backfill.service'
 
 const logger = createLogger(module)
 
@@ -75,13 +76,19 @@ export class BackfillController {
               return err as DatabaseError
             },
           ).map((answers) => {
+            const answerBodyList = []
+            for (const answer of answers) {
+              answerBodyList.push(
+                sanitizeHtml(answer.body, {
+                  allowedTags: [],
+                  allowedAttributes: {},
+                }),
+              )
+            }
             searchEntriesDataset.push({
               title: post.title,
               description: post.description,
-              answer: sanitizeHtml(answers[0].body, {
-                allowedTags: [],
-                allowedAttributes: {},
-              }),
+              answers: answerBodyList,
               agencyId: post.agencyId,
               postId: post.id,
               topicId: post.topicId,

--- a/server/src/modules/search/backfill/backfill.service.ts
+++ b/server/src/modules/search/backfill/backfill.service.ts
@@ -74,7 +74,7 @@ export class BackfillService {
     // If testing on live opensearch instance for 'should return error documents some
     // operations for client.bulk fail', change _index value to a camel case string.
     const body = searchEntriesDataset.flatMap((doc) => [
-      { index: { _index: indexName } },
+      { index: { _index: indexName, _id: doc.postId } },
       doc,
     ])
     return await ResultAsync.fromPromise(

--- a/server/src/modules/search/backfill/backfill.service.ts
+++ b/server/src/modules/search/backfill/backfill.service.ts
@@ -4,20 +4,12 @@ import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { createLogger } from '../../../bootstrap/logging'
+import { SearchEntry } from '../search.service'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { errors } = require('@opensearch-project/opensearch')
 
 const logger = createLogger(module)
-
-export type SearchEntry = {
-  title: string
-  description: string | null
-  answer: string
-  agencyId: number
-  postId: number
-  topicId: number | null
-}
 
 export class BackfillService {
   private client: Client

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -1,22 +1,15 @@
 import { Client } from '@opensearch-project/opensearch'
-import {
-  BulkResponseItemBase,
-  QueryDslMultiMatchQuery,
-} from '@opensearch-project/opensearch/api/types'
+import { QueryDslMultiMatchQuery } from '@opensearch-project/opensearch/api/types'
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
-import { StatusCodes } from 'http-status-codes'
-import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { ResultAsync } from 'neverthrow'
 import { createLogger } from '../../bootstrap/logging'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { errors } = require('@opensearch-project/opensearch')
 
 const logger = createLogger(module)
 
 export type SearchEntry = {
   title: string
   description: string | null
-  answer: string
+  answers: string[]
   agencyId: number
   postId: number
   topicId: number | null
@@ -39,7 +32,7 @@ export class SearchService {
   searchPosts = async (index: string, query: string, agencyId?: number) => {
     const multiMatchQuery: QueryDslMultiMatchQuery = {
       query: query,
-      fields: ['title', 'description', 'answer'],
+      fields: ['title', 'description', 'answers'],
       type: 'most_fields',
       fuzziness: 'AUTO',
     }


### PR DESCRIPTION
## Problem

As services to post and answer tables are separate, operations to add and update posts on the opensearch index have to be able to accommodate having questions and answers added separately too. In addition, doing so would allow for easier implementation of having questions and answers added by members of the public.

## Solution

- Set document _id as postId for easy access of search entries
- Change `answer` field to `answers` and take in list of answers. 

## Tests

Send a search query which will give results (e.g. "/search?query=What"). In the results returned in the response body, we should observe that for the search results:
1. `_id` should be the same as their `postId` 
2. `answers` should contain a list of strings
