### PR TITLE
style(edit-question): update styles for post/edit/delete button

### DIFF
--- a/client/src/components/EditQuestion/DeleteButton.component.tsx
+++ b/client/src/components/EditQuestion/DeleteButton.component.tsx
@@ -1,18 +1,10 @@
-import { BiChevronDown, BiTrash } from 'react-icons/bi'
+import { BiTrash } from 'react-icons/bi'
 import { useMutation, useQueryClient } from 'react-query'
-import { Link as RouterLink, useNavigate } from 'react-router-dom'
-import {
-  Button,
-  Icon,
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  useDisclosure,
-} from '@chakra-ui/react'
+import { useNavigate } from 'react-router-dom'
+import { Button, useDisclosure } from '@chakra-ui/react'
 
 import { getApiErrorMessage } from '../../api'
+import { DeviceType, useDetectDevice } from '../../hooks/useDetectDevice'
 import {
   deletePost,
   GET_POST_BY_ID_QUERY_KEY,
@@ -21,12 +13,16 @@ import {
 import { ConfirmDialog } from '../ConfirmDialog/ConfirmDialog.component'
 import { useStyledToast } from '../StyledToast/StyledToast'
 
-interface EditButtonProps {
+interface DeleteButtonProps {
   postId: number
-  onDeleteLink?: string
+  onDeleteLink: string
 }
 
-const EditButton = ({ postId, onDeleteLink }: EditButtonProps): JSX.Element => {
+const DeleteButton = ({
+  postId,
+  onDeleteLink,
+}: DeleteButtonProps): JSX.Element => {
+  const deviceType = useDetectDevice()
   const {
     onOpen: onDeleteDialogOpen,
     onClose: onDeleteDialogClose,
@@ -61,43 +57,17 @@ const EditButton = ({ postId, onDeleteLink }: EditButtonProps): JSX.Element => {
 
   const onDeleteConfirm = () => deletePostMutation.mutate(postId)
 
-  // post prop is injected into button
   return (
     <>
-      <RouterLink to={`/edit/question/${postId}`}>
-        <Button
-          variant="outline"
-          borderRadius="3px"
-          borderTopRightRadius="0"
-          borderBottomRightRadius="0"
-          borderColor="secondary.700"
-          color="secondary.700"
-        >
-          Edit
-        </Button>
-      </RouterLink>
-      <Menu placement="bottom-end">
-        <MenuButton
-          as={IconButton}
-          aria-label="Options"
-          icon={<Icon as={BiChevronDown} color="secondary.700" />}
-          variant="outline"
-          borderRadius="3px"
-          borderTopLeftRadius="0"
-          borderBottomLeftRadius="0"
-          borderLeft="none"
-          borderColor="secondary.700"
-        />
-        <MenuList minW={105} color="error.500">
-          <MenuItem
-            onClick={onDeleteDialogOpen}
-            icon={<Icon as={BiTrash} w={4} h={4} color="error.500" />}
-          >
-            Delete
-          </MenuItem>
-        </MenuList>
-      </Menu>
-
+      <Button
+        variant="clear"
+        color="error.600"
+        leftIcon={<BiTrash />}
+        onClick={onDeleteDialogOpen}
+        aria-label="Delete post"
+      >
+        {deviceType !== DeviceType.Mobile ? 'Delete' : ''}
+      </Button>
       <ConfirmDialog
         title="Delete this post"
         description="You’re about to delete this post. Are you sure you want to delete it?"
@@ -110,4 +80,4 @@ const EditButton = ({ postId, onDeleteLink }: EditButtonProps): JSX.Element => {
   )
 }
 
-export default EditButton
+export default DeleteButton

--- a/client/src/components/EditQuestion/DeleteButton.stories.tsx
+++ b/client/src/components/EditQuestion/DeleteButton.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import DeleteButton from './DeleteButton.component'
+
+export default {
+  title: 'Components/Buttons/DeleteButton',
+  component: DeleteButton,
+} as ComponentMeta<typeof DeleteButton>
+
+const Template: ComponentStory<typeof DeleteButton> = (args) => (
+  <DeleteButton {...args} />
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  postId: 1,
+  onDeleteLink: '/delete',
+}

--- a/client/src/components/EditQuestion/EditButton.component.tsx
+++ b/client/src/components/EditQuestion/EditButton.component.tsx
@@ -1,0 +1,28 @@
+import { BiPencil } from 'react-icons/bi'
+import { Link as RouterLink } from 'react-router-dom'
+import { Button } from '@chakra-ui/react'
+
+import { DeviceType, useDetectDevice } from '../../hooks/useDetectDevice'
+
+interface EditButtonProps {
+  postId: number
+}
+
+const EditButton = ({ postId }: EditButtonProps): JSX.Element => {
+  const deviceType = useDetectDevice()
+  // post prop is injected into button
+  return (
+    <RouterLink to={`/edit/question/${postId}`}>
+      <Button
+        variant="clear"
+        textColor="secondary.700"
+        leftIcon={<BiPencil />}
+        aria-label="Edit post"
+      >
+        {deviceType !== DeviceType.Mobile ? 'Edit' : ''}
+      </Button>
+    </RouterLink>
+  )
+}
+
+export default EditButton

--- a/client/src/components/EditQuestion/EditButton.stories.tsx
+++ b/client/src/components/EditQuestion/EditButton.stories.tsx
@@ -14,5 +14,4 @@ const Template: ComponentStory<typeof EditButton> = (args) => (
 export const Default = Template.bind({})
 Default.args = {
   postId: 1,
-  onDeleteLink: '/delete',
 }

--- a/client/src/components/LinkButton/LinkButton.component.tsx
+++ b/client/src/components/LinkButton/LinkButton.component.tsx
@@ -1,17 +1,20 @@
 import { Link } from 'react-router-dom'
-import { Button } from '@chakra-ui/react'
+import { Button, ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
+
+interface LinkButtonProps extends ChakraButtonProps {
+  text: string
+  link: string
+  handleClick?: () => void
+  leftIcon?: JSX.Element
+}
 
 const LinkButton = ({
   text,
   link,
   handleClick,
   leftIcon,
-}: {
-  text: string
-  link: string
-  handleClick?: () => void
-  leftIcon?: JSX.Element
-}): JSX.Element => {
+  ...props
+}: LinkButtonProps): JSX.Element => {
   return (
     <Link onClick={handleClick} to={link}>
       <Button
@@ -23,6 +26,7 @@ const LinkButton = ({
         borderRadius="3px"
         textStyle="subhead-1"
         leftIcon={leftIcon}
+        {...props}
       >
         {text}
       </Button>

--- a/client/src/components/PostItem/PostItem.component.tsx
+++ b/client/src/components/PostItem/PostItem.component.tsx
@@ -6,7 +6,8 @@ import { HighlightSearchEntry } from '~shared/types/api'
 
 import { BasePostDto } from '../../api'
 import { useAuth } from '../../contexts/AuthContext'
-import EditButton from '../EditButton/EditButton.component'
+import DeleteButton from '../EditQuestion/DeleteButton.component'
+import EditButton from '../EditQuestion/EditButton.component'
 
 // Note: PostItem is the component for the homepage
 const PostItem = ({
@@ -53,6 +54,10 @@ const PostItem = ({
       {isAgencyMember && (
         <Flex sx={styles.editWrapper}>
           <EditButton postId={id} />
+          <DeleteButton
+            postId={id}
+            onDeleteLink={`/agency/${user.agency.shortname}`}
+          />
         </Flex>
       )}
     </Flex>

--- a/client/src/components/PostQuestionButton/PostQuestionButton.component.tsx
+++ b/client/src/components/PostQuestionButton/PostQuestionButton.component.tsx
@@ -1,19 +1,18 @@
 import { BiPlus } from 'react-icons/bi'
+import { ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
 
 import LinkButton from '../LinkButton/LinkButton.component'
 
-const PostQuestionButton = (): JSX.Element => {
+const PostQuestionButton = ({ ...props }: ChakraButtonProps): JSX.Element => {
   return (
     <LinkButton
-      text={'Post Question'}
-      link={'/add/question'}
-      leftIcon={
-        <BiPlus
-          size="24"
-          color="var(--chakra-colors-secondary-700)"
-          style={{ marginRight: '10px' }}
-        />
-      }
+      text="Post Question"
+      link="/add/question"
+      color="white"
+      bgColor="secondary.700"
+      variant="solid"
+      leftIcon={<BiPlus size="24" />}
+      {...props}
     />
   )
 }

--- a/client/src/components/QuestionsHeader/QuestionsHeader.component.tsx
+++ b/client/src/components/QuestionsHeader/QuestionsHeader.component.tsx
@@ -17,13 +17,14 @@ export const QuestionsHeader = (): JSX.Element => {
     <Flex
       flexDir={{ base: 'column-reverse', sm: 'row' }}
       justifyContent="space-between"
+      mt={{ base: '32px', sm: '50px', xl: '58px' }}
+      mb={{ sm: '18px' }}
     >
       <Text
         color="primary.500"
         textStyle="subhead-3"
-        mt={{ base: '32px', sm: '50px', xl: '58px' }}
-        mb={{ sm: '18px' }}
         d="block"
+        my={{ base: '16px', sm: '0px' }}
       >
         {questionsDisplayState.label}
       </Text>
@@ -36,7 +37,9 @@ export const QuestionsHeader = (): JSX.Element => {
           questionsSortOrder={questionsSortOrder}
           setQuestionsSortOrder={setQuestionsSortOrder}
         />
-        {isAuthenticatedOfficer && <PostQuestionButton />}
+        {isAuthenticatedOfficer && (
+          <PostQuestionButton mb={{ base: '16px', sm: '0px' }} />
+        )}
       </Stack>
     </Flex>
   )

--- a/client/src/pages/Post/Post.component.tsx
+++ b/client/src/pages/Post/Post.component.tsx
@@ -18,7 +18,8 @@ import sanitizeHtml from 'sanitize-html'
 import { PostStatus } from '~shared/types/base'
 
 import CitizenRequest from '../../components/CitizenRequest/CitizenRequest.component'
-import EditButton from '../../components/EditButton/EditButton.component'
+import DeleteButton from '../../components/EditQuestion/DeleteButton.component'
+import EditButton from '../../components/EditQuestion/EditButton.component'
 import { NavBreadcrumb } from '../../components/NavBreadcrumb/NavBreadcrumb'
 import PageTitle from '../../components/PageTitle/PageTitle.component'
 import Spinner from '../../components/Spinner/Spinner.component'
@@ -146,10 +147,13 @@ const Post = (): JSX.Element => {
               </Flex>
               <Spacer />
               {isAgencyMember && agency && (
-                <EditButton
-                  postId={Number(postId)}
-                  onDeleteLink={`/agency/${agency.shortname}`}
-                />
+                <>
+                  <EditButton postId={Number(postId)} />
+                  <DeleteButton
+                    postId={Number(postId)}
+                    onDeleteLink={`/agency/${agency.shortname}`}
+                  />
+                </>
               )}
             </Flex>
             <Text sx={styles.title}>{post?.title}</Text>

--- a/client/src/theme/components/PostItem.ts
+++ b/client/src/theme/components/PostItem.ts
@@ -32,6 +32,6 @@ export const PostItem = makeMultiStyleConfig({
     mt: { base: '16px', sm: '8px' },
   },
   editWrapper: {
-    alignItems: 'center',
+    alignSelf: 'flex-end',
   },
 })


### PR DESCRIPTION
## Problem

There are a few style updates for the following buttons:
- `Edit` button
- `Delete` button
- `Post` button

There are also a few UI bugs that need to be fixed, such as incorrect margins between `Post` button and `AccordionMenu`
Closes #1517
Closes #1547

## Solution
Previously, we only have a single dropdown `Edit` button which had a menu of two options: `Edit` and `Delete`.

The new design splits them up into two discrete buttons, hence we create two button components.

**Improvements**:

- By extending `ChakraButtonProps`, we are able to pass the chakra-default props into our own buttons. This allow us to pass down useful props like `variant`, `color`, etc from the top-level component. 

**Bug Fixes**:

- Fixes #1517 , where the `Post` button is too close to the `AccordionMenu`

## Before & After Screenshots
**Desktop**:
BEFORE
<img width="1076" alt="Screenshot 2022-04-12 at 5 07 39 PM" src="https://user-images.githubusercontent.com/41635847/162924251-a59a7f75-e94a-4164-bb7b-46c7f461ccd8.png">
AFTER
<img width="1104" alt="Screenshot 2022-04-12 at 5 04 20 PM" src="https://user-images.githubusercontent.com/41635847/162923667-aeb5f5c0-cec7-42fe-b4f7-2797695d4139.png">

**Mobile**:
BEFORE
<img width="315" alt="image" src="https://user-images.githubusercontent.com/41635847/162924395-1ab2825c-ae95-4cbc-82a2-00971911717c.png">

AFTER
<img width="333" alt="Screenshot 2022-04-12 at 5 06 12 PM" src="https://user-images.githubusercontent.com/41635847/162923987-dcb82699-754e-4608-9c97-484435941546.png">

## Testing
Changes are live on staging




