### PR TITLE
chore: update license year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,7 +21,7 @@ language of the arbitration shall be English.
 
 MIT License
 
-Copyright 2021 Government Technology Agency.
+Copyright 2022 Government Technology Agency.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update license year to 2022