### PR TITLE
feat(OptionsMenu): display agency long and short names

### DIFF
--- a/client/src/components/OptionsMenu/OptionsMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsMenu.component.tsx
@@ -24,6 +24,8 @@ import {
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
   listAgencyShortNames,
   LIST_AGENCY_SHORTNAMES,
+  getListOfAllAgencies,
+  GET_LIST_OF_ALL_AGENCIES,
 } from '../../services/AgencyService'
 import {
   getTopicsUsedByAgency,
@@ -78,17 +80,28 @@ const OptionsMenu = (): ReactElement => {
     { enabled: !!agency },
   )
 
-  const { data: agencyShortNames } = useQuery(LIST_AGENCY_SHORTNAMES, () =>
-    listAgencyShortNames(),
+  // const { data: agencyShortNames } = useQuery(LIST_AGENCY_SHORTNAMES, () =>
+  //   listAgencyShortNames(),
+  // )
+
+  const { data: listOfAllAgencies } = useQuery(GET_LIST_OF_ALL_AGENCIES, () =>
+    getListOfAllAgencies(),
   )
 
   const topicsToShow = (topics || [])
     .filter((topic) => topic.name !== topicQueried)
     .sort(bySpecifiedOrder(agency))
 
-  const agencyShortNamesToShow = (agencyShortNames || [])
-    .map((agency) => agency.shortname)
-    .filter((shortname) => shortname !== agencyShortName)
+  // const agencyShortNamesToShow = (agencyShortNames || [])
+  //   .map((agency) => agency.shortname)
+  //   .filter((shortname) => shortname !== agencyShortName)
+
+  const agencyNamesToShow = (listOfAllAgencies || []).map((agency) => {
+    return {
+      shortname: agency.shortname,
+      longname: agency.longname,
+    }
+  })
 
   const optionsMenu = (
     <SimpleGrid sx={styles.accordionGrid}>
@@ -118,17 +131,19 @@ const OptionsMenu = (): ReactElement => {
               </Flex>
             )
           })
-        : agencyShortNamesToShow.map((shortname) => {
+        : agencyNamesToShow.map((agency) => {
             return (
               <Flex
                 sx={styles.accordionItem}
                 role="group"
                 as={RouterLink}
-                key={shortname}
-                to={getRedirectURLAgency(shortname)}
+                key={agency.shortname}
+                to={getRedirectURLAgency(agency.shortname)}
               >
                 <Flex m="auto" w="100%" px={8}>
-                  <Text>{shortname.toUpperCase()}</Text>
+                  <Text>
+                    {agency.longname} ({agency.shortname.toUpperCase()})
+                  </Text>
                   <Spacer />
                   <Flex alignItems="center">
                     <BiRightArrowAlt />

--- a/client/src/components/OptionsMenu/OptionsMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsMenu.component.tsx
@@ -24,6 +24,8 @@ import {
   GET_AGENCY_BY_SHORTNAME_QUERY_KEY,
   listAgencyShortNames,
   LIST_AGENCY_SHORTNAMES,
+  getListOfAllAgencies,
+  GET_LIST_OF_ALL_AGENCIES,
 } from '../../services/AgencyService'
 import {
   getTopicsUsedByAgency,
@@ -78,17 +80,20 @@ const OptionsMenu = (): ReactElement => {
     { enabled: !!agency },
   )
 
-  const { data: agencyShortNames } = useQuery(LIST_AGENCY_SHORTNAMES, () =>
-    listAgencyShortNames(),
+  const { data: listOfAllAgencies } = useQuery(GET_LIST_OF_ALL_AGENCIES, () =>
+    getListOfAllAgencies(),
   )
 
   const topicsToShow = (topics || [])
     .filter((topic) => topic.name !== topicQueried)
     .sort(bySpecifiedOrder(agency))
 
-  const agencyShortNamesToShow = (agencyShortNames || [])
-    .map((agency) => agency.shortname)
-    .filter((shortname) => shortname !== agencyShortName)
+  const agencyNamesToShow = (listOfAllAgencies || []).map((agency) => {
+    return {
+      shortname: agency.shortname,
+      longname: agency.longname,
+    }
+  })
 
   const optionsMenu = (
     <SimpleGrid sx={styles.accordionGrid}>
@@ -118,17 +123,19 @@ const OptionsMenu = (): ReactElement => {
               </Flex>
             )
           })
-        : agencyShortNamesToShow.map((shortname) => {
+        : agencyNamesToShow.map((agency) => {
             return (
               <Flex
                 sx={styles.accordionItem}
                 role="group"
                 as={RouterLink}
-                key={shortname}
-                to={getRedirectURLAgency(shortname)}
+                key={agency.shortname}
+                to={getRedirectURLAgency(agency.shortname)}
               >
                 <Flex m="auto" w="100%" px={8}>
-                  <Text>{shortname.toUpperCase()}</Text>
+                  <Text>
+                    {agency.longname} ({agency.shortname.toUpperCase()})
+                  </Text>
                   <Spacer />
                   <Flex alignItems="center">
                     <BiRightArrowAlt />

--- a/client/src/services/AgencyService.ts
+++ b/client/src/services/AgencyService.ts
@@ -1,10 +1,13 @@
 import { Agency } from '~shared/types/base'
 import { ApiClient } from '../api'
-
 export { Agency } from '~shared/types/base'
 
 export type AgencyQuery = {
   shortname: string
+}
+
+export const getListOfAllAgencies = (): Promise<Agency[]> => {
+  return ApiClient.get<Agency[]>('/').then(({ data }) => data)
 }
 
 export const getAgencyByShortName = (query: AgencyQuery): Promise<Agency> => {
@@ -23,6 +26,7 @@ export const listAgencyShortNames = (): Promise<{ shortname: string }[]> => {
   )
 }
 
+export const GET_LIST_OF_ALL_AGENCIES = 'getListOfAllAgencies'
 export const GET_AGENCY_BY_SHORTNAME_QUERY_KEY = 'getAgencyByShortName'
 export const GET_AGENCY_BY_ID_QUERY_KEY = 'getAgencyById'
 export const LIST_AGENCY_SHORTNAMES = 'listAgencyShortNames'

--- a/client/src/services/AgencyService.ts
+++ b/client/src/services/AgencyService.ts
@@ -7,7 +7,7 @@ export type AgencyQuery = {
 }
 
 export const getListOfAllAgencies = (): Promise<Agency[]> => {
-  return ApiClient.get<Agency[]>('/').then(({ data }) => data)
+  return ApiClient.get<Agency[]>('/agencies/').then(({ data }) => data)
 }
 
 export const getAgencyByShortName = (query: AgencyQuery): Promise<Agency> => {


### PR DESCRIPTION
Fixes #1405 
added features:

1. useQuery to request list of all agency data
2. map agency data to display both long and short name 