### PR TITLE
fix(post): respond with 404 on post not found

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
       "es6",


### PR DESCRIPTION
## Problem and Solution
Minimise spurious http 500 errors by returning the correct status code
if post is not found

- reconfigure tsc to emit es6 so that `instanceof` is meaningful
- if caught error is PublicPostNotFoundError, respond with that error's
  message and status code, not the generic one
- provide unit test coverage to account for 404
