### PR TITLE
feat(rte): update style and add toolbar options 

### DIFF
--- a/client/src/components/RichText/ImageControl.tsx
+++ b/client/src/components/RichText/ImageControl.tsx
@@ -318,7 +318,7 @@ export const ImageControl = ({
   )
 
   return (
-    <Box display={{ base: 'none', xl: 'block' }}>
+    <Box display={{ base: 'none', xl: 'block' }} mb="6px">
       <Box onClick={onImageModalOpen} className="rdw-option-wrapper">
         <BiImage size="18px" />
       </Box>

--- a/client/src/components/RichText/LinkControl.tsx
+++ b/client/src/components/RichText/LinkControl.tsx
@@ -90,11 +90,11 @@ export const LinkControl = ({
     </div>
   )
   return (
-    <div className={styles.linkControl}>
-      <div onClick={signalExpandShowModal} className="rdw-option-wrapper">
+    <Box position="relative" mb="6px">
+      <Box onClick={signalExpandShowModal} className="rdw-option-wrapper">
         <BiLink size="18px" />
-      </div>
+      </Box>
       {expanded ? renderModal() : undefined}
-    </div>
+    </Box>
   )
 }

--- a/client/src/components/RichText/RichTextEditor.component.tsx
+++ b/client/src/components/RichText/RichTextEditor.component.tsx
@@ -33,9 +33,12 @@ export type UploadCallback = (
 const ExtendedEditor = (props: EditorProps) => <Editor {...props} />
 
 const TOOLBAR_OPTIONS = {
-  options: ['inline', 'list', 'link'],
+  options: ['inline', 'textAlign', 'list', 'link'],
   inline: {
-    options: ['bold', 'italic'],
+    options: ['bold', 'italic', 'strikethrough'],
+  },
+  textAlign: {
+    inDropdown: true,
   },
   link: {
     defaultTargetOption: '_blank',

--- a/client/src/components/RichText/RichTextEditor.module.scss
+++ b/client/src/components/RichText/RichTextEditor.module.scss
@@ -9,7 +9,7 @@
     box-shadow: 0px 0px 20px rgba(193, 199, 205, 0.7);
 
     &:after {
-      content: " ";
+      content: ' ';
       position: absolute;
       right: 323px;
       top: -10px;
@@ -29,7 +29,7 @@
 
 .editor {
   padding: 0 0.5rem 1rem 0.5rem;
-  height: 250px;
+  min-height: 250px;
 }
 
 .toolbar {

--- a/client/src/components/RichText/RichTextEditor.module.scss
+++ b/client/src/components/RichText/RichTextEditor.module.scss
@@ -1,52 +1,51 @@
 .toolbar {
-    .form {
-      z-index: 2;
-      position: absolute;
-      top: 35px;
-      left: -20px;
-      background: white;
-      border-radius: 3px;
-      box-shadow: 0px 0px 20px rgba(193, 199, 205, 0.7);
-
-      &:after {
-        content: " ";
-        position: absolute;
-        right: 323px;
-        top: -10px;
-        border-top: none;
-        border-right: 15px solid transparent;
-        border-left: 15px solid transparent;
-        border-bottom: 15px solid white;
-      }
-    }
-
-    .linkControl {
-      position: relative;
-    }
-  }
-
-  .wrapper {
-    border: 1px solid var(--chakra-colors-neutral-400);
-    background-color: white;
+  .form {
+    z-index: 2;
+    position: absolute;
+    top: 35px;
+    left: -20px;
+    background: white;
     border-radius: 3px;
-  }
+    box-shadow: 0px 0px 20px rgba(193, 199, 205, 0.7);
 
-  .editor {
-    padding: 0 0.5rem 1rem 0.5rem;
-    height: 250px;
+    &:after {
+      content: " ";
+      position: absolute;
+      right: 323px;
+      top: -10px;
+      border-top: none;
+      border-right: 15px solid transparent;
+      border-left: 15px solid transparent;
+      border-bottom: 15px solid white;
+    }
   }
+}
 
-  .toolbar {
-    border-width: 0 0 1px 0;
-  }
+.wrapper {
+  border: 1px solid var(--chakra-colors-neutral-400);
+  background-color: white;
+  border-radius: 3px;
+}
 
-  .previewEditor {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    // no IE support, no support for EDGE 12-16, firefox 2-67
-    // 0.94% global impact (IE users)
-    // https://caniuse.com/?search=web-kit%20line%20clamp
-    -webkit-line-clamp: 3; /* number of lines to show */
-    -webkit-box-orient: vertical;
-  }
+.editor {
+  padding: 0 0.5rem 1rem 0.5rem;
+  height: 250px;
+}
+
+.toolbar {
+  min-height: 48px;
+  background: #bdbdbd;
+  border-width: 0 0 1px 0;
+  align-items: center;
+}
+
+.previewEditor {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  // no IE support, no support for EDGE 12-16, firefox 2-67
+  // 0.94% global impact (IE users)
+  // https://caniuse.com/?search=web-kit%20line%20clamp
+  -webkit-line-clamp: 3; /* number of lines to show */
+  -webkit-box-orient: vertical;
+}

--- a/client/src/components/RichText/RichTextEditor.styles.scss
+++ b/client/src/components/RichText/RichTextEditor.styles.scss
@@ -1,5 +1,3 @@
-
-
 .rdw-editor-wrapper {
   .rdw-link-decorator-wrapper {
     a {
@@ -37,5 +35,21 @@
         content: "";
       }
     }
+  }
+
+  .rdw-dropdown-wrapper {
+    margin-bottom: 6px;
+  }
+
+  .rdw-option-wrapper,
+  .rdw-dropdown-wrapper {
+    background: #bdbdbd;
+    border-color: transparent;
+  }
+
+  .rdw-option-wrapper:active,
+  .rdw-dropdown-wrapper:hover,
+  .rdw-dropdown-optionwrapper {
+    background: #e6e7ea;
   }
 }

--- a/client/src/pages/PostForm/AskForm/AskForm.component.tsx
+++ b/client/src/pages/PostForm/AskForm/AskForm.component.tsx
@@ -196,6 +196,14 @@ const AskForm = ({
           rules={{ validate: isTopicChosen }}
           render={({ field: { onChange, value } }) => (
             <Select
+              className="select-menu"
+              styles={{
+                // Fixes the overlapping problem where the menu overlay goes under the RTE
+                menuPortal: (provided) => ({
+                  ...provided,
+                  zIndex: 9999,
+                }),
+              }}
               options={optionsForTopicSelect}
               value={optionsForTopicSelect.find(
                 (topic) => topic.value === value.value,

--- a/client/src/theme/components/AskForm.tsx
+++ b/client/src/theme/components/AskForm.tsx
@@ -57,11 +57,8 @@ export const AskForm: ComponentMultiStyleConfig = {
       mt: '4px',
     },
     richTextEditor: {
-      wrapperStyle: {
-        height: '148px',
-      },
       editorStyle: {
-        height: `${148 - (48 + 6 * 2)}px`,
+        minHeight: '148px',
       },
     },
   }),

--- a/client/src/theme/components/AskForm.tsx
+++ b/client/src/theme/components/AskForm.tsx
@@ -61,7 +61,7 @@ export const AskForm: ComponentMultiStyleConfig = {
         height: '148px',
       },
       editorStyle: {
-        height: `${148 - (26 + 6 * 2)}px`,
+        height: `${148 - (48 + 6 * 2)}px`,
       },
     },
   }),


### PR DESCRIPTION
## Problem
Closes #815

The rich text editor is missing the following features since the latest design update:
- Toolbar options: `strikethrough`, `textalign`
- Styling: grey header with height of 48px
- Styling: to use boxicons [Not fixed in this PR]
- Styling: for RTE textarea to expand when user input overflows


## Solution
This PR aims to solve the first two issues by adding the `strikethrough` and `textalign` toolbar options, and updating the styles. 

**This PR does not convert the RTE default icons to BoxIcons since the changes required are rather extensive.** By default, the RTE library only accepts icons in the format of a `path`, `url` or `base64encoded image` (see [issue](https://github.com/jpuri/react-draft-wysiwyg/issues/872)). Unfortunately, we are not able to just pass in the React Component form `react-icons/bi` out-of-the-box. This change can be deferred for a later PR. 

**Context**:
<img width="788" alt="Screenshot 2022-04-13 at 4 28 06 PM" src="https://user-images.githubusercontent.com/41635847/163133942-3e420a7f-99f7-41a2-9320-4db0969f962e.png">
<img width="796" alt="Screenshot 2022-04-14 at 4 59 28 PM" src="https://user-images.githubusercontent.com/41635847/163351265-fef82188-5c7f-450f-aa22-5daf37462d37.png">

## Before & After Screenshots

**BEFORE**:
<img width="840" alt="Screenshot 2022-04-13 at 4 29 16 PM" src="https://user-images.githubusercontent.com/41635847/163134164-de16be0b-eee0-4926-a94a-cf705d643319.png">

**AFTER**:
<img width="653" alt="Screenshot 2022-04-13 at 4 29 23 PM" src="https://user-images.githubusercontent.com/41635847/163134183-f0e36fef-ffda-46d5-9073-815cd1ef3328.png">

https://user-images.githubusercontent.com/41635847/163357817-52788170-c496-48fc-8016-554adb4a2cdd.mov



## Test
Changes should be live on staging in a bit.