### PR TITLE
Add x button and bold important text in topics management dialog

### DIFF
--- a/client/src/components/ConfirmDialog/ConfirmDialog.component.tsx
+++ b/client/src/components/ConfirmDialog/ConfirmDialog.component.tsx
@@ -11,6 +11,7 @@ import {
   CloseButton,
   HStack,
 } from '@chakra-ui/react'
+import sanitizeHtml from 'sanitize-html'
 
 interface ConfirmDialogProps
   extends Pick<AlertDialogProps, 'isOpen' | 'onClose'> {
@@ -53,7 +54,14 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
             _focus={{ border: 'none' }}
           />
           <AlertDialogHeader>{title}</AlertDialogHeader>
-          <AlertDialogBody>{description}</AlertDialogBody>
+          <AlertDialogBody
+            dangerouslySetInnerHTML={{
+              __html: sanitizeHtml(description, {
+                allowedTags: ['b'],
+                allowedAttributes: {},
+              }),
+            }}
+          />
           <AlertDialogFooter>
             <HStack spacing={4}>
               <Button variant="ghost" onClick={onClose}>

--- a/client/src/components/ConfirmDialog/ConfirmDialog.component.tsx
+++ b/client/src/components/ConfirmDialog/ConfirmDialog.component.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialogOverlay,
   AlertDialogProps,
   Button,
+  CloseButton,
   HStack,
 } from '@chakra-ui/react'
 
@@ -44,6 +45,13 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
     >
       <AlertDialogOverlay>
         <AlertDialogContent>
+          <CloseButton
+            position="absolute"
+            right="4px"
+            top="4px"
+            onClick={onClose}
+            _focus={{ border: 'none' }}
+          />
           <AlertDialogHeader>{title}</AlertDialogHeader>
           <AlertDialogBody>{description}</AlertDialogBody>
           <AlertDialogFooter>

--- a/client/src/components/FailureDialog/FailureDialog.component.tsx
+++ b/client/src/components/FailureDialog/FailureDialog.component.tsx
@@ -11,6 +11,7 @@ import {
   AlertDialogProps,
   AlertIcon,
   Button,
+  chakra,
   Text,
   VStack,
 } from '@chakra-ui/react'
@@ -44,7 +45,9 @@ export const FailureDialog: FC<FailureDialogProps> = ({
               <Text>{plainMessage}</Text>
               <Alert status="error">
                 <AlertIcon />
-                <AlertDescription>{failureMessage}</AlertDescription>
+                <AlertDescription
+                  dangerouslySetInnerHTML={{ __html: failureMessage }}
+                />
               </Alert>
             </VStack>
           </AlertDialogBody>

--- a/client/src/components/FailureDialog/FailureDialog.component.tsx
+++ b/client/src/components/FailureDialog/FailureDialog.component.tsx
@@ -16,6 +16,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
+import sanitizeHtml from 'sanitize-html'
 
 interface FailureDialogProps
   extends Pick<AlertDialogProps, 'isOpen' | 'onClose'> {
@@ -56,7 +57,12 @@ export const FailureDialog: FC<FailureDialogProps> = ({
               <Alert status="error">
                 <AlertIcon />
                 <AlertDescription
-                  dangerouslySetInnerHTML={{ __html: failureMessage }}
+                  dangerouslySetInnerHTML={{
+                    __html: sanitizeHtml(failureMessage, {
+                      allowedTags: ['b'],
+                      allowedAttributes: {},
+                    }),
+                  }}
                 />
               </Alert>
             </VStack>

--- a/client/src/components/FailureDialog/FailureDialog.component.tsx
+++ b/client/src/components/FailureDialog/FailureDialog.component.tsx
@@ -10,8 +10,9 @@ import {
   AlertDialogOverlay,
   AlertDialogProps,
   AlertIcon,
+  Box,
   Button,
-  chakra,
+  CloseButton,
   Text,
   VStack,
 } from '@chakra-ui/react'
@@ -39,6 +40,15 @@ export const FailureDialog: FC<FailureDialogProps> = ({
     >
       <AlertDialogOverlay>
         <AlertDialogContent>
+          <Box paddingBottom="8px">
+            <CloseButton
+              position="absolute"
+              right="4px"
+              top="4px"
+              onClick={onClose}
+              _focus={{ border: 'none' }}
+            />
+          </Box>
           <AlertDialogHeader>{title}</AlertDialogHeader>
           <AlertDialogBody>
             <VStack spacing={4}>

--- a/client/src/components/Topics/TopicCard.component.tsx
+++ b/client/src/components/Topics/TopicCard.component.tsx
@@ -173,7 +173,7 @@ export const TopicCard = ({
           onClose={onDeleteClose}
           onConfirm={onDeleteConfirm}
           title="Confirm Delete?"
-          description={`Are you sure you want to delete the topic '${topicName}'? You cannot undo this action.`}
+          description={`Are you sure you want to delete the topic <b>'${topicName}'</b>? You cannot undo this action.`}
           confirmText="Yes, delete"
         />
       ) : (

--- a/client/src/components/Topics/TopicCard.component.tsx
+++ b/client/src/components/Topics/TopicCard.component.tsx
@@ -180,7 +180,7 @@ export const TopicCard = ({
         <FailureDialog
           title={`Unable to delete the topic '${topicName}'`}
           plainMessage="Please delete or move existing questions to another topic before deleting this topic."
-          failureMessage={`There are ${numberOfQuestions} questions under '${topicName}'.`}
+          failureMessage={`There are <b>${numberOfQuestions} questions</b> under '${topicName}'.`}
           isOpen={isDeleteOpen}
           onClose={onDeleteClose}
         />


### PR DESCRIPTION
Closes https://github.com/opengovsg/askgovsg/issues/1522

Some notes:
- Extra padding added to FailureDialog so as to maintain spacing between words and the CloseButton. This is probably not great for reusing and extending this component? 
- Bolding is slightly more difficult because if you pass tags like `<chakra.span>` as props, they will get rendered as literal strings. The way around that is to use `dangerouslySetInnerHTML` in conjunction with sanitizing HTML. Strictly speaking, bolding number of questions is quite safe because users can only control the number of questions, which is not dangerous. But sanitized anyway. For bolding the topic, sanitization is necessary, 

Results:
![image](https://user-images.githubusercontent.com/67887489/162448976-a94ec2ec-66df-4f24-9759-1de4715d175e.png)
![image](https://user-images.githubusercontent.com/67887489/162448856-0ded1cda-d69c-4876-9f46-a49412f4ca0b.png) 

