### PR TITLE
build(deps-dev): remove react-tabs, not used

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,7 +34,6 @@
         "react-router-dom": "^6.2.2",
         "react-scripts": "^5.0.0",
         "react-select": "^5.2.2",
-        "react-tabs": "^3.2.3",
         "sanitize-html": "^2.7.0",
         "sass": "^1.49.9",
         "styled-components": "^5.3.3",
@@ -15924,6 +15923,7 @@
     },
     "node_modules/clsx": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -28715,17 +28715,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/react-tabs": {
-      "version": "3.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.0",
-        "prop-types": "^15.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0-0"
       }
     },
     "node_modules/react-textarea-autosize": {
@@ -45513,7 +45502,8 @@
       }
     },
     "clsx": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "co": {
       "version": "4.6.0"
@@ -54003,13 +53993,6 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
-      }
-    },
-    "react-tabs": {
-      "version": "3.2.3",
-      "requires": {
-        "clsx": "^1.1.0",
-        "prop-types": "^15.5.0"
       }
     },
     "react-textarea-autosize": {

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,6 @@
     "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.0",
     "react-select": "^5.2.2",
-    "react-tabs": "^3.2.3",
     "sanitize-html": "^2.7.0",
     "sass": "^1.49.9",
     "styled-components": "^5.3.3",


### PR DESCRIPTION
react-tabs was used in earlier iterations of AskGov before Chakra was adopted as component framework of choice. Remove react-tabs accordingly