### PR TITLE
fix(optionsmenu): fix height of topic selection in side menu

### DIFF
--- a/client/src/theme/components/OptionsMenu.tsx
+++ b/client/src/theme/components/OptionsMenu.tsx
@@ -70,12 +70,12 @@ export const OptionsMenu: ComponentMultiStyleConfig = {
       px: '24px',
     },
     sideMenuTopicText: {
-      h: '24px',
+      minH: '24px',
       d: 'block',
     },
     sideMenuTopicSelect: {
       alignItems: 'flex-start',
-      h: '56px',
+      minH: '56px',
       w: '280px',
       p: '16px 24px',
       rounded: 'md',


### PR DESCRIPTION
## Problem

For longer topics, the text will overflow for the side menu.

## Solution

Change style to use min-height instead of fixed height.

## Before & After Screenshots
**BEFORE**:
![Screenshot 2021-12-30 at 11 07 32 AM](https://user-images.githubusercontent.com/41635847/147718524-ff315e3d-fb89-4d12-8bca-eef4a0e51dde.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/41635847/147718482-2f5dfeb1-c6cb-401d-bd86-7836b1873d12.png)

## Tests

Check that height of topic selection displays properly for longer topics (beyond 2 lines)
