### PR TITLE
fix(agencies): reinstate search by name

### DIFF
--- a/server/src/modules/agency/__tests__/agency.controller.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.controller.spec.ts
@@ -18,12 +18,12 @@ describe('AgencyController', () => {
     findOneByName: jest.fn(),
     findOneById: jest.fn(),
     listAgencyShortNames: jest.fn(),
-    listAllAgencies: jest.fn()
+    listAllAgencies: jest.fn(),
   }
   const agencyController = new AgencyController({ agencyService })
 
   const app = express()
-  app.get('/', agencyController.listAllAgencies)
+  app.get('/', agencyController.listAgencies)
   app.get('/:agencyId', agencyController.getSingleAgencyById)
   const request = supertest(app)
 
@@ -33,18 +33,51 @@ describe('AgencyController', () => {
     agencyService.listAllAgencies.mockReset()
     agencyService.findOneByName.mockReturnValue(okAsync(agency))
     agencyService.findOneById.mockReturnValue(okAsync(agency))
-    agencyService.listAllAgencies.mockReturnValue(okAsync(agency))
+    agencyService.listAllAgencies.mockReturnValue(okAsync([agency]))
   })
 
-  describe('listAllAgencies', () => {
+  describe('listAgencies', () => {
     it('returns OK on valid query', async () => {
       const response = await request.get('/')
       expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toStrictEqual([agency])
+    })
+
+    it('returns OK on valid name query', async () => {
+      agencyService.listAllAgencies.mockReturnValue(okAsync(agency))
+      const { shortname, longname } = agency
+
+      const response = await request.get(
+        `/?shortname=${shortname}&longname=${longname}`,
+      )
+      expect(response.status).toEqual(StatusCodes.OK)
       expect(response.body).toStrictEqual(agency)
+      expect(agencyService.findOneByName).toHaveBeenCalledWith({
+        shortname,
+        longname,
+      })
+    })
+
+    it('returns NOT_FOUND on invalid query', async () => {
+      const { shortname, longname } = agency
+      agencyService.findOneByName.mockReturnValue(
+        errAsync(new MissingAgencyError()),
+      )
+
+      const response = await request.get('/').query({ shortname, longname })
+
+      expect(response.status).toEqual(StatusCodes.NOT_FOUND)
+      expect(response.body).toStrictEqual({ message: 'Agency not found' })
+      expect(agencyService.findOneByName).toHaveBeenCalledWith({
+        shortname,
+        longname,
+      })
     })
 
     it('returns INTERNAL_SERVER_ERROR on bad service', async () => {
-      agencyService.listAllAgencies.mockReturnValue(errAsync(new DatabaseError()))
+      agencyService.listAllAgencies.mockReturnValue(
+        errAsync(new DatabaseError()),
+      )
       const response = await request.get('/')
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR)
     })

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -91,11 +91,13 @@ describe('/agencies', () => {
       const response = await request.get(path)
 
       expect(response.status).toEqual(StatusCodes.OK)
-      expect(response.body).toStrictEqual([{
-        ...agency.get(),
-        createdAt: `${(agency.createdAt as Date).toISOString()}`,
-        updatedAt: `${(agency.updatedAt as Date).toISOString()}`,
-      }])
+      expect(response.body).toStrictEqual([
+        {
+          ...agency.get(),
+          createdAt: `${(agency.createdAt as Date).toISOString()}`,
+          updatedAt: `${(agency.updatedAt as Date).toISOString()}`,
+        },
+      ])
     })
   })
 
@@ -105,11 +107,11 @@ describe('/agencies', () => {
       const response = await request.get(path).query({ shortname, longname })
 
       expect(response.status).toEqual(StatusCodes.OK)
-      expect(response.body).toStrictEqual([{
+      expect(response.body).toStrictEqual({
         ...agency.get(),
         createdAt: `${(agency.createdAt as Date).toISOString()}`,
         updatedAt: `${(agency.updatedAt as Date).toISOString()}`,
-      }])
+      })
     })
   })
 

--- a/server/src/modules/agency/__tests__/agency.service.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.service.spec.ts
@@ -30,7 +30,7 @@ describe('AgencyService', () => {
     await db.close()
   })
 
-  const expectAgencyMatch = (actualAgency: Agency | null , agency: Agency) => {
+  const expectAgencyMatch = (actualAgency: Agency | null, agency: Agency) => {
     expect(actualAgency?.id).toEqual(agency.id)
     expect(actualAgency?.shortname).toEqual(agency.shortname)
     expect(actualAgency?.longname).toEqual(agency.longname)
@@ -38,7 +38,10 @@ describe('AgencyService', () => {
     expect(actualAgency?.logo).toEqual(agency.logo)
   }
 
-  const expectListOfAgencyMatch = (actualListOfAgencies: Agency[], agency: Agency) => {
+  const expectListOfAgencyMatch = (
+    actualListOfAgencies: Agency[],
+    agency: Agency,
+  ) => {
     expect(actualListOfAgencies).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -46,13 +49,13 @@ describe('AgencyService', () => {
           shortname: agency.shortname,
           longname: agency.longname,
           email: agency.email,
-          logo: agency.logo
-        })
-      ])
+          logo: agency.logo,
+        }),
+      ]),
     )
   }
 
