### PR TITLE
style(header): add box shadow

### DIFF
--- a/client/src/theme/components/Header.ts
+++ b/client/src/theme/components/Header.ts
@@ -19,6 +19,7 @@ export const Header: ComponentMultiStyleConfig = {
       top: 0,
       zIndex: 999,
       bg: 'white',
+      boxShadow: 'sm',
     },
     compactSearch: {
       h: '56px',


### PR DESCRIPTION
## Problem

Current styling for the headers is not visually similar to Figma design.

## Solution

Add missing box shadow.

## Before & After Screenshots

**BEFORE**:
<img width="723" alt="Screenshot 2022-04-13 at 11 12 41 AM" src="https://user-images.githubusercontent.com/41635847/163092714-35043c20-df3a-4ba7-b32f-3fde3c214140.png">
<img width="189" alt="Screenshot 2022-04-13 at 11 13 11 AM" src="https://user-images.githubusercontent.com/41635847/163092764-3a93c19b-341a-40ce-90ad-8834e2d716e2.png">



**AFTER**:
<img width="1396" alt="Screenshot 2022-04-13 at 11 07 08 AM" src="https://user-images.githubusercontent.com/41635847/163092155-3405aba1-f508-4f26-aae3-8f3ffe7059f1.png">
<img width="315" alt="Screenshot 2022-04-13 at 11 07 39 AM" src="https://user-images.githubusercontent.com/41635847/163092206-6684cfa7-886d-4bf7-86a4-582cb72fae2e.png">


