### PR TITLE
refactor(landing): introduce v2 hero, simplify layout

### DIFF
--- a/client/src/components/AgencyLogo/AgencyLogo.component.tsx
+++ b/client/src/components/AgencyLogo/AgencyLogo.component.tsx
@@ -20,7 +20,6 @@ const AgencyLogo = ({
       width="120px"
       height="120px"
       p="5px"
-      position="relative"
       justifyContent="center"
       alignItems="center"
       overflow="hidden"

--- a/client/src/components/Header/Header.component.tsx
+++ b/client/src/components/Header/Header.component.tsx
@@ -25,7 +25,6 @@ import {
   getPostById,
   GET_POST_BY_ID_QUERY_KEY,
 } from '../../services/PostService'
-import AgencyLogo from '../AgencyLogo/AgencyLogo.component'
 import LinkButton from '../LinkButton/LinkButton.component'
 import Masthead from '../Masthead/Masthead.component'
 import { SearchBox } from '../SearchBox/SearchBox.component'
@@ -86,12 +85,12 @@ const Header = (): JSX.Element => {
     </Flex>
   )
 
-  const WebsiteLinks = () => {
+  const WebsiteLink = () => {
     // Extract hostname from URL
     const website = `${agency?.website}`
     const hostname = new URL(website).hostname
     return (
-      <Link href={website} isExternal>
+      <Link sx={styles.websiteLink} href={website} isExternal>
         <Button
           rightIcon={<BiLinkExternal color="neutral.900" />}
           variant="link"
@@ -164,75 +163,53 @@ const Header = (): JSX.Element => {
     }
   }, [matchQuestions?.pathname])
 
-  const ExpandedSearch = () => {
+  const Logo = () => {
     return (
-      <Box sx={styles.expandedSearchContainer}>
-        <Flex direction="row">
-          <Flex sx={styles.expandedSearch}>
-            <SearchBox agencyId={agency?.id} />
-          </Flex>
-        </Flex>
-        {agencyShortName && (
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          <AgencyLogo {...styles.expandedSearchAgencyLogo} agency={agency} />
-        )}
-      </Box>
-    )
-  }
-
-  const LogoBar = () => {
-    return (
-      <Flex justify="space-between" sx={styles.logoBarContainer}>
-        <Link
-          sx={styles.logoBarRouterLink}
-          as={RouterLink}
-          to={agency ? `/agency/${agency.shortname}` : '/'}
-        >
-          <HStack>
-            <Box sx={styles.logoBarAsk}>
-              <Ask />
-            </Box>
-            <Text sx={styles.logoBarText}>
-              {agency?.shortname.toUpperCase() || 'gov'}
-            </Text>
-          </HStack>
-        </Link>
-
-        <Flex sx={styles.logoBarWebsiteLink}>
-          {agency?.website && <WebsiteLinks />}
-        </Flex>
-        {user && <AuthLinks />}
-      </Flex>
+      <Link
+        sx={styles.logoBarRouterLink}
+        as={RouterLink}
+        to={agency ? `/agency/${agency.shortname}` : '/'}
+      >
+        <HStack>
+          <Box sx={styles.logoBarAsk}>
+            <Ask />
+          </Box>
+          <Text sx={styles.logoBarText}>
+            {agency?.shortname.toUpperCase() || 'gov'}
+          </Text>
+        </HStack>
+      </Link>
     )
   }
 
   return (
     <Flex direction="column" sx={styles.root}>
       <Masthead />
-      {deviceType === device.desktop ? (
+      {deviceType === device.mobile ? (
         <>
-          <LogoBar />
-          {!headerIsOpen ? (
-            <Flex sx={styles.collapsedSearch}>
+          {!matchQuestions ? (
+            <Collapse in={headerIsOpen} animateOpacity={false}>
+              <Flex justify="space-between" sx={styles.logoBarMobile}>
+                <Logo />
+                {user && <AuthLinks />}
+              </Flex>
+            </Collapse>
+          ) : null}
+          <Box sx={styles.expandedSearchContainer}>
+            <Flex sx={styles.expandedSearch}>
               <SearchBox agencyId={agency?.id} />
             </Flex>
-          ) : null}
-          {!matchQuestions ? (
-            <Collapse in={headerIsOpen} animateOpacity={false}>
-              <ExpandedSearch />
-            </Collapse>
-          ) : null}
+          </Box>
         </>
       ) : (
-        <>
-          {!matchQuestions ? (
-            <Collapse in={headerIsOpen} animateOpacity={false}>
-              <LogoBar />
-            </Collapse>
-          ) : null}
-          <ExpandedSearch />
-        </>
+        <Flex sx={styles.logoBarTabletDesktop}>
+          <Logo />
+          <Flex sx={styles.compactSearch}>
+            <SearchBox agencyId={agency?.id} />
+          </Flex>
+          {agency?.website && <WebsiteLink />}
+          {user && <AuthLinks />}
+        </Flex>
       )}
     </Flex>
   )

--- a/client/src/components/Header/Header.component.tsx
+++ b/client/src/components/Header/Header.component.tsx
@@ -196,17 +196,13 @@ const Header = (): JSX.Element => {
             </Collapse>
           ) : null}
           <Box sx={styles.expandedSearchContainer}>
-            <Flex sx={styles.expandedSearch}>
-              <SearchBox agencyId={agency?.id} />
-            </Flex>
+            <SearchBox sx={styles.expandedSearch} agencyId={agency?.id} />
           </Box>
         </>
       ) : (
         <Flex sx={styles.logoBarTabletDesktop}>
           <Logo />
-          <Flex sx={styles.compactSearch}>
-            <SearchBox agencyId={agency?.id} />
-          </Flex>
+          <SearchBox sx={styles.compactSearch} agencyId={agency?.id} />
           {agency?.website && <WebsiteLink />}
           {user && <AuthLinks />}
         </Flex>

--- a/client/src/components/Masthead/Masthead.component.tsx
+++ b/client/src/components/Masthead/Masthead.component.tsx
@@ -40,8 +40,12 @@ const Masthead: FC = () => {
     sm: '0px',
   }
   return (
-    <Box bg="neutral.200" px={{ base: '24px', sm: '29px', xl: '33px' }}>
-      <Flex direction="row">
+    <Box bg="neutral.200" px={{ base: '24px', sm: 0, xl: '33px' }}>
+      <Flex
+        direction="row"
+        width={{ sm: '77vw' }}
+        mx={{ base: 0, sm: 'auto', xl: 0 }}
+      >
         <Center my={mastheadTopMarginY}>
           <Image
             src={LionHeadSymbol}

--- a/client/src/components/SearchBox/SearchBox.component.tsx
+++ b/client/src/components/SearchBox/SearchBox.component.tsx
@@ -5,7 +5,7 @@ import {
   InputRightElement,
 } from '@chakra-ui/input'
 import { Box, Flex, UnorderedList } from '@chakra-ui/layout'
-import { useMultiStyleConfig } from '@chakra-ui/react'
+import { CSSObject, useMultiStyleConfig } from '@chakra-ui/react'
 import * as FullStory from '@fullstory/browser'
 import Downshift, {
   DownshiftState,
@@ -29,6 +29,7 @@ import {
 } from '../../services/PostService'
 
 export const SearchBox = ({
+  sx = {},
   placeholder,
   value,
   inputRef,
@@ -40,6 +41,7 @@ export const SearchBox = ({
   agencyId,
   ...inputProps
 }: {
+  sx?: CSSObject
   placeholder?: string
   value?: string
   inputRef?: RefCallBack
@@ -177,7 +179,7 @@ export const SearchBox = ({
   )
 
   return (
-    <Flex sx={styles.form}>
+    <Flex sx={{ ...styles.form, ...sx }}>
       <Downshift
         onChange={(selection) => navigate(`/questions/${selection?.id}`)}
         stateReducer={stateReducer}

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -98,10 +98,10 @@ const HomePage = (): JSX.Element => {
           }}
           width={{
             base: '90%',
-            sm: '75vw',
-            lg: '50vw',
+            sm: '77vw',
+            xl: '50vw',
           }}
-          mx="auto"
+          mx={{ base: '24px', sm: 'auto' }}
         >
           <Text
             textStyle={{ base: 'h2-mobile', sm: 'h1-mobile' }}

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Flex,
+  HStack,
   Menu,
   MenuButton,
   MenuItem,
@@ -14,6 +15,7 @@ import { useEffect, useState } from 'react'
 import { BiSortAlt2 } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
+import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostQuestionButton from '../../components/PostQuestionButton/PostQuestionButton.component'
@@ -84,6 +86,36 @@ const HomePage = (): JSX.Element => {
             : undefined
         }
       />
+      {agency && !hasTopicsKey && (
+        <HStack
+          display="grid"
+          gridTemplateColumns="3fr 1fr"
+          py="auto"
+          minH={{
+            base: '175px',
+            sm: '232px',
+            lg: '224px',
+          }}
+          width={{
+            base: '90%',
+            sm: '75vw',
+            lg: '50vw',
+          }}
+          mx="auto"
+        >
+          <Text
+            textStyle={{ base: 'h2-mobile', sm: 'h1-mobile' }}
+            color="primary.500"
+          >
+            Need help?
+            <br />
+            {agency?.longname && `Answers from ${agency?.longname}`}
+          </Text>
+          <Flex ml="auto !important">
+            {agency && <AgencyLogo agency={agency} />}
+          </Flex>
+        </HStack>
+      )}
       <Box flex="1">
         <OptionsMenu />
       </Box>

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -116,9 +116,7 @@ const HomePage = (): JSX.Element => {
           </Flex>
         </HStack>
       )}
-      <Box flex="1">
-        <OptionsMenu />
-      </Box>
+      <OptionsMenu />
       <Flex
         maxW="680px"
         m="auto"

--- a/client/src/theme/components/Header.ts
+++ b/client/src/theme/components/Header.ts
@@ -19,22 +19,15 @@ export const Header: ComponentMultiStyleConfig = {
       top: 0,
       zIndex: 999,
     },
-    collapsedSearch: {
+    compactSearch: {
       h: '56px',
       m: 'auto',
-      px: { base: '24px', md: 'auto' },
       maxW: '680px',
       w: '100%',
-      mt: '-68px',
     },
     expandedSearchContainer: {
       bg: 'white',
       h: { base: '100px', xl: '152px' },
-    },
-    expandedSearchAgencyLogo: {
-      ml: '36px',
-      mt: '-55px',
-      display: { base: 'none', xl: 'flex' },
     },
     expandedSearch: {
       h: '56px',
@@ -44,12 +37,25 @@ export const Header: ComponentMultiStyleConfig = {
       maxW: '680px',
       w: '100%',
     },
-    logoBarContainer: {
+    logoBarMobile: {
+      h: '64px',
       bg: 'white',
       px: 8,
       py: 4,
       shrink: 0,
       align: 'center',
+    },
+    logoBarTabletDesktop: {
+      bg: 'white',
+      px: 8,
+      py: 4,
+      shrink: 0,
+      alignItems: 'center',
+      display: 'grid',
+      gridTemplateColumns: {
+        base: '1fr 1fr',
+        xl: '1fr 2fr 1fr',
+      },
     },
     logoBarRouterLink: {
       _hover: {
@@ -67,8 +73,9 @@ export const Header: ComponentMultiStyleConfig = {
       textStyle: 'logo',
       color: 'black',
     },
-    logoBarWebsiteLink: {
-      d: { base: 'none', sm: 'block' },
+    websiteLink: {
+      ml: 'auto',
+      d: { base: 'none', xl: 'flex' },
     },
   }),
 }

--- a/client/src/theme/components/Header.ts
+++ b/client/src/theme/components/Header.ts
@@ -27,12 +27,12 @@ export const Header: ComponentMultiStyleConfig = {
     },
     expandedSearchContainer: {
       bg: 'white',
-      h: { base: '100px', xl: '152px' },
+      h: { base: '75px', xl: '152px' },
     },
     expandedSearch: {
       h: '56px',
       m: 'auto',
-      mt: { base: '20px', xl: '64px' },
+      mt: { base: '10px', xl: '64px' },
       px: { base: '24px', md: 'auto' },
       maxW: '680px',
       w: '100%',

--- a/client/src/theme/components/Header.ts
+++ b/client/src/theme/components/Header.ts
@@ -18,6 +18,7 @@ export const Header: ComponentMultiStyleConfig = {
       position: 'sticky',
       top: 0,
       zIndex: 999,
+      bg: 'white',
     },
     compactSearch: {
       h: '56px',
@@ -47,7 +48,13 @@ export const Header: ComponentMultiStyleConfig = {
     },
     logoBarTabletDesktop: {
       bg: 'white',
-      px: 8,
+      px: { xl: '32px' },
+      width: {
+        base: '90%',
+        sm: '77vw',
+        xl: '100%',
+      },
+      mx: 'auto',
       py: 4,
       shrink: 0,
       alignItems: 'center',

--- a/client/src/theme/textStyles.ts
+++ b/client/src/theme/textStyles.ts
@@ -43,6 +43,14 @@ export const textStyles = {
     letterSpacing: '-0.019em',
     fontFeatureSettings: "'tnum' on, 'lnum' on, 'cv05' on",
   },
+  'h2-mobile': {
+    ...baseTextStyle,
+    fontWeight: 300,
+    fontSize: '24px',
+    lineHeight: '32px',
+    letterSpacing: '-0.019em',
+    fontFeatureSettings: "'tnum' on, 'lnum' on, 'cv05' on",
+  },
   h3: {
     ...baseTextStyle,
     fontWeight: 600,


### PR DESCRIPTION
## Problem

Closes #797 

TODO - rework Desktop to be more inline with Figma designs

## Solution

- Place logo, searchbox and website link all as immediate children in
  tablet/desktop layout
- Use CSS grid to enforce positions for tablet/desktop elements
- Add a Hero component to agency page if no topic
- Inject Searchbox styles directly, adjust mobile height

## Screenshots

### Mobile

![image](https://user-images.githubusercontent.com/10572368/145951391-96daca99-3f89-4499-b8e1-774e693f81ed.png)
![image](https://user-images.githubusercontent.com/10572368/145951418-c0b98dc9-8288-4199-91e5-b20a5e788512.png)

### Tablet

![image](https://user-images.githubusercontent.com/10572368/145951007-15e0421f-7ce8-4289-abdc-8089d1dc96ac.png)
![image](https://user-images.githubusercontent.com/10572368/145951082-d7d82552-5905-4eba-860c-1bac6ef6f6f1.png)

### Desktop

![image](https://user-images.githubusercontent.com/10572368/145951291-7f7c8505-2c79-4b81-9948-d63e5f5cc571.png)
![image](https://user-images.githubusercontent.com/10572368/145951267-58281a0b-2d60-4216-9a75-7ec9bc4d6641.png)
