### PR TITLE
feat(search): highlight search query terms in search results

### DIFF
--- a/client/src/components/PostItem/PostItem.component.tsx
+++ b/client/src/components/PostItem/PostItem.component.tsx
@@ -1,27 +1,18 @@
-import { Flex, Link, Text, Box, useMultiStyleConfig } from '@chakra-ui/react'
+import { Flex, Link, Box, useMultiStyleConfig } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
 import sanitizeHtml from 'sanitize-html'
 import { BasePostDto } from '../../api'
+import { HighlightSearchEntry } from '~shared/types/api'
 import { useAuth } from '../../contexts/AuthContext'
 import EditButton from '../EditButton/EditButton.component'
 
-function formatPostTitle(title: string, searchQuery: string) {
-  const searchQueryTerms: string[] = searchQuery.split(' ')
-  let formattedTitle: string = title
-  searchQueryTerms.forEach((word) => {
-    const regex = new RegExp('(' + word + ')', 'gi')
-    formattedTitle = formattedTitle.replace(regex, `<b>$1</b>`)
-  })
-  return formattedTitle
-}
-
 // Note: PostItem is the component for the homepage
 const PostItem = ({
-  post: { id, title, tags, agencyId, answer, searchQuery },
+  post: { id, title, tags, agencyId, answer, highlight },
 }: {
   post: Pick<BasePostDto, 'id' | 'title' | 'tags' | 'agencyId'> & {
     answer?: string
-    searchQuery?: string
+    highlight?: HighlightSearchEntry
   }
 }): JSX.Element => {
   const { user } = useAuth()
@@ -33,20 +24,25 @@ const PostItem = ({
     <Flex sx={styles.container}>
       {/* Title display area */}
       <Link as={RouterLink} to={`/questions/${id}`}>
-        {searchQuery ? (
+        {
           <Box sx={styles.linkText}>
-            <p
-              dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(formatPostTitle(title, searchQuery), {
-                  allowedTags: ['b'],
-                  allowedAttributes: {},
-                }),
-              }}
-            />
+            {highlight ? (
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeHtml(
+                    highlight.title ? highlight.title[0] : title,
+                    {
+                      allowedTags: ['b'],
+                      allowedAttributes: {},
+                    },
+                  ),
+                }}
+              />
+            ) : (
+              title
+            )}
           </Box>
-        ) : (
-          <Text sx={styles.linkText}>{title}</Text>
-        )}
+        }
         {<Box sx={styles.answer}>{answer}</Box>}
       </Link>
       {/* <Box sx={styles.description}>

--- a/client/src/components/SearchBox/SearchBox.component.tsx
+++ b/client/src/components/SearchBox/SearchBox.component.tsx
@@ -17,7 +17,7 @@ import { RefCallBack } from 'react-hook-form'
 import { BiSearch } from 'react-icons/bi'
 import { useQuery } from 'react-query'
 import { Link, useNavigate } from 'react-router-dom'
-import { SearchEntry } from '~shared/types/api'
+import { SearchEntryWithHighlight } from '~shared/types/api'
 import { useGoogleAnalytics } from '../../contexts/googleAnalytics'
 import {
   getAgencyById,
@@ -51,9 +51,9 @@ export const SearchBox = ({
   const styles = useMultiStyleConfig('SearchBox', {})
 
   const [searchQueryStrState, setSearchQueryStrState] = useState('')
-  const [searchEntriesState, setSearchEntriesState] = useState<SearchEntry[]>(
-    [],
-  )
+  const [searchEntriesState, setSearchEntriesState] = useState<
+    SearchEntryWithHighlight[]
+  >([])
 
   useQuery(
     [SEARCH_QUERY_KEY, agencyId, searchQueryStrState],
@@ -126,12 +126,12 @@ export const SearchBox = ({
 
   // null type required due to Downshift's type definitions
   // eslint-disable-next-line
-  const itemToString = (item: SearchEntry | null) =>
-    item?.title ? item.title : ''
+  const itemToString = (item: SearchEntryWithHighlight | null) =>
+    item?.result.title ?? ''
 
   const stateReducer = (
-    _state: DownshiftState<SearchEntry>,
-    changes: StateChangeOptions<SearchEntry>,
+    _state: DownshiftState<SearchEntryWithHighlight>,
+    changes: StateChangeOptions<SearchEntryWithHighlight>,
   ) => {
     return changes.type === Downshift.stateChangeTypes.blurInput ||
       changes.type === Downshift.stateChangeTypes.mouseUp ||
@@ -148,15 +148,17 @@ export const SearchBox = ({
     itemToString,
     onClick,
   }: {
-    item: SearchEntry
+    item: SearchEntryWithHighlight
     index: number
-    getItemProps: (options: GetItemPropsOptions<SearchEntry>) => SearchEntry
+    getItemProps: (
+      options: GetItemPropsOptions<SearchEntryWithHighlight>,
+    ) => SearchEntryWithHighlight
     highlightedIndex: number | null
-    itemToString: (item: SearchEntry | null) => string
+    itemToString: (item: SearchEntryWithHighlight | null) => string
     onClick: () => void
   }) => (
     <Link
-      to={`/questions/${item.postId}`}
+      to={`/questions/${item.result.postId}`}
       {...getItemProps({
         index,
         item,
@@ -179,7 +181,9 @@ export const SearchBox = ({
   return (
     <Flex sx={{ ...styles.form, ...sx }}>
       <Downshift
-        onChange={(selection) => navigate(`/questions/${selection?.postId}`)}
+        onChange={(selection) =>
+          navigate(`/questions/${selection?.result.postId}`)
+        }
         stateReducer={stateReducer}
         itemToString={itemToString}
         initialInputValue={value}
@@ -250,7 +254,7 @@ export const SearchBox = ({
                 ? searchEntriesState.map((entry, index) => {
                     return (
                       <SearchItem
-                        key={entry.postId}
+                        key={entry.result.postId}
                         onClick={() => sendSearchEventToAnalytics(inputValue)}
                         {...{
                           item: entry,

--- a/client/src/pages/SearchResults/SearchResults.component.tsx
+++ b/client/src/pages/SearchResults/SearchResults.component.tsx
@@ -138,18 +138,25 @@ const SearchResults = (): JSX.Element => {
               {foundPosts && foundPosts.length > 0 ? (
                 foundPosts.map((entry) => (
                   <PostItem
-                    key={entry.postId}
+                    key={entry.result.postId}
                     post={{
-                      id: entry.postId,
-                      title: entry.title ?? '',
+                      id: entry.result.postId,
+                      title: entry.result.title ?? '',
                       tags: [],
-                      agencyId: entry.agencyId ?? 0,
-                      answer: entry.answers
-                        ? entry.answers[0].length > MAX_CHAR
-                          ? `${entry.answers[0].substring(0, MAX_CHAR)}...`
-                          : entry.answers[0]
+                      agencyId: entry.result.agencyId ?? 0,
+                      answer: entry.result.answers
+                        ? entry.result.answers[0].length > MAX_CHAR
+                          ? `${entry.result.answers[0].substring(
+                              0,
+                              MAX_CHAR,
+                            )}...`
+                          : entry.result.answers[0]
                         : '',
-                      searchQuery: searchQuery,
+                      highlight: entry.highlight ?? {
+                        title: [],
+                        description: [],
+                        answers: [],
+                      },
                     }}
                   />
                 ))

--- a/client/src/services/SearchService.ts
+++ b/client/src/services/SearchService.ts
@@ -1,4 +1,4 @@
-import { SearchEntry } from '~shared/types/api'
+import { SearchEntryWithHighlight } from '~shared/types/api'
 import { ApiClient } from '../api'
 
 const SEARCH_API_BASE = '/search'
@@ -10,8 +10,8 @@ export const search = async ({
 }: {
   query: string
   agencyId?: number
-}): Promise<SearchEntry[]> => {
-  return ApiClient.get<SearchEntry[]>(SEARCH_API_BASE, {
+}): Promise<SearchEntryWithHighlight[]> => {
+  return ApiClient.get<SearchEntryWithHighlight[]>(SEARCH_API_BASE, {
     params: { query, agencyId },
   }).then(({ data }) => data)
 }

--- a/server/src/modules/search/__tests__/search.routes.spec.ts
+++ b/server/src/modules/search/__tests__/search.routes.spec.ts
@@ -3,7 +3,7 @@ import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { okAsync } from 'neverthrow'
 import supertest from 'supertest'
-import { SearchEntry } from '../../../../../shared/src/types/api'
+import { SearchEntryWithHighlight } from '../../../../../shared/src/types/api'
 import { SearchController } from '../search.controller'
 import { routeSearch } from '../search.routes'
 
@@ -22,31 +22,42 @@ describe('/', () => {
     const router = routeSearch({ controller })
     const indexName = 'search_entries'
 
-    const searchEntries: SearchEntry[] = [
+    const searchEntries: SearchEntryWithHighlight[] = [
       {
-        agencyId: 2,
-        answers: ['answer 2000'],
-        description: 'description 200',
-        postId: 2,
-        title: 'title 20',
-        topicId: null,
+        result: {
+          agencyId: 2,
+          answers: ['answer 2000'],
+          description: 'description 200',
+          postId: 2,
+          title: 'title 20',
+          topicId: null,
+        },
+        highlight: {
+          title: ['<b>title</b> 20'],
+        },
       },
       {
-        agencyId: 1,
-        answers: ['answer 1000'],
-        description: 'description 100',
-        postId: 1,
-        title: 'title 10',
-        topicId: null,
+        result: {
+          agencyId: 1,
+          answers: ['answer 1000'],
+          description: 'description 100',
+          postId: 1,
+          title: 'title 10',
+          topicId: null,
+        },
+        highlight: {
+          title: ['<b>title</b> 10'],
+        },
       },
     ]
     const sampleHits: SearchHit[] = searchEntries.map((entry) => {
       return {
-        _id: `${entry.postId}`,
+        _id: `${entry.result.postId}`,
         _index: indexName,
         _score: 0.125,
-        _source: entry,
+        _source: entry.result,
         _type: '_doc',
+        highlight: entry.highlight,
       }
     })
 

--- a/server/src/modules/search/__tests__/search.service.spec.ts
+++ b/server/src/modules/search/__tests__/search.service.spec.ts
@@ -1,6 +1,6 @@
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors'
 import { StatusCodes } from 'http-status-codes'
-import { SearchEntry } from '~shared/types/api/search'
+import { SearchEntryWithHighlight } from '~shared/types/api/search'
 import { Mocker } from '../opensearch-mock'
 import { SearchService } from '../search.service'
 
@@ -52,16 +52,21 @@ describe('Search Service', () => {
 
   const indexName = 'search_entries'
 
-  const searchEntriesDataset: SearchEntry[] = []
+  const searchEntriesDataset: SearchEntryWithHighlight[] = []
 
   for (let i = 1; i < 3; i++) {
     searchEntriesDataset.push({
-      title: `title ${i * 10}`,
-      description: `description ${i * 100}`,
-      answers: [`answer ${i * 1000}`],
-      agencyId: i,
-      postId: i,
-      topicId: null,
+      result: {
+        title: `title ${i * 10}`,
+        description: `description ${i * 100}`,
+        answers: [`answer ${i * 1000}`],
+        agencyId: i,
+        postId: i,
+        topicId: null,
+      },
+      highlight: {
+        title: [],
+      },
     })
   }
 
@@ -175,6 +180,9 @@ describe('Search Service', () => {
                     topicId: null,
                   },
                   _type: '_doc',
+                  highlight: {
+                    title: ['<b>title 20</b>'],
+                  },
                 },
                 {
                   _index: indexName,
@@ -188,6 +196,9 @@ describe('Search Service', () => {
                     topicId: null,
                   },
                   _type: '_doc',
+                  highlight: {
+                    title: ['<b>title</b> 10'],
+                  },
                 },
               ],
             },

--- a/server/src/modules/search/search.controller.ts
+++ b/server/src/modules/search/search.controller.ts
@@ -63,7 +63,7 @@ export class SearchController {
       .map((response) => {
         const searchResults = response.body.hits.hits.map(
           (result: SearchHit) => {
-            return result._source
+            return { result: result._source, highlight: result.highlight }
           },
         )
         return res.status(StatusCodes.OK).json(searchResults)

--- a/server/src/modules/search/search.service.ts
+++ b/server/src/modules/search/search.service.ts
@@ -34,6 +34,12 @@ export class SearchService {
         body: {
           query: { multi_match: multiMatchQuery },
           ...(agencyId && { post_filter: { term: { agencyId: agencyId } } }),
+          highlight: {
+            fields: { title: {}, description: {}, answers: {} },
+            pre_tags: '<b>',
+            post_tags: '</b>',
+            fragment_size: 200,
+          },
         },
       }),
       (err) => {

--- a/shared/src/types/api/search.ts
+++ b/shared/src/types/api/search.ts
@@ -1,3 +1,9 @@
+export type HighlightSearchEntry = {
+  title?: string[]
+  description?: string[]
+  answers?: string[]
+}
+
 export type SearchEntry = {
   postId: number
   title?: string
@@ -5,4 +11,9 @@ export type SearchEntry = {
   answers?: string[]
   agencyId?: number
   topicId?: number | null
+}
+
+export type SearchEntryWithHighlight = {
+  result: SearchEntry
+  highlight?: HighlightSearchEntry
 }


### PR DESCRIPTION
## Problem

The bolded search terms might include words that have not been used to identify the results e.g. stop words

Closes #1069 

## Solution

Add the `highlight` parameter to the query block, this returns a `highlight` object that shows the search term wrapped in a `<b></b>` tag. The highlight parameter highlights the original terms even when using synonyms or stemming for the search itself.

Relevant documentation [here](https://opensearch.org/docs/latest/opensearch/ux/#highlight-query-matches) and [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/searching.html#searching-dsl)



## Before & After Screenshots

**BEFORE**:
![Screenshot 2022-01-06 at 10 38 58 AM](https://user-images.githubusercontent.com/56983748/148319644-6c42aac7-98f5-40d6-a614-f3cccf26008f.png)


**AFTER**:
![image](https://user-images.githubusercontent.com/56983748/148319621-83f7f7a6-f1ff-4abd-ad73-2086a428f47a.png)


## Tests

- Use misspelled search terms in the search query, the results shown should have the correct search term bolded