### PR TITLE
chore(backfill): add logging for backfill script

### DIFF
--- a/server/src/modules/search/backfill/backfill.controller.ts
+++ b/server/src/modules/search/backfill/backfill.controller.ts
@@ -42,6 +42,10 @@ export class BackfillController {
    * @returns result async with error or response
    */
   indexAllData = async (indexName: string) => {
+    logger.info({
+      message: `Querying data from database`,
+      meta: { function: `indexAllData` },
+    })
     return await ResultAsync.fromPromise(
       this.postService.listPosts({
         sort: SortType.Top,
@@ -61,6 +65,10 @@ export class BackfillController {
     )
       .map(async (postResponse) => {
         const searchEntriesDataset: SearchEntry[] = []
+        logger.info({
+          message: `Creating searchEntriesDataset for ${postResponse.posts.length} posts`,
+          meta: { function: `indexAllData` },
+        })
         for (const post of postResponse.posts) {
           const listAnswersResult = await ResultAsync.fromPromise(
             this.answersService.listAnswers(post.id),
@@ -98,6 +106,10 @@ export class BackfillController {
             return listAnswersResult
           }
         }
+        logger.info({
+          message: `Indexing searchEntriesDataset on search service`,
+          meta: { function: `indexAllData` },
+        })
         return await this.searchService.indexAllData(
           indexName,
           searchEntriesDataset,


### PR DESCRIPTION
## Problem

There is currently no indication of progress when running the backfill script.

Closes #946

## Solution

Add logging statements for each stage (i.e. querying from database, creating searchEntriesDataset, indexing the dataset on open search).

As the indexing process itself is done as a bulk operation, it is not very feasible to add a progress bar to track the progress of indexing.

**Improvements**:

Note: running `npx ts-node search-backfill-trigger` has a [noticeable startup/compilation time](https://github.com/TypeStrong/ts-node/issues/754) as `ts-node` does type-checking in the background. In production, a faster alternative could be to add a transpile-only flag like `npx ts-node -T search-backfill-trigger`.

## Screenshots
<img width="883" alt="Screenshot 2021-12-22 at 11 56 06 AM" src="https://user-images.githubusercontent.com/41635847/147033119-074521c9-3a27-4f19-bd16-01c65ccd45e8.png">

