### PR TITLE
fix(ci): use new npm cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,9 @@ jobs:
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.OS }}-node-askgov-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.OS }}-node-askgov-
       - run: npm ci
       - run: npm test
   gatekeep:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.OS }}-node-askgov-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.OS }}-node-askgov-
       - run: npm ci
       - run: npx lockfile-lint --type npm --path client/package-lock.json --validate-https --allowed-hosts npm
       - run: npx lockfile-lint --type npm --path server/package-lock.json --validate-https --allowed-hosts npm


### PR DESCRIPTION
## Problem and Solution
Our GitHub Actions cache for npm is corrupted,
breaking CI. Specify a different key prefix to start
a fresh set of npm dependencies to cache.
