### PR TITLE
feat: add backend safeguard against deleting topic that has posts

### DIFF
--- a/server/src/bootstrap/index.ts
+++ b/server/src/bootstrap/index.ts
@@ -145,7 +145,11 @@ const searchController = new SearchController({
 const apiOptions = {
   agency: {
     controller: new AgencyController({ agencyService }),
-    topicsController: new TopicsController({ topicsService, authService }),
+    topicsController: new TopicsController({
+      topicsService,
+      authService,
+      postService,
+    }),
   },
   answers: {
     controller: new AnswersController({
@@ -184,6 +188,7 @@ const apiOptions = {
     controller: new TopicsController({
       topicsService,
       authService,
+      postService,
     }),
     authMiddleware,
   },

--- a/server/src/modules/agency/__tests__/agency.routes.spec.ts
+++ b/server/src/modules/agency/__tests__/agency.routes.spec.ts
@@ -6,13 +6,26 @@ import {
   TopicWithChildRelations,
 } from '../../topics/topics.service'
 import { TopicsController } from '../../topics/topics.controller'
-import { createTestDatabase, getModel, ModelName } from '../../../util/jest-db'
+import {
+  createTestDatabase,
+  getModel,
+  getModelDef,
+  ModelName,
+} from '../../../util/jest-db'
 import { Sequelize, Model } from 'sequelize'
-import { Agency, Topic } from '~shared/types/base'
+import { Agency, Topic, Post } from '~shared/types/base'
 import { ModelDef } from '../../../types/sequelize'
 import express from 'express'
 import supertest, { SuperTest, Test } from 'supertest'
 import { StatusCodes } from 'http-status-codes'
+import { PostService } from '../../post/post.service'
+import {
+  Answer as AnswerModel,
+  PostTag,
+  Tag as TagModel,
+  User as UserModel,
+} from '../../../models'
+import { PostCreation } from '../../../models/posts.model'
 
 describe('/agencies', () => {
   const path = '/agencies'
@@ -40,6 +53,16 @@ describe('/agencies', () => {
     db = await createTestDatabase()
     Agency = getModel<Agency & Model>(db, ModelName.Agency)
     Topic = getModel<Topic & Model>(db, ModelName.Topic)
+    const Answer = getModel<AnswerModel>(db, ModelName.Answer)
+    const Post = getModelDef<Post, PostCreation>(db, ModelName.Post)
+    const PostTag = getModelDef<PostTag>(db, ModelName.PostTag)
+    const Tag = getModel<TagModel>(db, ModelName.Tag)
+    const User = getModel<UserModel>(db, ModelName.User)
+    const searchSyncService = {
+      createPost: jest.fn(),
+      updatePost: jest.fn(),
+      deletePost: jest.fn(),
+    }
 
     agency = await Agency.create({
       shortname: 'was',
@@ -72,9 +95,20 @@ describe('/agencies', () => {
     const agencyService = new AgencyService({ Agency })
     const controller = new AgencyController({ agencyService })
     const topicsService = new TopicsService({ Topic })
+    const postService = new PostService({
+      Answer,
+      Post,
+      PostTag,
+      Tag,
+      User,
+      Topic,
+      searchSyncService,
+      sequelize: db,
+    })
     const topicsController = new TopicsController({
       authService,
       topicsService,
+      postService,
     })
     const router = routeAgencies({ controller, topicsController })
     const app = express()

--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -28,7 +28,7 @@ describe('PostController', () => {
     updatePost: jest.fn(),
     getSinglePost: jest.fn(),
     listPosts: jest.fn(),
-    getPostsOfTopic: jest.fn(),
+    getPostsByTopic: jest.fn(),
   }
 
   const userService = {

--- a/server/src/modules/post/__tests__/post.controller.spec.ts
+++ b/server/src/modules/post/__tests__/post.controller.spec.ts
@@ -28,6 +28,7 @@ describe('PostController', () => {
     updatePost: jest.fn(),
     getSinglePost: jest.fn(),
     listPosts: jest.fn(),
+    getPostsOfTopic: jest.fn(),
   }
 
   const userService = {

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -512,7 +512,7 @@ export class PostService {
    * Get all posts belonging to that topic
    * @param topicId
    */
-  getPostsOfTopic = async (
+  getPostsByTopic = async (
     topicId: number,
   ): Promise<{
     posts: Post[]

--- a/server/src/modules/post/post.service.ts
+++ b/server/src/modules/post/post.service.ts
@@ -509,6 +509,50 @@ export class PostService {
   }
 
   /**
+   * Get all posts belonging to that topic
+   * @param topicId
+   */
+  getPostsOfTopic = async (
+    topicId: number,
+  ): Promise<{
+    posts: Post[]
+    totalItems: number
+  }> => {
+    const posts = (await this.Post.findAll({
+      where: {
+        topicId,
+        status: { [Op.ne]: PostStatus.Archived },
+      },
+      include: [
+        // not sure about this
+        {
+          model: this.Tag,
+          required: false,
+          attributes: ['tagname', 'description', 'tagType'],
+        },
+        { model: this.User, required: true, attributes: ['username'] },
+        { model: this.Answer, required: false },
+      ],
+      attributes: [
+        'id',
+        'userId',
+        'agencyId',
+        'title',
+        'description',
+        'createdAt',
+        'views',
+        this.answerCountLiteral,
+        'topicId',
+      ],
+    })) as PostWithUserTopicTagRelations[]
+    if (!posts) {
+      return { posts: [], totalItems: 0 }
+    } else {
+      return { posts, totalItems: posts.length }
+    }
+  }
+
+  /**
    * Get a single post and all the tags, topic and users associated with it
    * @param postId Id of the post
    * @param noOfRelatedPosts number of related posts to show

--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -39,7 +39,7 @@ describe('TopicsController', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
-    getPostsOfTopic: jest.fn(),
+    getPostsByTopic: jest.fn(),
   }
 
   const topicsController = new TopicsController({
@@ -347,7 +347,7 @@ describe('TopicsController', () => {
       topicsService.updateTopicById.mockReturnValue(
         errAsync(new DatabaseError()),
       )
-      postService.getPostsOfTopic.mockResolvedValue({
+      postService.getPostsByTopic.mockResolvedValue({
         posts: [],
         totalItems: 0,
       })
@@ -437,7 +437,7 @@ describe('TopicsController', () => {
       topicsService.deleteTopicById.mockReturnValue(
         errAsync(new DatabaseError()),
       )
-      postService.getPostsOfTopic.mockResolvedValue({
+      postService.getPostsByTopic.mockResolvedValue({
         posts: [],
         totalItems: 0,
       })
@@ -456,7 +456,7 @@ describe('TopicsController', () => {
     })
     it('returns 200 on successful deletion', async () => {
       authService.verifyUserCanModifyTopic.mockResolvedValue(true)
-      postService.getPostsOfTopic.mockResolvedValue({
+      postService.getPostsByTopic.mockResolvedValue({
         posts: [],
         totalItems: 0,
       })

--- a/server/src/modules/topics/__tests__/topics.controller.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.controller.spec.ts
@@ -27,9 +27,25 @@ describe('TopicsController', () => {
     listTopics: jest.fn(),
     getTopicById: jest.fn(),
   }
+
+  const postService = {
+    getExistingTagsFromRequestTags: jest.fn(),
+    getExistingTopicFromRequestTopic: jest.fn(),
+    getExistingTopicsFromRequestTopics: jest.fn(),
+    getChildTopicsFromRequestTopics: jest.fn(),
+    listPosts: jest.fn(),
+    listAnswerablePosts: jest.fn(),
+    getSinglePost: jest.fn(),
+    createPost: jest.fn(),
+    deletePost: jest.fn(),
+    updatePost: jest.fn(),
+    getPostsOfTopic: jest.fn(),
+  }
+
   const topicsController = new TopicsController({
     authService,
     topicsService,
+    postService,
   })
 
   // Set up auth middleware to inject user
@@ -331,6 +347,10 @@ describe('TopicsController', () => {
       topicsService.updateTopicById.mockReturnValue(
         errAsync(new DatabaseError()),
       )
+      postService.getPostsOfTopic.mockResolvedValue({
+        posts: [],
+        totalItems: 0,
+      })
 
       const app = express()
       app.use(express.json())
@@ -417,6 +437,10 @@ describe('TopicsController', () => {
       topicsService.deleteTopicById.mockReturnValue(
         errAsync(new DatabaseError()),
       )
+      postService.getPostsOfTopic.mockResolvedValue({
+        posts: [],
+        totalItems: 0,
+      })
 
       const app = express()
       app.use(express.json())
@@ -432,6 +456,10 @@ describe('TopicsController', () => {
     })
     it('returns 200 on successful deletion', async () => {
       authService.verifyUserCanModifyTopic.mockResolvedValue(true)
+      postService.getPostsOfTopic.mockResolvedValue({
+        posts: [],
+        totalItems: 0,
+      })
 
       const app = express()
       app.use(express.json())

--- a/server/src/modules/topics/__tests__/topics.routes.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.routes.spec.ts
@@ -37,6 +37,20 @@ describe('/topics', () => {
     verifyUserInAgency: jest.fn(),
   }
 
+  const postService = {
+    getExistingTagsFromRequestTags: jest.fn(),
+    getExistingTopicFromRequestTopic: jest.fn(),
+    getExistingTopicsFromRequestTopics: jest.fn(),
+    getChildTopicsFromRequestTopics: jest.fn(),
+    listPosts: jest.fn(),
+    listAnswerablePosts: jest.fn(),
+    getSinglePost: jest.fn(),
+    createPost: jest.fn(),
+    deletePost: jest.fn(),
+    updatePost: jest.fn(),
+    getPostsOfTopic: jest.fn(),
+  }
+
   // Set up auth middleware to inject user
   let authUser: Express.User | undefined = undefined
   const authenticate: ControllerHandler = (req, _res, next) => {
@@ -58,6 +72,7 @@ describe('/topics', () => {
     controller = new TopicsController({
       authService,
       topicsService,
+      postService,
     })
 
     mockAgency = await Agency.create({
@@ -297,6 +312,10 @@ describe('/topics', () => {
       authService.verifyUserCanModifyTopic.mockResolvedValue(true)
     })
     it('returns 200 if topic is deleted successfully', async () => {
+      postService.getPostsOfTopic.mockResolvedValue({
+        posts: [],
+        totalItems: 0,
+      })
       const router = routeTopics({ controller, authMiddleware })
       const app = express()
       app.use(express.json())

--- a/server/src/modules/topics/__tests__/topics.routes.spec.ts
+++ b/server/src/modules/topics/__tests__/topics.routes.spec.ts
@@ -48,7 +48,7 @@ describe('/topics', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
-    getPostsOfTopic: jest.fn(),
+    getPostsByTopic: jest.fn(),
   }
 
   // Set up auth middleware to inject user
@@ -312,7 +312,7 @@ describe('/topics', () => {
       authService.verifyUserCanModifyTopic.mockResolvedValue(true)
     })
     it('returns 200 if topic is deleted successfully', async () => {
-      postService.getPostsOfTopic.mockResolvedValue({
+      postService.getPostsByTopic.mockResolvedValue({
         posts: [],
         totalItems: 0,
       })

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -175,9 +175,8 @@ export class TopicsController {
     }
 
     // Check if topic has posts
-    const hasPosts = await this.postService
-      .getPostsOfTopic(topicId)
-      .then((data) => data.totalItems !== 0)
+    const posts = await this.postService.getPostsOfTopic(topicId)
+    const hasPosts = posts.totalItems !== 0
 
     if (hasPosts) {
       return res

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -7,20 +7,25 @@ import { Message } from '../../types/message-type'
 import { StatusCodes } from 'http-status-codes'
 import { ControllerHandler } from '../../types/response-handler'
 import { TopicWithChildRelations } from './topics.service'
+import { PostService } from '../post/post.service'
 
 export class TopicsController {
   private authService: Public<AuthService>
   private topicsService: Public<TopicsService>
+  private postService: Public<PostService>
 
   constructor({
     authService,
     topicsService,
+    postService,
   }: {
     authService: Public<AuthService>
     topicsService: Public<TopicsService>
+    postService: Public<PostService>
   }) {
     this.authService = authService
     this.topicsService = topicsService
+    this.postService = postService
   }
 
   /**
@@ -167,6 +172,17 @@ export class TopicsController {
       return res
         .status(StatusCodes.FORBIDDEN)
         .json({ message: 'You do not have permission to delete this topic' })
+    }
+
+    // Check if topic has posts
+    const hasPosts = await this.postService
+      .getPostsOfTopic(topicId)
+      .then((data) => data.totalItems !== 0)
+
+    if (hasPosts) {
+      return res
+        .status(StatusCodes.FORBIDDEN)
+        .json({ message: 'You cannot delete a topic that has posts' })
     }
 
     return this.topicsService

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -180,7 +180,7 @@ export class TopicsController {
 
     if (hasPosts) {
       return res
-        .status(StatusCodes.FORBIDDEN)
+        .status(StatusCodes.BAD_REQUEST)
         .json({ message: 'You cannot delete a topic that has posts' })
     }
 

--- a/server/src/modules/topics/topics.controller.ts
+++ b/server/src/modules/topics/topics.controller.ts
@@ -175,7 +175,7 @@ export class TopicsController {
     }
 
     // Check if topic has posts
-    const posts = await this.postService.getPostsOfTopic(topicId)
+    const posts = await this.postService.getPostsByTopic(topicId)
     const hasPosts = posts.totalItems !== 0
 
     if (hasPosts) {

--- a/server/src/modules/web/__tests__/web.controller.spec.ts
+++ b/server/src/modules/web/__tests__/web.controller.spec.ts
@@ -46,7 +46,7 @@ describe('WebController', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
-    getPostsOfTopic: jest.fn(),
+    getPostsByTopic: jest.fn(),
   }
   const webService = {
     getAgencyPage: jest.fn(),

--- a/server/src/modules/web/__tests__/web.controller.spec.ts
+++ b/server/src/modules/web/__tests__/web.controller.spec.ts
@@ -46,6 +46,7 @@ describe('WebController', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
+    getPostsOfTopic: jest.fn(),
   }
   const webService = {
     getAgencyPage: jest.fn(),

--- a/server/src/modules/web/__tests__/web.routes.spec.ts
+++ b/server/src/modules/web/__tests__/web.routes.spec.ts
@@ -65,7 +65,7 @@ describe('/', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
-    getPostsOfTopic: jest.fn(),
+    getPostsByTopic: jest.fn(),
   }
   const webService = {
     getAgencyPage: jest.fn(),

--- a/server/src/modules/web/__tests__/web.routes.spec.ts
+++ b/server/src/modules/web/__tests__/web.routes.spec.ts
@@ -65,6 +65,7 @@ describe('/', () => {
     createPost: jest.fn(),
     deletePost: jest.fn(),
     updatePost: jest.fn(),
+    getPostsOfTopic: jest.fn(),
   }
   const webService = {
     getAgencyPage: jest.fn(),


### PR DESCRIPTION
## Problem

Following https://github.com/opengovsg/askgovsg/pull/1350, I was somewhat uncomfortable with the fact that deleting a topic that will result in orphan posts (with no parent topic) is only safeguarded on the frontend. 

## Solution

Have modified the backend slightly to add an additional layer of safeguard

## Doubts

I'm not very familiar with Sequelize, so am not very sure if that part of `post.service.ts` is correct. Would appreciate if reviewer could take a closer look at that. 