### PR TITLE
feat(search/sync): replace fusejs search with /search

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,6 @@
         "downshift": "^6.1.7",
         "draft-js": "^0.11.7",
         "draftjs-to-html": "^0.9.1",
-        "fuse.js": "^6.4.6",
         "prop-types": "^15.7.2",
         "query-string": "^7.0.1",
         "react": "^17.0.2",
@@ -11936,14 +11935,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
-    "node_modules/fuse.js": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.6.tgz",
-      "integrity": "sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -35307,11 +35298,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
-    "fuse.js": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.6.tgz",
-      "integrity": "sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,6 @@
     "downshift": "^6.1.7",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",
-    "fuse.js": "^6.4.6",
     "prop-types": "^15.7.2",
     "query-string": "^7.0.1",
     "react": "^17.0.2",

--- a/client/src/components/PostItem/PostItem.component.tsx
+++ b/client/src/components/PostItem/PostItem.component.tsx
@@ -8,7 +8,7 @@ import EditButton from '../EditButton/EditButton.component'
 const PostItem = ({
   post: { id, title, tags, agencyId },
 }: {
-  post: BasePostDto
+  post: Pick<BasePostDto, 'id' | 'title' | 'tags' | 'agencyId'>
 }): JSX.Element => {
   const { user } = useAuth()
   const styles = useMultiStyleConfig('PostItem', {})

--- a/client/src/services/SearchService.ts
+++ b/client/src/services/SearchService.ts
@@ -1,0 +1,17 @@
+import { SearchEntry } from '~shared/types/api'
+import { ApiClient } from '../api'
+
+const SEARCH_API_BASE = '/search'
+export const SEARCH_QUERY_KEY = 'search'
+
+export const search = async ({
+  query,
+  agencyId,
+}: {
+  query: string
+  agencyId?: number
+}): Promise<SearchEntry[]> => {
+  return ApiClient.get<SearchEntry[]>(SEARCH_API_BASE, {
+    params: { query, agencyId },
+  }).then(({ data }) => data)
+}

--- a/server/src/modules/search/__tests__/search.controller.spec.ts
+++ b/server/src/modules/search/__tests__/search.controller.spec.ts
@@ -1,8 +1,10 @@
+import { SearchHit } from '@opensearch-project/opensearch/api/types'
 import express from 'express'
 import { query } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync } from 'neverthrow'
 import supertest from 'supertest'
+import { SearchEntry } from '../../../../../shared/src/types/api'
 import { PostStatus } from '../../../../../shared/src/types/base'
 import { SearchController } from '../search.controller'
 
