### PR TITLE
style(Agency/OptionsMenu): increase OptionsMenu max-width to 680px and fix styles for AgencyHomePage

### DIFF
--- a/client/src/components/OptionsMenu/OptionsMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsMenu.component.tsx
@@ -93,6 +93,18 @@ const OptionsMenu = (): ReactElement => {
     }
   })
 
+  const OptionsItem = (option: string) => {
+    return (
+      <Flex m="auto" w="100%" px={8}>
+        <Text maxW="244px">{option}</Text>
+        <Spacer />
+        <Flex alignItems="center">
+          <BiRightArrowAlt />
+        </Flex>
+      </Flex>
+    )
+  }
+
   const optionsMenu = (
     <SimpleGrid sx={styles.accordionGrid}>
       {agency
@@ -100,24 +112,17 @@ const OptionsMenu = (): ReactElement => {
             return (
               <Flex
                 sx={styles.accordionItem}
-                _hover={{ bg: 'secondary.600', boxShadow: 'lg' }}
                 role="group"
                 as={RouterLink}
                 key={id}
-                to={getRedirectURLTopics(name, agency)}
+                to={getRedirectURLTopics(name, agency.shortname)}
                 onClick={() => {
                   sendClickTopicEventToAnalytics(name)
                   setTopicQueried(name)
                   accordionRef.current?.click()
                 }}
               >
-                <Flex m="auto" w="100%" px={8}>
-                  <Text>{name}</Text>
-                  <Spacer />
-                  <Flex alignItems="center">
-                    <BiRightArrowAlt />
-                  </Flex>
-                </Flex>
+                {OptionsItem(name)}
               </Flex>
             )
           })
@@ -130,15 +135,9 @@ const OptionsMenu = (): ReactElement => {
                 key={agency.shortname}
                 to={getRedirectURLAgency(agency.shortname)}
               >
-                <Flex m="auto" w="100%" px={8}>
-                  <Text>
-                    {agency.longname} ({agency.shortname.toUpperCase()})
-                  </Text>
-                  <Spacer />
-                  <Flex alignItems="center">
-                    <BiRightArrowAlt />
-                  </Flex>
-                </Flex>
+                {OptionsItem(
+                  `${agency.longname} (${agency.shortname.toUpperCase()})`,
+                )}
               </Flex>
             )
           })}

