### PR TITLE
fix: reinstate padding for tablet view

### DIFF
--- a/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
+++ b/client/src/pages/AgencyHomePage/AgencyHomePage.component.tsx
@@ -150,7 +150,7 @@ const AgencyHomePage = (): JSX.Element => {
         m="auto"
         justifySelf="center"
         w="100%"
-        px={{ base: 8, sm: 0 }}
+        px={{ base: 8, md: 0 }}
         direction={{ base: 'column', xl: 'row' }}
       >
         {children}

--- a/client/src/pages/HomePage/HomePage.component.tsx
+++ b/client/src/pages/HomePage/HomePage.component.tsx
@@ -23,7 +23,7 @@ const HomePage = (): JSX.Element => {
           justifySelf="center"
           w="100%"
           pt={{ sm: '30px', xl: '22px' }}
-          px={{ base: 8, sm: 0 }}
+          px={{ base: 8, md: 0 }}
           direction={{ base: 'column', lg: 'row' }}
         >
           <Questions />

--- a/client/src/theme/components/OptionsMenu.tsx
+++ b/client/src/theme/components/OptionsMenu.tsx
@@ -56,7 +56,7 @@ export const OptionsMenu: ComponentMultiStyleConfig = {
       maxW: '680px',
       m: 'auto',
       w: '100%',
-      px: { base: 8, sm: 0 },
+      px: { base: 8, md: 0 },
       textAlign: 'left',
     },
     sideMenuBox: {


### PR DESCRIPTION
## Problem

Tablet view looked stretched when width  < 680px and width > 480px


## Solution

Add padding up till `md` breakpoint (previously padding was removed if > `sm` breakpoint)

## Before & After Screenshots

**BEFORE**:
![Screenshot 2022-03-29 at 2 36 32 PM](https://user-images.githubusercontent.com/41635847/160548676-bcd642c0-8692-4f52-ae45-b61afdaa4d83.png)


**AFTER**:
![Screenshot 2022-03-29 at 2 35 47 PM](https://user-images.githubusercontent.com/41635847/160548565-8246dfdb-e417-48f6-aaa8-67419e2ecaea.png)
