### PR TITLE
feat(search-results): add breadcrumbs, update search query and search results UI

### DIFF
--- a/client/src/components/PostItem/PostItem.component.tsx
+++ b/client/src/components/PostItem/PostItem.component.tsx
@@ -1,14 +1,28 @@
-import { Flex, Link, Text, useMultiStyleConfig } from '@chakra-ui/react'
+import { Flex, Link, Text, Box, useMultiStyleConfig } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
+import sanitizeHtml from 'sanitize-html'
 import { BasePostDto } from '../../api'
 import { useAuth } from '../../contexts/AuthContext'
 import EditButton from '../EditButton/EditButton.component'
 
+function formatPostTitle(title: string, searchQuery: string) {
+  const searchQueryTerms: string[] = searchQuery.split(' ')
+  let formattedTitle: string = title
+  searchQueryTerms.forEach((word) => {
+    const regex = new RegExp('(' + word + ')', 'gi')
+    formattedTitle = formattedTitle.replace(regex, `<b>$1</b>`)
+  })
+  return formattedTitle
+}
+
 // Note: PostItem is the component for the homepage
 const PostItem = ({
-  post: { id, title, tags, agencyId },
+  post: { id, title, tags, agencyId, answer, searchQuery },
 }: {
-  post: Pick<BasePostDto, 'id' | 'title' | 'tags' | 'agencyId'>
+  post: Pick<BasePostDto, 'id' | 'title' | 'tags' | 'agencyId'> & {
+    answer?: string
+    searchQuery?: string
+  }
 }): JSX.Element => {
   const { user } = useAuth()
   const styles = useMultiStyleConfig('PostItem', {})
@@ -19,7 +33,21 @@ const PostItem = ({
     <Flex sx={styles.container}>
       {/* Title display area */}
       <Link as={RouterLink} to={`/questions/${id}`}>
-        <Text sx={styles.linkText}>{title}</Text>
+        {searchQuery ? (
+          <Box sx={styles.linkText}>
+            <p
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(formatPostTitle(title, searchQuery), {
+                  allowedTags: ['b'],
+                  allowedAttributes: {},
+                }),
+              }}
+            />
+          </Box>
+        ) : (
+          <Text sx={styles.linkText}>{title}</Text>
+        )}
+        {<Box sx={styles.answer}>{answer}</Box>}
       </Link>
       {/* <Box sx={styles.description}>
             {description && <RichTextFrontPreview value={description} />}

--- a/client/src/pages/SearchResults/SearchResults.component.tsx
+++ b/client/src/pages/SearchResults/SearchResults.component.tsx
@@ -122,8 +122,13 @@ const SearchResults = (): JSX.Element => {
             </Flex>
             <Flex sx={styles.questionsGrid} className="questions-grid">
               <Box sx={styles.questionsHeadline} className="questions-headline">
-                {searchQuery ? 'Search Results' : 'All Questions'}
+                {foundPosts && foundPosts.length > 0
+                  ? foundPosts.length === 1
+                    ? `${foundPosts?.length} result found for`
+                    : `${foundPosts?.length} results found for`
+                  : 'No results found for'}
               </Box>
+              <Box sx={styles.searchQuery}>"{searchQuery}"</Box>
             </Flex>
             <Box sx={styles.questions} className="questions">
               {foundPosts && foundPosts.length > 0 ? (
@@ -141,10 +146,13 @@ const SearchResults = (): JSX.Element => {
               ) : (
                 <>
                   <Box sx={styles.noResults} className="no-results">
-                    {`No results found for "${searchQuery}".`}
-                  </Box>
-                  <Box>
-                    {`Try rephrasing your question, or check your spelling.`}
+                    <Box sx={styles.noResultsCaption}>
+                      Your search did not match any questions and answers. Try
+                      another search?
+                    </Box>
+                    <Box>- Check if the spelling is correct</Box>
+                    <Box>- Use different keywords</Box>
+                    <Box>- Try general keywords</Box>
                   </Box>
                 </>
               )}

--- a/client/src/pages/SearchResults/SearchResults.component.tsx
+++ b/client/src/pages/SearchResults/SearchResults.component.tsx
@@ -21,6 +21,7 @@ import {
 
 const SearchResults = (): JSX.Element => {
   const styles = useMultiStyleConfig('SearchResults', {})
+  const MAX_CHAR = 120
   const { search } = useLocation()
   const searchParams = new URLSearchParams(search)
   const searchQuery = searchParams.get('search') ?? ''
@@ -130,6 +131,9 @@ const SearchResults = (): JSX.Element => {
               </Box>
               <Box sx={styles.searchQuery}>"{searchQuery}"</Box>
             </Flex>
+            <Box sx={styles.questionsHeadline} className="questions-headline">
+              {foundPosts && foundPosts.length > 0 ? 'QUESTIONS' : null}
+            </Box>
             <Box sx={styles.questions} className="questions">
               {foundPosts && foundPosts.length > 0 ? (
                 foundPosts.map((entry) => (
@@ -140,6 +144,12 @@ const SearchResults = (): JSX.Element => {
                       title: entry.title ?? '',
                       tags: [],
                       agencyId: entry.agencyId ?? 0,
+                      answer: entry.answers
+                        ? entry.answers[0].length > MAX_CHAR
+                          ? `${entry.answers[0].substring(0, MAX_CHAR)}...`
+                          : entry.answers[0]
+                        : '',
+                      searchQuery: searchQuery,
                     }}
                   />
                 ))

--- a/client/src/pages/SearchResults/SearchResults.component.tsx
+++ b/client/src/pages/SearchResults/SearchResults.component.tsx
@@ -115,14 +115,14 @@ const SearchResults = (): JSX.Element => {
           </>
         )}
         <VStack id="search-results">
-          <Box sx={styles.questionsPage} className="questions-page">
+          <Flex sx={styles.questionsPage} className="questions-page">
             <Flex sx={styles.breadcrumb}>
               {breadcrumbContentRef.current.length > 0 ? (
                 <NavBreadcrumb navOrder={breadcrumbContentRef.current} />
               ) : null}
             </Flex>
             <Flex sx={styles.questionsGrid} className="questions-grid">
-              <Box sx={styles.questionsHeadline} className="questions-headline">
+              <Box sx={styles.resultsHeadline} className="questions-headline">
                 {foundPosts && foundPosts.length > 0
                   ? foundPosts.length === 1
                     ? `${foundPosts?.length} result found for`
@@ -154,20 +154,18 @@ const SearchResults = (): JSX.Element => {
                   />
                 ))
               ) : (
-                <>
-                  <Box sx={styles.noResults} className="no-results">
-                    <Box sx={styles.noResultsCaption}>
-                      Your search did not match any questions and answers. Try
-                      another search?
-                    </Box>
-                    <Box>- Check if the spelling is correct</Box>
-                    <Box>- Use different keywords</Box>
-                    <Box>- Try general keywords</Box>
+                <Box sx={styles.noResults} className="no-results">
+                  <Box sx={styles.noResultsCaption}>
+                    Your search did not match any questions and answers. Try
+                    another search?
                   </Box>
-                </>
+                  <Box>- Check if the spelling is correct</Box>
+                  <Box>- Use different keywords</Box>
+                  <Box>- Try general keywords</Box>
+                </Box>
               )}
             </Box>
-          </Box>
+          </Flex>
         </VStack>
       </HStack>
 

--- a/client/src/pages/SearchResults/SearchResults.component.tsx
+++ b/client/src/pages/SearchResults/SearchResults.component.tsx
@@ -1,13 +1,15 @@
 import { Box, Flex, HStack, Spacer, VStack } from '@chakra-ui/react'
+import { useMultiStyleConfig } from '@chakra-ui/system'
 import { useQuery } from 'react-query'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import OptionsSideMenu from '../../components/OptionsMenu/OptionsSideMenu.component'
-import { BackToHome } from '../../components/BackToHome/BackToHome'
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import PostItem from '../../components/PostItem/PostItem.component'
 import Spinner from '../../components/Spinner/Spinner.component'
 import AgencyLogo from '../../components/AgencyLogo/AgencyLogo.component'
+import { NavBreadcrumb } from '../../components/NavBreadcrumb/NavBreadcrumb'
 import {
   getAgencyByShortName,
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
@@ -16,9 +18,9 @@ import {
   search as sendSearchRequest,
   SEARCH_QUERY_KEY,
 } from '../../services/SearchService'
-import { useEffect, useState } from 'react'
 
 const SearchResults = (): JSX.Element => {
+  const styles = useMultiStyleConfig('SearchResults', {})
   const { search } = useLocation()
   const searchParams = new URLSearchParams(search)
   const searchQuery = searchParams.get('search') ?? ''
@@ -60,8 +62,33 @@ const SearchResults = (): JSX.Element => {
     window.addEventListener('resize', checkViewportSize)
     return () => window.removeEventListener('resize', checkViewportSize)
   }, [])
+  const breadcrumbContentRef = useRef<{ text: string; link: string }[]>([])
+
+  useEffect(() => {
+    const searchResult = agency
+      ? {
+          text: 'Search Results',
+          link: `/questions?search=${searchQuery}&agency=${agency.shortname}`,
+        }
+      : {
+          text: 'Search Results',
+          link: `/questions?search=${searchQuery}`,
+        }
+
+    const questionsList = agency
+      ? {
+          text: agency.shortname.toUpperCase(),
+          link: `/agency/${agency.shortname}`,
+        }
+      : { text: 'All Agencies', link: `/` }
+
+    breadcrumbContentRef.current = []
+    breadcrumbContentRef.current.push(questionsList)
+    breadcrumbContentRef.current.push(searchResult)
+  })
+
   return isLoading ? (
-    <Spinner centerHeight="200px" />
+    <Spinner centerHeight={`${styles.spinner.height}`} />
   ) : (
     <>
       <HStack
@@ -87,34 +114,18 @@ const SearchResults = (): JSX.Element => {
           </>
         )}
         <VStack id="search-results">
-          <Box
-            px={{ base: '32px', md: '48px' }}
-            mx="auto"
-            maxW="calc(793px + 48px * 2)"
-            className="questions-page"
-          >
-            <Flex
-              mt={{ base: '32px', sm: '60px' }}
-              mb={{ base: '32px', sm: '50px' }}
-            >
-              <BackToHome mainPageName={agencyShortName} />
+          <Box sx={styles.questionsPage} className="questions-page">
+            <Flex sx={styles.breadcrumb}>
+              {breadcrumbContentRef.current.length > 0 ? (
+                <NavBreadcrumb navOrder={breadcrumbContentRef.current} />
+              ) : null}
             </Flex>
-            <Flex className="questions-grid">
-              <Box
-                as="h3"
-                textStyle="display-2"
-                mb="24px"
-                flex="1 auto"
-                className="questions-headline"
-              >
+            <Flex sx={styles.questionsGrid} className="questions-grid">
+              <Box sx={styles.questionsHeadline} className="questions-headline">
                 {searchQuery ? 'Search Results' : 'All Questions'}
               </Box>
             </Flex>
-            <Box
-              padding="0"
-              w={{ base: '100%', md: undefined }}
-              className="questions"
-            >
+            <Box sx={styles.questions} className="questions">
               {foundPosts && foundPosts.length > 0 ? (
                 foundPosts.map((entry) => (
                   <PostItem
@@ -129,11 +140,7 @@ const SearchResults = (): JSX.Element => {
                 ))
               ) : (
                 <>
-                  <Box
-                    textStyle="subhead-1"
-                    color="gray.800"
-                    className="no-results"
-                  >
+                  <Box sx={styles.noResults} className="no-results">
                     {`No results found for "${searchQuery}".`}
                   </Box>
                   <Box>

--- a/client/src/theme/components/PostItem.ts
+++ b/client/src/theme/components/PostItem.ts
@@ -6,6 +6,7 @@ export const PostItem = makeMultiStyleConfig({
     py: '24px',
     borderBottom: '1px solid',
     borderBottomColor: 'neutral.300',
+    flexDirection: 'column',
   },
   content: {
     maxW: '1188px',
@@ -24,6 +25,11 @@ export const PostItem = makeMultiStyleConfig({
     '& .public-DraftStyleDefault-block': {
       my: 0,
     },
+  },
+  answer: {
+    textStyle: { base: 'body-2', sm: 'body-1' },
+    color: 'secondary.800',
+    mt: { base: '16px', sm: '8px' },
   },
   editWrapper: {
     alignItems: 'center',

--- a/client/src/theme/components/SearchResults.ts
+++ b/client/src/theme/components/SearchResults.ts
@@ -11,7 +11,8 @@ export const SearchResults = makeMultiStyleConfig({
   questionsPage: {
     px: { base: '32px', md: '48px' },
     mx: 'auto',
-    maxW: 'calc(793px + 48px * 2)',
+    w: { md: 'calc(793px + 48px * 2)' },
+    flexDirection: 'column',
   },
   questionsGrid: {
     mb: { base: '32px', md: '58px' },
@@ -19,6 +20,7 @@ export const SearchResults = makeMultiStyleConfig({
   },
   resultsHeadline: {
     textStyle: 'h4',
+    mb: '8px',
   },
   searchQuery: { as: 'h2', fontSize: '24px', fontWeight: 'semibold' },
   questions: { padding: '0', w: { base: '100%', md: undefined } },

--- a/client/src/theme/components/SearchResults.ts
+++ b/client/src/theme/components/SearchResults.ts
@@ -1,0 +1,33 @@
+import { makeMultiStyleConfig } from './helpers'
+
+export const SearchResults = makeMultiStyleConfig({
+  spinner: {
+    height: '200px',
+  },
+  breadcrumb: {
+    mt: { base: '32px', sm: '60px' },
+    mb: { base: '32px', sm: '50px' },
+  },
+  questionsPage: {
+    px: { base: '32px', md: '48px' },
+    mx: 'auto',
+    maxW: 'calc(793px + 48px * 2)',
+  },
+  questionsGrid: {
+    textStyle: 'display-2',
+    as: 'h3',
+    mb: '24px',
+    flex: '1 auto',
+  },
+  questionsHeadline: {
+    as: 'h3',
+    textStyle: 'display-2',
+    mb: '24px',
+    flex: '1 auto',
+  },
+  questions: { padding: '0', w: { base: '100%', md: undefined } },
+  noResults: {
+    textStyle: 'subhead-1',
+    color: 'gray.800',
+  },
+})

--- a/client/src/theme/components/SearchResults.ts
+++ b/client/src/theme/components/SearchResults.ts
@@ -5,8 +5,8 @@ export const SearchResults = makeMultiStyleConfig({
     height: '200px',
   },
   breadcrumb: {
-    mt: { base: '32px', sm: '60px' },
-    mb: { base: '32px', sm: '50px' },
+    mt: { base: '24px', sm: '60px' },
+    mb: { base: '32px', sm: '64px' },
   },
   questionsPage: {
     px: { base: '32px', md: '48px' },
@@ -14,20 +14,19 @@ export const SearchResults = makeMultiStyleConfig({
     maxW: 'calc(793px + 48px * 2)',
   },
   questionsGrid: {
-    textStyle: 'display-2',
-    as: 'h3',
-    mb: '24px',
-    flex: '1 auto',
+    mb: '32px',
+    flexDirection: 'column',
   },
   questionsHeadline: {
-    as: 'h3',
-    textStyle: 'display-2',
-    mb: '24px',
-    flex: '1 auto',
+    textStyle: 'h4',
   },
+  searchQuery: { as: 'h2', fontSize: '24px', fontWeight: 'semibold' },
   questions: { padding: '0', w: { base: '100%', md: undefined } },
   noResults: {
     textStyle: 'subhead-1',
-    color: 'gray.800',
+    color: 'secondary.800',
+  },
+  noResultsCaption: {
+    mb: '8px',
   },
 })

--- a/client/src/theme/components/SearchResults.ts
+++ b/client/src/theme/components/SearchResults.ts
@@ -14,10 +14,10 @@ export const SearchResults = makeMultiStyleConfig({
     maxW: 'calc(793px + 48px * 2)',
   },
   questionsGrid: {
-    mb: '32px',
+    mb: { base: '32px', md: '58px' },
     flexDirection: 'column',
   },
-  questionsHeadline: {
+  resultsHeadline: {
     textStyle: 'h4',
   },
   searchQuery: { as: 'h2', fontSize: '24px', fontWeight: 'semibold' },
@@ -28,5 +28,10 @@ export const SearchResults = makeMultiStyleConfig({
   },
   noResultsCaption: {
     mb: '8px',
+  },
+  questionsHeadline: {
+    textStyle: 'subhead-3',
+    color: 'primary.500',
+    mb: { sm: '26px' },
   },
 })

--- a/client/src/theme/components/index.ts
+++ b/client/src/theme/components/index.ts
@@ -10,6 +10,7 @@ import { PostItem } from './PostItem'
 import { SearchBox } from './SearchBox'
 import { StyledToast } from './StyledToast'
 import { OptionsMenu } from './OptionsMenu'
+import { SearchResults } from './SearchResults'
 
 export const components = {
   AuthForm,
@@ -24,4 +25,5 @@ export const components = {
   ImageBlock,
   AskForm,
   OptionsMenu,
+  SearchResults,
 }


### PR DESCRIPTION
## Problem

The search result page has not been updated according to the new designs on [Figma](https://www.figma.com/file/O6lxjjfn04Ow6nn2TMStpk/AskGov-Design-Master-v2?node-id=6255%3A56583)

Working towards #798 

## Solution

**Features**:

- Add breadcrumbs for navigation 
- Mention the search query in the headline
- Bold the search query terms whenever they occur in the search results' post title, ignoring case sensitivity
- Display answer preview, truncate if >120 characters

**Improvements**:
- Migrate theming from component to SearchResults Chakra theme

**Bug Fixes**:
- Make width of search results consistent for results found and no results found

## Before & After Screenshots

**BEFORE**:
Mobile:

https://user-images.githubusercontent.com/56983748/147716978-f4d125dd-623f-48bf-9daf-b74127186532.mov


Desktop:

https://user-images.githubusercontent.com/56983748/147716971-720acba7-14a1-4f63-81e3-451af4b681a3.mov


**AFTER**:
Mobile:

https://user-images.githubusercontent.com/56983748/147716806-e39ac187-525c-4c3d-bf27-5185e1379bf7.mov


Desktop:

https://user-images.githubusercontent.com/56983748/147716807-d5523e10-ce27-4eca-ba1f-d382d135fb0f.mov



## Tests

- Clicking on the breadcrumb links should bring you to the relevant pages
- Search terms should be bolded in the results
- Both question and answer should be displayed, clicking on either brings you to the post