@@ -48,36 +50,33 @@ describe('SearchController', () => {
   }
 
   describe('searchPosts', () => {
-    const sampleHits = [
+    const searchEntries: SearchEntry[] = [
       {
-        _id: '2',
-        _index: 'search_entries',
-        _score: 0.8754687,
-        _source: {
-          agencyId: 2,
-          answer: 'answer 2000',
-          description: 'description 200',
-          postId: 2,
-          title: 'title 20',
-          topicId: null,
-        },
-        _type: '_doc',
+        agencyId: 2,
+        answers: ['answer 2000'],
+        description: 'description 200',
+        postId: 2,
+        title: 'title 20',
+        topicId: null,
       },
       {
-        _id: '1',
-        _index: 'search_entries',
-        _score: 0.18232156,
-        _source: {
-          agencyId: 1,
-          answer: 'answer 1000',
-          description: 'description 100',
-          postId: 1,
-          title: 'title 10',
-          topicId: null,
-        },
-        _type: '_doc',
+        agencyId: 1,
+        answers: ['answer 1000'],
+        description: 'description 100',
+        postId: 1,
+        title: 'title 10',
+        topicId: null,
       },
     ]
+    const sampleHits: SearchHit[] = searchEntries.map((entry) => {
+      return {
+        _id: `${entry.postId}`,
+        _index: indexName,
+        _score: 0.5,
+        _source: entry,
+        _type: '_doc',
+      }
+    })
     const sampleSearchPostsResponse = {
       body: {
         _shards: { failed: 0, skipped: 0, successful: 1, total: 1 },
@@ -149,7 +148,7 @@ describe('SearchController', () => {
       )
 
       expect(response.status).toEqual(StatusCodes.OK)
-      expect(response.body).toStrictEqual(sampleHits)
+      expect(response.body).toStrictEqual(searchEntries)
     })
 
     it('returns Bad Request Error when agencyId is not an integer', async () => {

--- a/server/src/modules/search/__tests__/search.routes.spec.ts
+++ b/server/src/modules/search/__tests__/search.routes.spec.ts
@@ -1,7 +1,9 @@
+import { SearchHit } from '@opensearch-project/opensearch/api/types'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { okAsync } from 'neverthrow'
 import supertest from 'supertest'
+import { SearchEntry } from '../../../../../shared/src/types/api'
 import { SearchController } from '../search.controller'
 import { routeSearch } from '../search.routes'
 
@@ -9,12 +11,6 @@ describe('/', () => {
   describe('GET /', () => {
     const path = '/'
 
-    const answersService = {
-      listAnswers: jest.fn(),
-    }
-    const postService = {
-      listPosts: jest.fn(),
-    }
     const searchService = {
       searchPosts: jest.fn(),
       indexPost: jest.fn(),
@@ -24,37 +20,36 @@ describe('/', () => {
       searchService,
     })
     const router = routeSearch({ controller })
+    const indexName = 'search_entries'
 
-    const sampleHits = [
+    const searchEntries: SearchEntry[] = [
       {
-        _id: 'm42WIn0BbFqfMhuFmmR4',
-        _index: 'search_entries',
-        _score: 0.8754687,
-        _source: {
-          agencyId: 2,
-          answer: 'answer 2000',
-          description: 'description 200',
-          postId: 2,
-          title: 'title 20',
-          topicId: null,
-        },
-        _type: '_doc',
+        agencyId: 2,
+        answers: ['answer 2000'],
+        description: 'description 200',
+        postId: 2,
+        title: 'title 20',
+        topicId: null,
       },
       {
-        _id: 'mo2WIn0BbFqfMhuFmmR4',
-        _index: 'search_entries',
-        _score: 0.18232156,
-        _source: {
-          agencyId: 1,
-          answer: 'answer 1000',
-          description: 'description 100',
-          postId: 1,
-          title: 'title 10',
-          topicId: null,
-        },
-        _type: '_doc',
+        agencyId: 1,
+        answers: ['answer 1000'],
+        description: 'description 100',
+        postId: 1,
+        title: 'title 10',
+        topicId: null,
       },
     ]
+    const sampleHits: SearchHit[] = searchEntries.map((entry) => {
+      return {
+        _id: `${entry.postId}`,
+        _index: indexName,
+        _score: 0.125,
+        _source: entry,
+        _type: '_doc',
+      }
+    })
+
     const sampleSearchPostsResponse = {
       body: {
         _shards: { failed: 0, skipped: 0, successful: 1, total: 1 },
@@ -80,7 +75,7 @@ describe('/', () => {
       const response = await request.get(path).query({ query: 'test' })
 
       expect(response.status).toEqual(StatusCodes.OK)
-      expect(response.body).toStrictEqual(sampleHits)
+      expect(response.body).toStrictEqual(searchEntries)
     })
 
     it('returns BAD REQUEST on invalid agencyId format', async () => {
@@ -118,7 +113,7 @@ describe('/', () => {
 
       expect(response.status).toEqual(StatusCodes.OK)
       expect(searchService.searchPosts).toHaveBeenCalledWith(
-        'search_entries',
+        indexName,
         trimmedSearch,
         undefined,
       )

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -1,3 +1,4 @@
+import { SearchHit } from '@opensearch-project/opensearch/api/types'
 import { validationResult } from 'express-validator'
 import { StatusCodes } from 'http-status-codes'
 import { createLogger } from '../../bootstrap/logging'
@@ -60,7 +61,12 @@ export class SearchController {
       )
     )
       .map((response) => {
-        return res.status(StatusCodes.OK).json(response.body.hits.hits)
+        const searchResults = response.body.hits.hits.map(
+          (result: SearchHit) => {
+            return result._source
+          },
+        )
+        return res.status(StatusCodes.OK).json(searchResults)
       })
       .mapErr((error) => {
         logger.error({


### PR DESCRIPTION
## Problem

Search on frontend was still using fuse.js, which is limited to fuzzy search.

Closes #690

## Solution

Port search used on frontend over to use search queries powered by opensearch.

**Features**:

- Port search on search bar over to use `/search`
- Port search on search results page over to use `/search`

**Bug Fixes**:

- Change response format of `/search` to be `SearchEntry[]`

## Tests

1. Use the search bar on the main AskGov page and agency pages to make sure that only relevant search results show up.
2. Press enter in search bar to get to the search results page. Ensure that only the relevant search results show up.

## Deploy Notes

Removed `fuse.js` from client dependencies.
