### PR TITLE
Add line to docker-compose.yml to specify platform for Apple Silicon Mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - '1025:25'
 
   db:
+    platform: linux/x86_64
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
     restart: always


### PR DESCRIPTION
## Problem

Error message `no matching manifest for linux/arm64/v8 in the manifest list entries` when trying to set up project on an Apple Silicon Mac because mysql image is not available for ARM64.

Closes https://github.com/opengovsg/askgovsg/issues/894

## Solution

To get Docker to play nicely with an Apple Silicon Mac, adding this line to dock-compose.yml is necessary: `platform: linux/x86_64`

For detailed discussion, see [this Stack Overflow post](https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8) and [this in the Docker documentation](https://docs.docker.com/desktop/mac/apple-silicon/#:~:text=Not%20all%20images%20are%20available%20for%20ARM64%20architecture.%20You%20can%20add%20%2D%2Dplatform%20linux/amd64%20to%20run%20an%20Intel%20image%20under%20emulation.%20In%20particular%2C%20the%20mysql%20image%20is%20not%20available%20for%20ARM64.%20You%20can%20work%20around%20this%20issue%20by%20using%20a%20mariadb%20image.). 

An alternative solution suggested in the links above is to use `mariadb` instead of `mysql`. I'm not very familiar with the relative pros and cons of either solution and did not try this solution myself.