### PR TITLE
feat(char-count): add character exceed logic

### DIFF
--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -15,8 +15,6 @@ import {
   HStack,
   Icon,
   Input,
-  InputGroup,
-  InputRightElement,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
@@ -126,25 +124,18 @@ const AskForm = ({
         <FormHelperText sx={styles.formHelperText}>
           Give your question a short and relevant title
         </FormHelperText>
-        <InputGroup>
-          <Input
-            placeholder="Field Empty"
-            focusBorderColor={
-              isTitleCharsExceeded ? 'error.500' : 'secondary.700'
-            }
-            isInvalid={isTitleCharsExceeded}
-            {...register('postTitle', {
-              minLength: 15,
-              maxLength: TITLE_MAX_LEN,
-              required: true,
-            })}
-          />
-          {isTitleCharsExceeded && (
-            <InputRightElement
-              children={<Icon as={MdError} color="error.500" />}
-            />
-          )}
-        </InputGroup>
+        <Input
+          placeholder="Field Empty"
+          focusBorderColor={
+            isTitleCharsExceeded ? 'error.500' : 'secondary.700'
+          }
+          isInvalid={isTitleCharsExceeded}
+          {...register('postTitle', {
+            minLength: 15,
+            maxLength: TITLE_MAX_LEN,
+            required: true,
+          })}
+        />
         {formErrors.postTitle && (
           <Alert status="error" sx={styles.alert}>
             <AlertIcon />

--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import { MdError } from 'react-icons/md'
 import { useNavigate } from 'react-router-dom'
 import Select from 'react-select'
 import {
@@ -12,7 +13,10 @@ import {
   FormHelperText,
   FormLabel,
   HStack,
+  Icon,
   Input,
+  InputGroup,
+  InputRightElement,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
@@ -99,10 +103,8 @@ const AskForm = ({
 
   const watchTitle = watch('postTitle')
 
-  const titleCharsRemaining =
-    watchTitle && typeof watchTitle === 'string'
-      ? Math.max(TITLE_MAX_LEN - watchTitle.length, 0)
-      : TITLE_MAX_LEN
+  const titleCharsRemaining = TITLE_MAX_LEN - watchTitle.length
+  const isTitleCharsExceeded = titleCharsRemaining < 0
 
   const internalOnSubmit = handleSubmit((formData) =>
     onSubmit({
@@ -124,22 +126,38 @@ const AskForm = ({
         <FormHelperText sx={styles.formHelperText}>
           Give your question a short and relevant title
         </FormHelperText>
-        <Input
-          placeholder="Field Empty"
-          {...register('postTitle', {
-            minLength: 15,
-            maxLength: TITLE_MAX_LEN,
-            required: true,
-          })}
-        />
-        {formErrors.postTitle ? (
+        <InputGroup>
+          <Input
+            placeholder="Field Empty"
+            focusBorderColor={
+              isTitleCharsExceeded ? 'error.500' : 'secondary.700'
+            }
+            isInvalid={isTitleCharsExceeded}
+            {...register('postTitle', {
+              minLength: 15,
+              maxLength: TITLE_MAX_LEN,
+              required: true,
+            })}
+          />
+          {isTitleCharsExceeded && (
+            <InputRightElement
+              children={<Icon as={MdError} color="error.500" />}
+            />
+          )}
+        </InputGroup>
+        {formErrors.postTitle && (
           <Alert status="error" sx={styles.alert}>
             <AlertIcon />
             Please enter a title with 15-150 characters.
           </Alert>
+        )}
+        {isTitleCharsExceeded ? (
+          <Box sx={styles.charsOverBox}>
+            <Icon as={MdError} /> {-titleCharsRemaining} characters over
+          </Box>
         ) : (
           <Box sx={styles.charsRemainingBox}>
-            {titleCharsRemaining} characters left
+            {titleCharsRemaining} characters remaining
           </Box>
         )}
       </FormControl>

--- a/client/src/theme/components/AskForm.tsx
+++ b/client/src/theme/components/AskForm.tsx
@@ -30,6 +30,11 @@ export const AskForm: ComponentMultiStyleConfig = {
       color: 'secondary.600',
       pt: '8px',
     },
+    charsOverBox: {
+      textStyle: 'body-2',
+      textColor: 'error.500',
+      pt: '8px',
+    },
     submitButton: {
       //textStyle is not used due to a bug in Chakra UI (Issue #3884)
       font: 'inter',


### PR DESCRIPTION
## Problem

Closes #1053

## Solution

* BorderFocusColor set to `error.500` when there is an error
* BorderFocusColor set to `secondary.700` when there is no error
* Do not just show `0 characters left` when characters exceeded
* Add icon next to character count warning when characters exceed 150

## Before & After Screenshots
**BEFORE**:
<img width="893" alt="Screenshot 2022-04-12 at 7 05 39 PM" src="https://user-images.githubusercontent.com/41635847/162946732-1fdcdba2-5707-4c5a-94d9-10b67fc3f784.png">

**AFTER**:
<img width="726" alt="Screenshot 2022-04-13 at 10 17 37 AM" src="https://user-images.githubusercontent.com/41635847/163086500-b3801a10-7edc-47ae-b348-ad13798a766e.png">


## Contextual Details
Update: after discussing with Khaleedah, we have decided to remove the error icon from the input group.
<img width="844" alt="Screenshot 2022-04-12 at 7 07 54 PM" src="https://user-images.githubusercontent.com/41635847/162947123-539d1b9e-5b35-44b8-acf0-cf7fe78b494a.png">
 