-  describe('listAllAgencies', () => { 
+  describe('listAllAgencies', () => {
     it('returns list of all agencies', async () => {
       const actualAgency = await service.listAllAgencies()
       expectListOfAgencyMatch(actualAgency._unsafeUnwrap(), agency)

--- a/server/src/modules/agency/agency.controller.ts
+++ b/server/src/modules/agency/agency.controller.ts
@@ -12,41 +12,26 @@ export class AgencyController {
   }
 
   /**
-   * list all agencies
-   * @return 200 with agency
-   * @return 404 if agency is not found
-   * @return 500 if database error
-   */
-
-  listAllAgencies: ControllerHandler<
-    undefined,
-    Agency[] | Message,
-    undefined,
-    AgencyQuery
-  > = async (req, res) => {
-    return this.agencyService
-      .listAllAgencies()
-      .map((data) => res.status(StatusCodes.OK).json(data))
-      .mapErr((error) => {
-        return res.status(error.statusCode).json({ message: error.message })
-      })
-  }
-
-  /**
-   * Find an agency by their shortname or longname
+   * list all agencies, or agency by shortname or longname
    * @param query agency's shortname or longname
    * @return 200 with agency
    * @return 404 if agency is not found
    * @return 500 if database error
    */
-  getSingleAgency: ControllerHandler<
+
+  listAgencies: ControllerHandler<
     undefined,
-    Agency | Message,
+    Agency[] | Agency | Message,
     undefined,
     AgencyQuery
   > = async (req, res) => {
-    return this.agencyService
-      .findOneByName(req.query)
+    const { longname, shortname } = req.query
+
+    const result =
+      longname || shortname
+        ? this.agencyService.findOneByName(req.query)
+        : this.agencyService.listAllAgencies()
+    return result
       .map((data) => res.status(StatusCodes.OK).json(data))
       .mapErr((error) => {
         return res.status(error.statusCode).json({ message: error.message })

--- a/server/src/modules/agency/agency.routes.ts
+++ b/server/src/modules/agency/agency.routes.ts
@@ -20,7 +20,11 @@ export const routeAgencies = ({
    * @return 500 if database error
    * @access Public
    */
-  router.get('/', controller.listAllAgencies)
+  router.get(
+    '/',
+    [query('shortname').optional(), query('longname').optional()],
+    controller.listAgencies,
+  )
 
   /**
    * List all agencies' shortnames

--- a/server/src/modules/agency/agency.service.ts
+++ b/server/src/modules/agency/agency.service.ts
@@ -20,21 +20,20 @@ export class AgencyService {
    * @returns err(DatabaseError) if database errors occurs whilst retrieving agency
    * @returns err(MissingAgencyError) if agency does not exist in the database
    */
-  listAllAgencies = (): 
-  ResultAsync<Agency[], DatabaseError | MissingAgencyError> => {
-    return ResultAsync.fromPromise(
-      this.Agency.findAll({}),
-      (error) => {
-        logger.error({
-          message: 'Database error while retrieving list of all agencies.',
-          meta: {
-            function: 'listAgencies'
-          },
-          error,
-        })
-        return new DatabaseError()
-      },
-    ).andThen((agencies) => {
+  listAllAgencies = (): ResultAsync<
+    Agency[],
+    DatabaseError | MissingAgencyError
+  > => {
+    return ResultAsync.fromPromise(this.Agency.findAll({}), (error) => {
+      logger.error({
+        message: 'Database error while retrieving list of all agencies.',
+        meta: {
+          function: 'listAgencies',
+        },
+        error,
+      })
+      return new DatabaseError()
+    }).andThen((agencies) => {
       if (!agencies) {
         return errAsync(new MissingAgencyError())
       }

--- a/server/src/modules/web/__tests__/web.controller.spec.ts
+++ b/server/src/modules/web/__tests__/web.controller.spec.ts
@@ -27,7 +27,7 @@ describe('WebController', () => {
     findOneByName: jest.fn(),
     findOneById: jest.fn(),
     listAgencyShortNames: jest.fn(),
-    listAllAgencies: jest.fn()
+    listAllAgencies: jest.fn(),
   }
   const answersService = {
     listAnswers: jest.fn(),

--- a/server/src/modules/web/__tests__/web.routes.spec.ts
+++ b/server/src/modules/web/__tests__/web.routes.spec.ts
@@ -46,7 +46,7 @@ describe('/', () => {
     findOneByName: jest.fn(),
     findOneById: jest.fn(),
     listAgencyShortNames: jest.fn(),
-    listAllAgencies: jest.fn()
+    listAllAgencies: jest.fn(),
   }
   const answersService = {
     listAnswers: jest.fn(),


### PR DESCRIPTION
opengovsg#1426 broke frontend, as `agencies/` removed lookup
of agencies by name, which certain frontend components
still relied on that to return agency information. Reinstate this
functionality, while also allowing listing all agencies.

- remove `getSingleAgency()`, not used
- `listAllAgencies()` -> `listAgencies()`
- if the relevant query parameters are provided to `agencies/`,
  perform an agency lookup by name, otherwise return an array
  of all known agencies
- delint the codebase as needed
