### PR TITLE
feat(search/sync): sync opensearch index with db for deletePost operations

### DIFF
--- a/server/src/modules/post/__tests__/post.routes.spec.ts
+++ b/server/src/modules/post/__tests__/post.routes.spec.ts
@@ -68,6 +68,7 @@ describe('/posts', () => {
   const searchSyncService = {
     createPost: jest.fn(),
     updatePost: jest.fn(),
+    deletePost: jest.fn(),
   }
 
   beforeAll(async () => {
@@ -239,6 +240,7 @@ describe('/posts', () => {
     it('returns 200 if post is deleted', async () => {
       const { id } = mockPosts[0]
       authService.hasPermissionToAnswer.mockResolvedValue(true)
+      searchSyncService.deletePost.mockResolvedValue(okAsync({}))
 
       const path = '/posts'
       const app = express()

--- a/server/src/modules/search/sync/sync.service.ts
+++ b/server/src/modules/search/sync/sync.service.ts
@@ -35,9 +35,9 @@ export class SyncService {
       }),
       (err) => {
         logger.error({
-          message: 'Error while adding posts for OpenSearch - client.index',
+          message: 'Error while adding posts for OpenSearch - client.create',
           meta: {
-            function: 'searchPosts',
+            function: 'createPost',
           },
           error: err,
         })
@@ -68,9 +68,9 @@ export class SyncService {
       }),
       (err) => {
         logger.error({
-          message: 'Error while adding posts for OpenSearch - client.index',
+          message: 'Error while adding posts for OpenSearch - client.update',
           meta: {
-            function: 'searchPosts',
+            function: 'updatePost',
           },
           error: err,
         })

--- a/server/src/modules/search/sync/sync.service.ts
+++ b/server/src/modules/search/sync/sync.service.ts
@@ -78,4 +78,30 @@ export class SyncService {
       },
     )
   }
+
+  /**
+   * Deletes posts in opensearch index
+   * @param index index name
+   * @param id document id
+   * @returns results async with opensearch response
+   */
+  deletePost = (index: string, id: number) => {
+    return ResultAsync.fromPromise(
+      this.client.delete({
+        index,
+        id: `${id}`,
+        refresh: true,
+      }),
+      (err) => {
+        logger.error({
+          message: 'Error while adding posts for OpenSearch - client.delete',
+          meta: {
+            function: 'deletePost',
+          },
+          error: err,
+        })
+        return err as ResponseError
+      },
+    )
+  }
 }


### PR DESCRIPTION
## Problem

Search entries on opensearch would remain in index even when deleted on database.

Closes #687

## Solution

Do an API call to opensearch to delete relevant search entry when a post is deleted from the database.

- add deletePost to sync service
- call `sync.service`'s `deletePost` in `post.service`'s `deletePost`

## Tests

1. Login as an administrator.
2. Open the network panel so as to observe network calls.

### Test for success use cases

3. Navigate to a post. The post used in the following screenshots is the one at `/questions/39`.
4. Check that the post is indexed on opensearch with `curl --insecure -u 'admin:admin' -XGET 'https://localhost:9200/search_entries/_doc/39'`.

    <img width="1104" alt="Screenshot 2021-12-14 at 1 01 11 PM" src="https://user-images.githubusercontent.com/37061143/145937862-66005d10-b741-44c0-aa35-ea4f3c32e192.png">

    If the post is not indexed on opensearch:
    1. Delete index with `curl --insecure -u 'admin:admin' -XDELETE 'https://localhost:9200/search_entries/'`
    2. Backfill opensearch index with data by navigating to `server/src/bootstrap` then running `npx ts-node search-backfill-trigger.ts`

5. Delete the post. The request should succeed as shown in the request on the network panel.

    <img width="725" alt="Screenshot 2021-12-14 at 1 00 51 PM" src="https://user-images.githubusercontent.com/37061143/145937868-39012fc7-cd25-477a-971b-171a8ecb60fe.png">

6. Check that the post no longer exists on both database and opensearch's index. To check that it is no longer in database, try navigating to the post's page or check the MySQL db directly.

    To check that it is no longer in opensearch's index, send a GET request for it with `curl --insecure -u 'admin:admin' -XGET 'https://localhost:9200/search_entries/_doc/39'`

    <img width="1071" alt="Screenshot 2021-12-14 at 1 01 21 PM" src="https://user-images.githubusercontent.com/37061143/145937857-8a15c09e-9287-439d-8da7-d711ba528e60.png">

### Test for failure use cases

To cause `sync.service` to throw an error, change the `index` field to a string which is not 'search_entries'.

7. Delete the post. The operation should fail as seen in the network panel:

    <img width="614" alt="Screenshot 2021-12-14 at 1 32 56 PM" src="https://user-images.githubusercontent.com/37061143/145939230-cc4e0cd0-c9a4-4e97-a577-1de01c19c405.png">

8. Check that the post still exists in db and opensearch index.
