### PR TITLE
feat(search): filter stop words in search and index backfill

### DIFF
--- a/server/src/modules/search/backfill/backfill.service.ts
+++ b/server/src/modules/search/backfill/backfill.service.ts
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { SearchEntry } from '~shared/types/api/search'
 import { createLogger } from '../../../bootstrap/logging'
+import { indexConfig } from './index-config'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { errors } = require('@opensearch-project/opensearch')
@@ -47,6 +48,7 @@ export class BackfillService {
       const indiciesCreateResponse = await ResultAsync.fromPromise(
         this.client.indices.create({
           index: indexName,
+          body: indexConfig,
         }),
         (error) => {
           logger.error({

--- a/server/src/modules/search/backfill/index-config.ts
+++ b/server/src/modules/search/backfill/index-config.ts
@@ -1,0 +1,19 @@
+export const indexConfig = {
+  settings: {
+    // Implement stop word filter using text analyzer
+    analysis: {
+      analyzer: {
+        default: {
+          tokenizer: 'whitespace',
+          filter: ['stop_words_filter'],
+        },
+      },
+      filter: {
+        stop_words_filter: {
+          type: 'stop',
+          ignore_case: true,
+        },
+      },
+    },
+  },
+}

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -26,6 +26,7 @@ export class SearchService {
       fields: ['title', 'description', 'answers'],
       type: 'most_fields',
       fuzziness: 'AUTO',
+      analyzer: 'stop',
     }
     return ResultAsync.fromPromise(
       this.client.search({


### PR DESCRIPTION
## Problem

The current implementation of open search uses stop words for search relevance, which may disproportionately favour longer texts.

Closes #972

## Solution

We want to remove stop words when a) the user makes a search and b) creating the index using the
backfill script. This can be done via the analyzer (which is used during search or index time to perform text analysis), and can be used to remove stop words for this use case. 

The [default stop filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-stop-tokenfilter.html) is used, which is based on Lucene's stop filter.

UPDATE: There is also another solution that allows us to dynamically change index settings. This can be done via a [series of curl commands ](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html) that can be found in the deploy notes below.

**Improvements**:

- We are able to add custom stop words by adding an array of stop words under `settings.filter.<filter_name>.stopwords`

## Before & After Screenshots

**BEFORE**:
<img width="1178" alt="Screenshot 2021-12-21 at 9 43 47 AM" src="https://user-images.githubusercontent.com/41635847/146865029-ed8dd73b-b34e-4a32-8215-986a5ba21fe9.png">

**AFTER**:
<img width="1122" alt="Screenshot 2021-12-21 at 10 44 05 AM" src="https://user-images.githubusercontent.com/41635847/146864982-2a92c5be-24e3-4288-89a5-40f9a402aac6.png">

## Tests

To verify that the new configuration works, you can test the change in search/indexing behaviour by taking the following steps.

- Before: search 'the' (or any preferred stop words) and verify that there are search results.
- After: 
   1. delete the current index using `curl -XDELETE 'https://localhost:9200/search_entries' --insecure -u 'admin:admin'`
  2. run the backfill script using `cd server/src/bootstrap && npx ts-node search-backfill-trigger.ts`
  3. search 'the' and verify that there are no search results

## Deploy notes
For deployment, it is possible to change the index settings dynamically (without having to recreate the index).  Note that if we want to edit index settings dynamically, we are required to close the index first.

1. Close the index first
```
curl -X POST "https://localhost:9200/search_entries/_close?wait_for_active_shards=0&pretty"  --insecure -u 'admin:admin'
```
2. Update the settings
```
curl -X PUT "https://localhost:9200/search_entries/_settings?pretty" --insecure -u 'admin:admin' -H 'Content-Type: application/json' -d'
{
  "analysis" : {
    "analyzer":{
      "default":{
        "tokenizer":"whitespace",
        "filter": ["stop_words_filter"]
      }
    },
    "filter" : {
      "stop_words_filter": {
        "type": "stop",
        "ignore_case" : true
      }
    }
  }
}
'
```
3. Re-open the index
```
curl -X POST "https://localhost:9200/search_entries/_open?pretty"  --insecure -u 'admin:admin'
```
4. Verify that the settings are updated
```
curl -HEAD 'https://localhost:9200/search_entries' --insecure -u 'admin:admin'
```
