### PR TITLE
fix(backend port number): change backend port number to 6174

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ DB_HOST=localhost
 DB_NAME=askgov
 DB_USER=root
 DB_PASSWORD=password
-SERVER_PORT=5000
+SERVER_PORT=6174
 NODE_ENV=development
 SESSION_SECRET=mySessionSecret
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Optionally [DBeaver](https://dbeaver.io/download/) to view database with GUI
   
   Frontend server accessible on `localhost:3000`
   
-  Backend server accessible on `localhost:5000/api/v1`
+  Backend server accessible on `localhost:6174/api/v1`
   
   Local mail server `MailDev` accessible on `localhost:1080`
 
@@ -158,7 +158,7 @@ Optionally [DBeaver](https://dbeaver.io/download/) to view database with GUI
 
 ## API Endpoints
 
-#### Base Url - `http://localhost:5000/api/v1`
+#### Base Url - `http://localhost:6174/api/v1`
 
 #### Agencies
 - `GET /agencies?<longname, shortname>`

--- a/client/package.json
+++ b/client/package.json
@@ -57,7 +57,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:6174",
   "devDependencies": {
     "@types/draftjs-to-html": "^0.8.0",
     "@types/html-to-draftjs": "^1.4.0",

--- a/server/src/bootstrap/config/base.ts
+++ b/server/src/bootstrap/config/base.ts
@@ -23,7 +23,7 @@ const baseSchema: Schema<BaseConfig> = {
   serverPort: {
     doc: 'Application port',
     format: 'port',
-    default: 5000,
+    default: 6174,
     env: 'SERVER_PORT',
   },
   logoHost: {

--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -77,7 +77,7 @@ app.use(requestLoggingMiddleware)
 
 // cors enable
 app.options('*', cors<express.Request>())
-app.use(cors({ origin: 'http://localhost:5000' }))
+app.use(cors({ origin: `http://localhost:${process.env.SERVER_PORT}` }))
 
 // security config
 app.use(helmet(helmetOptions))


### PR DESCRIPTION
Current port number of 5000 clashes with Apple using port 5000 for AirPlay Receiver on Mac.

fixes #992

Notes:
- Port number of 6174 is somewhat arbitrarily chosen. 
- Not sure if it's possible to make the port number a variable instead (so as to adhere to DRY principle); currently, the port number is repeated across multiple files)

Pros: macOS users don't need to switch off AirPlay. (Useful when, say, trying to use Mac to stream audio/video from iPhone!) 
Cons: Defies convention of using 5000 for ExpressJS. 6174 chosen [somewhat arbitrarily](https://en.wikipedia.org/wiki/6174_(number)).  It also appear [to be unassigned](https://www.adminsub.net/tcp-udp-port-finder/6174). 