### PR TITLE
feat(search): add updatePost to answer service

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -128,7 +128,12 @@ const postService = new PostService({
 })
 const enquiryService = new EnquiryService({ Agency, mailService })
 const recaptchaService = new RecaptchaService({ axios, ...recaptchaConfig })
-const answersService = new AnswersService({ Post, Answer })
+const answersService = new AnswersService({
+  Post,
+  Answer,
+  searchSyncService,
+  sequelize,
+})
 const topicsService = new TopicsService({ Topic })
 const userService = new UserService({ User, Tag, Agency })
 

--- a/server/src/bootstrap/search-backfill-trigger.ts
+++ b/server/src/bootstrap/search-backfill-trigger.ts
@@ -17,8 +17,13 @@ const triggerIndexAllData = async (searchController: BackfillController) => {
 // To delete search_entries index locally: curl -XDELETE 'https://localhost:9200/search_entries' --insecure -u 'admin:admin'
 
 if (require.main === module) {
-  const answersService = new AnswersService({ Post, Answer })
   const searchSyncService = new SyncService({ client: searchClient })
+  const answersService = new AnswersService({
+    Post,
+    Answer,
+    searchSyncService,
+    sequelize,
+  })
   const postService = new PostService({
     Answer,
     Post,

--- a/server/src/modules/answers/answers.service.ts
+++ b/server/src/modules/answers/answers.service.ts
@@ -1,21 +1,37 @@
-import { Answer, PostStatus, Post } from '~shared/types/base'
-import { ModelDef } from '../../types/sequelize'
+import type { Sequelize as SequelizeType } from 'sequelize'
+import { Answer, Post, PostStatus } from '~shared/types/base'
 import { PostCreation } from '../../models/posts.model'
+import { ModelDef } from '../../types/sequelize'
+import { ApplicationError } from '../core/core.errors'
+import { SyncService as SearchSyncService } from '../search/sync/sync.service'
 
 export class AnswersService {
   private Post: ModelDef<Post, PostCreation>
   private Answer: ModelDef<Answer>
+  private searchSyncService: Pick<
+    SearchSyncService,
+    'createPost' | 'updatePost'
+  >
+  private sequelize: SequelizeType
 
   constructor({
     Post,
     Answer,
+    searchSyncService,
+    sequelize,
   }: {
     Post: ModelDef<Post, PostCreation>
     Answer: ModelDef<Answer>
+    searchSyncService: Pick<SearchSyncService, 'createPost' | 'updatePost'>
+    sequelize: SequelizeType
   }) {
     this.Post = Post
     this.Answer = Answer
+    this.searchSyncService = searchSyncService
+    this.sequelize = sequelize
   }
+
+  private searchIndexName = 'search_entries'
 
   /**
    * Returns all answers to a post
@@ -41,16 +57,34 @@ export class AnswersService {
     body,
     userId,
   }: Pick<Answer, 'body' | 'postId' | 'userId'>): Promise<number> => {
-    const answer = await this.Answer.create({
-      postId: postId,
-      body: body,
-      userId: userId,
-    })
-    await this.Post.update(
-      { status: PostStatus.Public },
-      { where: { id: postId } },
-    )
-    return answer.id
+    try {
+      const answerId = await this.sequelize.transaction(async (transaction) => {
+        const answer = await this.Answer.create(
+          {
+            postId: postId,
+            body: body,
+            userId: userId,
+          },
+          { transaction },
+        )
+        await this.Post.update(
+          { status: PostStatus.Public },
+          { where: { id: postId }, transaction },
+        )
+        const updatePostResponse = await this.searchSyncService.updatePost(
+          this.searchIndexName,
+          {
+            postId,
+            answers: [body],
+          },
+        )
+        if (updatePostResponse.isErr()) throw updatePostResponse.error
+        return answer.id
+      })
+      return answerId
+    } catch (error) {
+      throw error
+    }
   }
 
   /**
@@ -63,12 +97,34 @@ export class AnswersService {
     id: number
     body: string
   }): Promise<number> => {
-    const res = await this.Answer.update(
-      { body: updatedAnswer.body },
-      { where: { id: updatedAnswer.id } },
-    )
-    const changedRows = res[0]
-    return changedRows
+    try {
+      const answersChanged = await this.sequelize.transaction(
+        async (transaction) => {
+          const answers = await this.Answer.update(
+            { body: updatedAnswer.body },
+            { where: { id: updatedAnswer.id }, transaction },
+          )
+          const answerFound = await this.Answer.findByPk(updatedAnswer.id)
+          if (!answerFound) {
+            throw new ApplicationError(
+              `No answers of id ${updatedAnswer.id} found`,
+            )
+          }
+          const updatePostResponse = await this.searchSyncService.updatePost(
+            this.searchIndexName,
+            {
+              postId: answerFound.postId,
+              answers: [updatedAnswer.body],
+            },
+          )
+          if (updatePostResponse.isErr()) throw updatePostResponse.error
+          return answers[0]
+        },
+      )
+      return answersChanged
+    } catch (error) {
+      throw error
+    }
   }
 
   /**

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -638,9 +638,7 @@ export class PostService {
               postId: post.id,
             },
           )
-          if (createPostResponse.isErr()) {
-            throw createPostResponse.error
-          }
+          if (createPostResponse.isErr()) throw createPostResponse.error
           return post.id
         })
         return postId


### PR DESCRIPTION
## Problem

Answers are not indexed when posts are added or updated.

Working towards #687

## Solution

Update search entry with answers when answers are created or updated.

- uses updatePost for both createAnswer and updateAnswer as search entry would have been created by
createPost
- includes tests

## Tests

1. Login as an administrator.
2. Open the network panel so as to observe network calls.

### Test for success use cases

3. Create a post. A POST request to `/posts/answers/<postId>` should be observed in the network panel as usual, as seen in the screenshot:

    <img width="725" alt="Screenshot 2021-12-13 at 5 52 18 PM" src="https://user-images.githubusercontent.com/37061143/145790352-01566bf7-1d81-4b3e-ad57-26f99cd9488b.png">

    The answer should be sent in the payload as seen in the screenshot below:

    <img width="724" alt="Screenshot 2021-12-13 at 5 52 49 PM" src="https://user-images.githubusercontent.com/37061143/145790349-b1b0d37b-b754-4bb3-8a7d-ded6ed52c722.png">

    The response is the answer id.

    <img width="726" alt="Screenshot 2021-12-13 at 5 52 58 PM" src="https://user-images.githubusercontent.com/37061143/145790341-9eda45cd-769d-4a24-bbc2-ab25a645c5ca.png">

4. Check that the answer in the post has been indexed on opensearch with a GET request `curl -XGET 'https://localhost:9200/search_entries/_doc/47' --insecure -u 'admin:admin'`. `_version` should be 2 as the search entry is first created when created by the post service, then updated when the answer is created.

    <img width="1108" alt="Screenshot 2021-12-13 at 5 53 39 PM" src="https://user-images.githubusercontent.com/37061143/145790328-f8591da7-873f-4c72-af92-d61ee7ef054f.png">

5. Edit the post. A PUT request to `/posts/answers/<answer_id>` should be observed in the network panel as usual, as seen in the screenshot.

    <img width="723" alt="Screenshot 2021-12-13 at 5 57 02 PM" src="https://user-images.githubusercontent.com/37061143/145790966-7a2e1b1a-86ef-47b4-8671-81c4f2b78d58.png">

    This means that the PUT request to add the post was successful. Payload included in the request should be something like the one below. Take note of the value in the `text` field which contains the updated body of the answer:

    <img width="725" alt="Screenshot 2021-12-13 at 5 57 11 PM" src="https://user-images.githubusercontent.com/37061143/145790960-4b6b00fc-5370-4f3d-8aae-57d02274b1f3.png">

6. Check that the answer in the post has been indexed on opensearch with a GET request curl -XGET 'https://localhost:9200/search_entries/_doc/47' --insecure -u 'admin:admin'.

    <img width="1099" alt="Screenshot 2021-12-13 at 5 58 15 PM" src="https://user-images.githubusercontent.com/37061143/145791045-17745f08-5e4a-4f7e-bfaf-4ffa5b24288b.png">

### Test for failure use cases

7. To test for failure, we need to ensure that the sequelize transactions in post service do not cause the operation to fail before the answer service does so. As such, comment out the sync operations in `post.service`. As an example, the code below is commented out for `updatePost`. This should be done for `createPost` as well.

```ts
// const updatePostResponse = await this.searchSyncService.updatePost(
//   this.searchIndexName,
//   {
//     ...sharedObjValues,
//     postId: id,
//   },
// )
// if (updatePostResponse.isErr()) throw updatePostResponse.error
```

8. Next, in `sync.service`'s `updatePost`, replace `this.client.update` with `this.client.create`. This should cause opensearch's API to throw an error as the search entry should have been already been created.

9. Update a post. The answer update request should fail with status code `500 Internal Server Error`.

    <img width="726" alt="Screenshot 2021-12-13 at 6 37 07 PM" src="https://user-images.githubusercontent.com/37061143/145797939-249044df-f4fb-4b80-8b70-30ab629c5b6b.png">

    The request can be verified with the payload panel.

    <img width="724" alt="Screenshot 2021-12-13 at 6 37 16 PM" src="https://user-images.githubusercontent.com/37061143/145797932-bf6ae6dc-d05c-45a4-8938-35237696d9ef.png">

     Verify that the request did not make any changed to opensearch's index by sending a GET request:

    <img width="1105" alt="Screenshot 2021-12-13 at 6 37 43 PM" src="https://user-images.githubusercontent.com/37061143/145797923-150d3bc8-c757-41da-94ee-b4a6a3b9d6d1.png">

    Verify that the request did not update the answer as well by checking the database or navigating to `/questions/<post_id>`.

10. Create a post. The answer creation request should fail with status code `500 Internal Server Error` as well.