### PR TITLE
chore(search): use integer type instead of long type when indexing

### DIFF
--- a/server/src/modules/search/backfill/index-config.ts
+++ b/server/src/modules/search/backfill/index-config.ts
@@ -16,4 +16,17 @@ export const indexConfig = {
       },
     },
   },
+  mappings: {
+    properties: {
+      agencyId: {
+        type: 'integer',
+      },
+      postId: {
+        type: 'integer',
+      },
+      topicId: {
+        type: 'integer',
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Problem

By default, OpenSearch builds the index using loosely defined properties. For example, `id` is marked with type `float` instead of `integer`. Specifying types which will help to[ improve indexing and searching efficiency.](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/number.html)

Closes #945

## Solution

Added `mapping` to `indexConfig` file. Note that [mapping cannot be changed for an existing field](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#updating-field-mappings). This means that applying the changes dynamically is slightly more complex. Look at the improvements section.

## Improvements

There are a few ways that we can change mapping without any downtime. 

- Method 1: reindex -> delete old index -> use alias on new index.
![OpenSearch Index-Page-1 drawio](https://user-images.githubusercontent.com/41635847/147064021-4de7d8c7-a2d5-4623-8d0e-42377f71f28c.png)

- Method 2: using alias from the get-go for the main search index
![OpenSearch Index-Page-2 drawio (2)](https://user-images.githubusercontent.com/41635847/147069339-03704d3a-732c-40c5-9037-5bb89010933f.png)


Method 2 would require a refactor of how we currently reference the `search_entries` index in the post and answer services (assuming we do not delete the existing search_entries index).

**Pros of using aliases**
- Using aliases makes future index changes more reliable. We do not need to delete the existing index before running the backfill script. We can create the new index and reference it by the active alias name, and revert to the old index in case of failure.

**Cons of using aliases**
- Managing aliases may be messy. For e.g., we are not able to delete indices by referencing their alias. Although, it is still easy to check the alias mappings by `GET /_alias`.
- As multiple indices could occur at the same time, we need to (1) ensure there are no stale indices and (2) have an index naming strategy. Maybe new indices could have the date appended to the end of the index, for e.g. `search_entries_221221`.

**Further question**
- Should we write a bash script to document which CURL commands to handle slightly more complex operations, like reindexing or changing index setting dynamically (see #996 )? 

## Before & After Screenshots

**BEFORE**:
<img width="1340" alt="Screenshot 2021-12-22 at 1 38 46 PM" src="https://user-images.githubusercontent.com/41635847/147065087-177af128-c3c6-498c-9e2a-6b8435a637a4.png">

**AFTER**:
<img width="1350" alt="Screenshot 2021-12-22 at 1 33 43 PM" src="https://user-images.githubusercontent.com/41635847/147065113-ab0dd8c1-e4cd-46e2-b8cb-987fe75e45db.png">

## Deploy Notes
Assuming we go ahead with method 1, it should look like

```sh
#----------- CHANGE INDEX MAPPING -----------#
# Create new index
curl -X PUT "https://localhost:9200/search_entries_copy" --insecure -u 'admin:admin' -H 'Content-Type: application/json' -d'
{
  "settings": {
    "analysis" : {
      "analyzer":{
        "default":{
          "tokenizer":"whitespace",
          "filter": ["stop_words_filter"]
        }
      },
      "filter" : {
        "stop_words_filter": {
          "type": "stop",
          "ignore_case" : true
        }
      }
    }
  }, 
  "mappings": {
    "properties" : {
      "agencyId" : {
        "type" : "integer"
      },
      "postId" : {
        "type" : "integer"
      },
      "topicId":{
        "type" : "integer"
      }
    }
  } 
}
'

# Reindex from old to new index
curl -X POST "https://localhost:9200/_reindex?pretty" --insecure -u 'admin:admin' -H 'Content-Type: application/json' -d'
{
  "source": {
    "index": "search_entries"
  },
  "dest": {
    "index": "search_entries_copy"
  }
}
'

# Delete old index
curl -X DELETE 'https://localhost:9200/search_entries' --insecure -u 'admin:admin'

# Add alias
curl -X POST "https://localhost:9200/_aliases?pretty" --insecure -u 'admin:admin' -H 'Content-Type: application/json' -d'
{
  "actions": [
    {
      "add": {
        "index": "search_entries_copy",
        "alias": "search_entries"
      }
    }
  ]
}
'
```

## Logistics
This PR has been blocked by #996; once that PR is merged to develop, this PR should be rebased on this branch.

**References**:
https://www.elastic.co/blog/changing-mapping-with-zero-downtime