--- a/client/src/components/OptionsMenu/OptionsSideMenu.component.tsx
+++ b/client/src/components/OptionsMenu/OptionsSideMenu.component.tsx
@@ -51,7 +51,7 @@ const OptionsSideMenu = ({
             bg={name === topicQueried ? 'secondary.100' : undefined}
             as={RouterLink}
             key={id}
-            to={getRedirectURLTopics(name, agency)}
+            to={getRedirectURLTopics(name, agency.shortname)}
             onClick={() => {
               sendClickTopicEventToAnalytics(name)
               setTopicQueried(name)

--- a/client/src/components/QuestionsHeader/QuestionsHeader.component.tsx
+++ b/client/src/components/QuestionsHeader/QuestionsHeader.component.tsx
@@ -15,14 +15,13 @@ export const QuestionsHeader = (): JSX.Element => {
   return (
     <Flex
       flexDir={{ base: 'column-reverse', sm: 'row' }}
-      mb={5}
       justifyContent="space-between"
     >
       <Text
         color="primary.500"
         textStyle="subhead-3"
-        mt={{ base: '32px', sm: 0 }}
-        mb={{ sm: '20px' }}
+        mt={{ base: '32px', sm: '50px', xl: '58px' }}
+        mb={{ sm: '18px' }}
         d="block"
       >
         {questionsDisplayState.label}

--- a/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
+++ b/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
@@ -178,7 +178,7 @@ const AgencyHomePage = (): JSX.Element => {
         w="100%"
         pt={{ base: '32px', sm: '80px', xl: '90px' }}
         px={8}
-        direction={{ base: 'column', lg: 'row' }}
+        direction={{ base: 'column', xl: 'row' }}
       >
         {children}
       </Flex>
@@ -217,12 +217,10 @@ const AgencyHomePage = (): JSX.Element => {
   const topicPageMobileView = (
     <>
       <OptionsMenu />
-      <HStackWrapper>
-        <FlexWrapper>
-          {topicsDescriptionAboveQuestions}
-          {agencyQuestions}
-        </FlexWrapper>
-      </HStackWrapper>
+      <FlexWrapper>
+        {topicsDescriptionAboveQuestions}
+        {agencyQuestions}
+      </FlexWrapper>
     </>
   )
 

--- a/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
+++ b/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
@@ -130,7 +130,7 @@ const AgencyHomePage = (): JSX.Element => {
     ?.filter(({ name }) => name === topicQueried)
     .map((topic) => {
       return topic.description ? (
-        <Text textStyle="body-1" color="neutral.900" mb="50px">
+        <Text textStyle="body-1" color="neutral.900" mb={{ sm: '50px' }}>
           {topic.description}
         </Text>
       ) : null

--- a/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
+++ b/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
@@ -130,7 +130,7 @@ const AgencyHomePage = (): JSX.Element => {
     ?.filter(({ name }) => name === topicQueried)
     .map((topic) => {
       return topic.description ? (
-        <Text textStyle="body-1" color="neutral.900" mb={{ sm: '50px' }}>
+        <Text textStyle="body-1" color="neutral.900" pt={{ base: 8, sm: 10 }}>
           {topic.description}
         </Text>
       ) : null
@@ -176,8 +176,7 @@ const AgencyHomePage = (): JSX.Element => {
         m="auto"
         justifySelf="center"
         w="100%"
-        pt={{ base: '32px', sm: '80px', xl: '90px' }}
-        px={8}
+        px={{ base: 8, sm: 0 }}
         direction={{ base: 'column', xl: 'row' }}
       >
         {children}

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -22,8 +22,8 @@ const HomePage = (): JSX.Element => {
           m="auto"
           justifySelf="center"
           w="100%"
-          pt={{ base: '32px', sm: '80px', xl: '90px' }}
-          px={8}
+          pt={{ sm: '30px', xl: '22px' }}
+          px={{ base: 8, sm: 0 }}
           direction={{ base: 'column', lg: 'row' }}
         >
           <Questions />

--- a/client/src/theme/components/OptionsMenu.tsx
+++ b/client/src/theme/components/OptionsMenu.tsx
@@ -21,7 +21,7 @@ export const OptionsMenu: ComponentMultiStyleConfig = {
     },
     accordionGrid: {
       'grid-template-columns': { base: 'repeat(1, 1fr)', sm: 'repeat(2, 1fr)' },
-      maxW: '620px',
+      maxW: '680px',
       m: 'auto',
       'grid-row-gap': urlHasTopicsParamKey
         ? { base: undefined, sm: '16px' }

--- a/client/src/theme/components/OptionsMenu.tsx
+++ b/client/src/theme/components/OptionsMenu.tsx
@@ -56,7 +56,7 @@ export const OptionsMenu: ComponentMultiStyleConfig = {
       maxW: '680px',
       m: 'auto',
       w: '100%',
-      px: 8,
+      px: { base: 8, sm: 0 },
       textAlign: 'left',
     },
     sideMenuBox: {

--- a/client/src/util/urlparser.ts
+++ b/client/src/util/urlparser.ts
@@ -1,5 +1,4 @@
 import queryString from 'query-string'
-import { Agency } from '../services/AgencyService'
 
 export const getTagsQuery = (search: string): string => {
   const query = queryString.parse(search)
@@ -24,12 +23,13 @@ export const getTopicsQuery = (search: string): string => {
 export const isSpecified = (search: string, key: string): boolean =>
   key in queryString.parse(search)
 
-export const getRedirectURLTopics = (name: string, agency?: Agency): string => {
-  return agency
-    ? `/agency/${encodeURIComponent(
-        agency.shortname,
-      )}?topics=${encodeURIComponent(name)}`
-    : `/?topics=${encodeURIComponent(name)}`
+export const getRedirectURLTopics = (
+  topic: string,
+  agencyShortName: string,
+): string => {
+  return `/agency/${encodeURIComponent(
+    agencyShortName,
+  )}?topics=${encodeURIComponent(topic)}`
 }
 
 export const getRedirectURLAgency = (agencyShortName: string): string => {


### PR DESCRIPTION
Changes are live on staging.

## Problem

- Options menu is set to 620px max width, when it should be 680px. This causes option items to wrap into 3 lines when it should be 2 lines.
- Tablet view ( < 1440px) would cause the topic description and question header to fold into one single row.
- Mobile view shows that the topic description has a large bottom margin.
- `getRedirectUrlTopics` should not accept optional agency shortname.

## Solution
- Set options menu max width to 680px.
- Increase breakpoint for AgencyHomePage from l (1024px) to xl (1440px)
- Use responsive bottom margin for topic description.
- Refactor `getRedirectUrlTopics` to take in a string field for agencyShortName.

## Before & After Screenshots

**BEFORE**:
Tablet view ( < 1440px) would cause the topic description and question header to fold into one single row.
<img width="779" alt="Screenshot 2022-03-24 at 3 13 03 PM" src="https://user-images.githubusercontent.com/41635847/159862202-6d81f6d5-ff81-4692-836d-a0f96a0eb9fe.png">

Mobile view shows that the topic description has a large bottom margin.
<img width="273" alt="Screenshot 2022-03-24 at 3 13 35 PM" src="https://user-images.githubusercontent.com/41635847/159862281-54a0f1ac-7a18-458d-994e-3032dacf4d5b.png">

**AFTER**:
<img width="835" alt="Screenshot 2022-03-24 at 3 22 50 PM" src="https://user-images.githubusercontent.com/41635847/159863671-db6f9aed-f91e-4d13-9387-f391706f1a03.png">

<img width="264" alt="Screenshot 2022-03-24 at 3 22 35 PM" src="https://user-images.githubusercontent.com/41635847/159863640-efd50168-ab03-465b-93f5-3518e86f3f88.png">

